### PR TITLE
Implement add_semantic_tags

### DIFF
--- a/data_tables/data_column.py
+++ b/data_tables/data_column.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 
 import pandas as pd
@@ -65,6 +66,13 @@ class DataColumn(object):
         self._semantic_tags = _parse_semantic_tags(semantic_tags)
         if self.add_standard_tags:
             self._semantic_tags = self._semantic_tags.union(self._logical_type.standard_tags)
+
+    def add_semantic_tags(self, semantic_tags):
+        new_tags = _parse_semantic_tags(semantic_tags)
+        duplicate_tags = sorted(list(self._semantic_tags.intersection(new_tags)))
+        if duplicate_tags:
+            warnings.warn(f"Semantic tag(s) '{', '.join(duplicate_tags)}' already present on column '{self.name}'", UserWarning)
+        self._semantic_tags = self._semantic_tags.union(new_tags)
 
     @property
     def logical_type(self):

--- a/data_tables/data_table.py
+++ b/data_tables/data_table.py
@@ -147,9 +147,10 @@ class DataTable(object):
                 column.series = self.dataframe[name]
 
     def add_semantic_tags(self, semantic_tags):
-        # semantic_tags: (dict -> SemanticTag/str)
-        # will not overwrite, will add to set
-        pass
+        """Adds specified semantic tags to columns. Will retain any previously set values."""
+        _check_semantic_tags(self.dataframe, semantic_tags)
+        for name in semantic_tags.keys():
+            self.columns[name].add_semantic_tags(semantic_tags[name])
 
     def remove_semantic_tags(self, semantic_tags):
         # semantic_tags: (dict -> SemanticTag/str)

--- a/data_tables/tests/data_column/test_data_column.py
+++ b/data_tables/tests/data_column/test_data_column.py
@@ -223,3 +223,28 @@ def test_does_not_add_standard_tags():
                           semantic_tags=semantic_tags,
                           add_standard_tags=False)
     assert data_col.semantic_tags == {'custom_tag'}
+
+
+def test_add_custom_tags(sample_series):
+    semantic_tags = 'initial_tag'
+    data_col = DataColumn(sample_series, semantic_tags=semantic_tags, add_standard_tags=False)
+
+    data_col.add_semantic_tags('string_tag')
+    assert data_col.semantic_tags == {'initial_tag', 'string_tag'}
+
+    data_col.add_semantic_tags(['list_tag'])
+    assert data_col.semantic_tags == {'initial_tag', 'string_tag', 'list_tag'}
+
+    data_col.add_semantic_tags({'set_tag'})
+    assert data_col.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'set_tag'}
+
+
+def test_warns_on_setting_duplicate_tag(sample_series):
+    semantic_tags = ['first_tag', 'second_tag']
+    data_col = DataColumn(sample_series, semantic_tags=semantic_tags, add_standard_tags=False)
+
+    expected_message = "Semantic tag(s) 'first_tag, second_tag' already present on column 'sample_series'"
+    with pytest.warns(UserWarning) as record:
+        data_col.add_semantic_tags(['first_tag', 'second_tag'])
+    assert len(record) == 1
+    assert record[0].message.args[0] == expected_message

--- a/data_tables/tests/data_table/test_datatable.py
+++ b/data_tables/tests/data_table/test_datatable.py
@@ -369,6 +369,24 @@ def test_set_semantic_tags(sample_df):
     assert dt.columns['age'].semantic_tags == {'numeric'}
 
 
+def test_add_semantic_tags(sample_df):
+    semantic_tags = {
+        'full_name': 'tag1',
+        'age': ['numeric', 'age']
+    }
+    dt = DataTable(sample_df, semantic_tags=semantic_tags, add_standard_tags=False)
+
+    new_tags = {
+        'full_name': ['list_tag'],
+        'age': 'str_tag',
+        'id': {'set_tag'}
+    }
+    dt.add_semantic_tags(new_tags)
+    assert dt.columns['full_name'].semantic_tags == {'tag1', 'list_tag'}
+    assert dt.columns['age'].semantic_tags == {'numeric', 'age', 'str_tag'}
+    assert dt.columns['id'].semantic_tags == {'set_tag'}
+
+
 def test_replace_none_with_pdna(none_df):
     logical_types = {
         'all_none': NaturalLanguage,


### PR DESCRIPTION
Closes #101 

This PR implements `add_semantic_tags` methods on DataTable and DataColumn. Similar to setting tags initially, tags can be specified as a single string, a list of strings or a set of strings. If a user attempts to add a tag that is already present, a warning is raised.