### PR TITLE
Implement DataTable.__sizeof__

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,7 +17,7 @@ Release Notes
         * Updates to LogicalTypes to support Koalas 1.4.0 (:pr:`393`)
         * Replace ``set_logical_types`` and ``set_semantic_tags`` with just ``set_types`` (:pr:`379`)
         * Remove ``copy_dataframe`` parameter from DataTable initialization (:pr:`398`)
-        * Implement ``DataTable.__sizeof__`` to return size of DataTable and underlying dataframe (:pr:`401`)
+        * Implement ``DataTable.__sizeof__`` to return size of the underlying dataframe (:pr:`401`)
     * Documentation Changes
     * Testing Changes
         * Add pyarrow, dask, and koalas to automated dependency checks (:pr:`388`)

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -154,7 +154,7 @@ class DataTable(object):
         self._update_columns({col_name: column})
 
     def __sizeof__(self):
-        return sum([item.__sizeof__() for item in dir(self)]) + self._dataframe.__sizeof__()
+        return self._dataframe.__sizeof__()
 
     @property
     def types(self):

--- a/woodwork/tests/datatable/test_datatable.py
+++ b/woodwork/tests/datatable/test_datatable.py
@@ -2463,7 +2463,7 @@ def test_datatable_rename(sample_df):
 def test_datatable_sizeof(sample_df):
     dt = DataTable(sample_df)
     if isinstance(sample_df, pd.DataFrame):
-        expected_size = 4967
+        expected_size = 1069
     else:
-        expected_size = 3930
+        expected_size = 32
     assert dt.__sizeof__() == expected_size


### PR DESCRIPTION
- Implement DataTable.__sizeof__
- Closes #381 

This PR implements DataTable.__sizeof__ which returns the total size in bytes used by the object, including the size of the underlying dataframe.
