### PR TITLE
Implement DataTable.__getitem__

### DIFF
--- a/woodwork/data_table.py
+++ b/woodwork/data_table.py
@@ -69,6 +69,13 @@ class DataTable(object):
                                             self.add_standard_tags)
         self._update_dtypes(self.columns)
 
+    def __getitem__(self, key):
+        if not isinstance(key, str):
+            raise KeyError('Column name must be a string')
+        if key not in self.columns.keys():
+            raise KeyError(f"Column with name '{key}' not found in DataTable")
+        return self.columns[key]
+
     @property
     def types(self):
         typing_info = {}

--- a/woodwork/tests/data_table/test_datatable.py
+++ b/woodwork/tests/data_table/test_datatable.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from woodwork import DataTable
+from woodwork import DataColumn, DataTable
 from woodwork.data_table import (
     _check_index,
     _check_logical_types,
@@ -951,3 +951,28 @@ def test_select_semantic_tags_warning(sample_df):
     with pytest.warns(UserWarning, match=warning):
         dt_single = dt.select_semantic_tags(['numeric', 'doesnt_exist', 'category', 'tag2'])
     assert len(dt_single.columns) == 3
+
+
+def test_getitem(sample_df):
+    dt = DataTable(sample_df,
+                   name='datatable',
+                   logical_types={'age': WholeNumber},
+                   semantic_tags={'age': 'custom_tag'},
+                   add_standard_tags=True)
+
+    data_col = dt['age']
+    assert isinstance(data_col, DataColumn)
+    assert data_col.logical_type == WholeNumber
+    assert data_col.semantic_tags == {'numeric', 'custom_tag'}
+
+
+def test_getitem_invalid_input(sample_df):
+    dt = DataTable(sample_df)
+
+    error_msg = 'Column name must be a string'
+    with pytest.raises(KeyError, match=error_msg):
+        dt[1]
+
+    error_msg = "Column with name 'invalid_column' not found in DataTable"
+    with pytest.raises(KeyError, match=error_msg):
+        dt['invalid_column']


### PR DESCRIPTION
Closes #80 

Add `DataTable.__getitem__` method to return the DataColumn object with the specified name. Also checks that provided input is a string and that the column is present in the DataTable, and if not raises a KeyError.