### PR TITLE
Set semantic types

### DIFF
--- a/data_tables/data_column.py
+++ b/data_tables/data_column.py
@@ -64,6 +64,10 @@ class DataColumn(object):
         msg += u"(Semantic Tags = {})>".format(self.semantic_types)
         return msg
 
+    def set_semantic_types(self, semantic_types):
+        """Replace semantic types with passed values"""
+        self.semantic_types = _parse_semantic_types(semantic_types)
+
 
 def _parse_semantic_types(semantic_types):
     if not semantic_types:

--- a/data_tables/data_table.py
+++ b/data_tables/data_table.py
@@ -98,6 +98,10 @@ class DataTable(object):
     def physical_types(self):
         return {dc.name: dc.dtype for dc in self.columns.values()}
 
+    @property
+    def semantic_types(self):
+        return {dc.name: dc.semantic_types for dc in self.columns.values()}
+
     def _update_columns(self, new_columns):
         """Update the DataTable columns based on items contained in the
             provided new_columns dictionary"""
@@ -129,9 +133,11 @@ class DataTable(object):
         pass
 
     def set_semantic_types(self, semantic_types):
-        # semantic_types: (dict -> SemanticTag/str)
-        # overwrite the tags
-        pass
+        """Update the semantic types for any column names in the provided semantic_types
+            dictionary. Replaces the existing semantic types with the new values."""
+        _check_semantic_types(self.dataframe, semantic_types)
+        for name in semantic_types.keys():
+            self.columns[name].set_semantic_types(semantic_types[name])
 
     @property
     def df(self):

--- a/data_tables/tests/data_column/test_data_column.py
+++ b/data_tables/tests/data_column/test_data_column.py
@@ -187,3 +187,17 @@ def test_natural_language_inference():
 def test_data_column_repr(sample_series):
     data_col = DataColumn(sample_series)
     assert data_col.__repr__() == "<DataColumn: sample_series (Physical Type = object) (Logical Type = Categorical) (Semantic Tags = {})>"
+
+
+def test_set_semantic_types(sample_series):
+    semantic_types = {
+        'index': {},
+        'tag2': {'key': 'value'},
+    }
+    data_col = DataColumn(sample_series, semantic_types=semantic_types)
+    assert data_col.semantic_types == semantic_types
+
+    new_types = {'new_type': {'additional': 'value'}}
+    data_col.set_semantic_types(new_types)
+
+    assert data_col.semantic_types == new_types

--- a/data_tables/tests/data_table/test_datatable.py
+++ b/data_tables/tests/data_table/test_datatable.py
@@ -226,6 +226,24 @@ def test_datatable_logical_types(sample_df):
         assert v == dt.columns[k].logical_type
 
 
+def test_datatable_semantic_types(sample_df):
+    semantic_types = {
+        'full_name': 'tag1',
+        'email': {'tag2': {'option1': 'value1'}},
+        'phone_number': {'tag3': None},
+        'signup_date': {'secondary_time_index': {'columns': ['expired']}},
+        'age': ['numeric', 'age']
+    }
+    dt = DataTable(sample_df, semantic_types=semantic_types)
+    assert isinstance(dt.semantic_types, dict)
+    assert set(dt.semantic_types.keys()) == set(sample_df.columns)
+    for k, v in dt.semantic_types.items():
+        assert isinstance(k, str)
+        assert k in sample_df.columns
+        assert isinstance(v, dict)
+        assert v == dt.columns[k].semantic_types
+
+
 def test_check_semantic_types_errors(sample_df):
     error_message = 'semantic_types must be a dictionary'
     with pytest.raises(TypeError, match=error_message):
@@ -315,3 +333,25 @@ def test_semantic_types_during_init(sample_df):
     assert dt.columns['phone_number'].semantic_types == expected_types['phone_number']
     assert dt.columns['signup_date'].semantic_types == expected_types['signup_date']
     assert dt.columns['age'].semantic_types == expected_types['age']
+
+
+def test_set_semantic_types(sample_df):
+    semantic_types = {
+        'full_name': 'tag1',
+        'age': ['numeric', 'age']
+    }
+    expected_types = {
+        'full_name': {'tag1': {}},
+        'age': {'numeric': {}, 'age': {}}
+    }
+    dt = DataTable(sample_df, semantic_types=semantic_types)
+    assert dt.columns['full_name'].semantic_types == expected_types['full_name']
+    assert dt.columns['age'].semantic_types == expected_types['age']
+
+    new_types = {
+        'full_name': {'new_tag': {'additional': 'value'}},
+        'age': 'numeric',
+    }
+    dt.set_semantic_types(new_types)
+    assert dt.columns['full_name'].semantic_types == new_types['full_name']
+    assert dt.columns['age'].semantic_types == {'numeric': {}}


### PR DESCRIPTION
Closes #73 

Implements `set_semantic_types` methods on both DataTable and DataColumn, which replace any existing semantic types with the new values passed to the method. Also adds `semantic_types` property to DataTable. This implementation updates the existing column and does not create a new column object.