### PR TITLE
Add support for string logical types

### DIFF
--- a/data_tables/data_column.py
+++ b/data_tables/data_column.py
@@ -12,7 +12,8 @@ from data_tables.logical_types import (
     LogicalType,
     NaturalLanguage,
     Timedelta,
-    WholeNumber
+    WholeNumber,
+    get_logical_types
 )
 
 
@@ -41,10 +42,15 @@ class DataColumn(object):
         """
         self.series = series
         self.name = series.name
+
+        logical_types_dict = get_logical_types()
         if logical_type:
-            if logical_type not in LogicalType.__subclasses__():
+            if logical_type in LogicalType.__subclasses__():
+                self.logical_type = logical_type
+            elif isinstance(logical_type, str) and logical_type in logical_types_dict:
+                self.logical_type = logical_types_dict[logical_type]
+            else:
                 raise TypeError(f"Invalid logical type specified for '{series.name}'")
-            self.logical_type = logical_type
         else:
             self.logical_type = infer_logical_type(self.series)
         self.dtype = series.dtype

--- a/data_tables/logical_types.py
+++ b/data_tables/logical_types.py
@@ -103,3 +103,14 @@ class WholeNumber(LogicalType):
 
 class ZIPCode(LogicalType):
     pass
+
+
+def get_logical_types():
+    '''Returns a dictionary of logical type name strings and logical type classes'''
+    # Get snake case strings
+    logical_types = {logical_type.type_string: logical_type for logical_type in LogicalType.__subclasses__()}
+    # Add class name strings
+    class_name_dict = {logical_type.__name__: logical_type for logical_type in LogicalType.__subclasses__()}
+    logical_types.update(class_name_dict)
+
+    return logical_types

--- a/data_tables/tests/data_column/test_data_column.py
+++ b/data_tables/tests/data_column/test_data_column.py
@@ -27,6 +27,12 @@ def test_data_column_init_with_logical_type(sample_series):
     data_col = DataColumn(sample_series, NaturalLanguage)
     assert data_col.logical_type == NaturalLanguage
 
+    data_col = DataColumn(sample_series, "natural_language")
+    assert data_col.logical_type == NaturalLanguage
+
+    data_col = DataColumn(sample_series, "NaturalLanguage")
+    assert data_col.logical_type == NaturalLanguage
+
 
 def test_data_column_init_with_semantic_types(sample_series):
     semantic_types = {
@@ -59,6 +65,9 @@ def test_invalid_logical_type(sample_series):
     error_message = "Invalid logical type specified for 'sample_series'"
     with pytest.raises(TypeError, match=error_message):
         DataColumn(sample_series, int)
+
+    with pytest.raises(TypeError, match=error_message):
+        DataColumn(sample_series, 'naturallanguage')
 
 
 def test_semantic_type_errors(sample_series):

--- a/data_tables/tests/data_table/test_datatable.py
+++ b/data_tables/tests/data_table/test_datatable.py
@@ -70,6 +70,28 @@ def test_datatable_init_with_logical_types(sample_df):
     assert dt.columns['age'].logical_type == Double
 
 
+def test_datatable_init_with_string_logical_types(sample_df):
+    logical_types = {
+        'full_name': 'natural_language',
+        'age': 'whole_number'
+    }
+    dt = DataTable(sample_df,
+                   name='datatable',
+                   logical_types=logical_types)
+    assert dt.columns['full_name'].logical_type == NaturalLanguage
+    assert dt.columns['age'].logical_type == WholeNumber
+
+    logical_types = {
+        'full_name': 'NaturalLanguage',
+        'age': 'WholeNumber'
+    }
+    dt = DataTable(sample_df,
+                   name='datatable',
+                   logical_types=logical_types)
+    assert dt.columns['full_name'].logical_type == NaturalLanguage
+    assert dt.columns['age'].logical_type == WholeNumber
+
+
 def test_datatable_init_with_semantic_types(sample_df):
     semantic_types = {
         'id': 'index',

--- a/data_tables/tests/logical_types/test_logical_types.py
+++ b/data_tables/tests/logical_types/test_logical_types.py
@@ -1,4 +1,9 @@
-from data_tables.logical_types import Boolean, Categorical
+from data_tables.logical_types import (
+    Boolean,
+    Categorical,
+    LogicalType,
+    get_logical_types
+)
 
 
 def test_logical_eq():
@@ -12,3 +17,14 @@ def test_logical_repr():
     assert repr(Boolean) == 'Boolean'
     assert isinstance(repr(Categorical), str)
     assert repr(Categorical) == 'Categorical'
+
+
+def test_get_logical_types():
+    all_types = LogicalType.__subclasses__()
+    logical_types = get_logical_types()
+
+    for logical_type in all_types:
+        assert logical_types[logical_type.__name__] == logical_type
+        assert logical_types[logical_type.type_string] == logical_type
+
+    assert len(logical_types) == 2 * len(all_types)

--- a/data_tables/tests/test_utils.py
+++ b/data_tables/tests/test_utils.py
@@ -1,0 +1,13 @@
+from data_tables.utils import camel_to_snake
+
+
+def test_camel_to_snake():
+    test_items = {
+        'ZIPCode': 'zip_code',
+        'SubRegionCode': 'sub_region_code',
+        'NaturalLanguage': 'natural_language',
+        'Categorical': 'categorical',
+    }
+
+    for key, value in test_items.items():
+        assert camel_to_snake(key) == value


### PR DESCRIPTION
Closes #36 

Allow user to pass camel case or snake case strings for setting logical types when creating a DataTable or DataColumn, in addition to allowing for a LogicalType object to be passed.