### PR TITLE
Allow initializing accessor with valid schema

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
         * Implement Schema and Accessor API (:pr:`497`)
         * Add Schema class that holds typing info (:pr:`499`)
         * Add WoodworkTableAccessor class that performs type inference and stores Schema (:pr:`514`)
+        * Allow initializing Accessor schema with a valid Schema object (:pr:`522`)
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
     * Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -251,3 +251,22 @@ def _update_column_dtype(series, logical_type, name):
                 f'logical type {logical_type}.'
             raise TypeError(error_msg)
     return series
+
+
+def _is_valid_schema(dataframe, schema):
+    # --> consider raising warnings that tell the user what' wrong???
+    if set(dataframe.columns) != set(schema.columns.keys()):
+        return False
+    for name in dataframe.columns:
+        # --> need to know when to use backup dtype
+        if str(dataframe[name].dtype) != schema.logical_types[name].pandas_dtype:
+            return False
+    if schema.index is not None:
+        if not dataframe.index.equals(dataframe[schema.index]):
+            return False
+        elif not dataframe[schema.index].is_unique:
+            return False
+
+    return True
+
+    # --> need to check if index is still unique???

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -833,7 +833,8 @@ def test_is_valid_schema(sample_df):
     dropped_df = schema_df.drop('id', axis=1)
     assert not _is_valid_schema(dropped_df, schema)
 
-    different_underlying_index_df = schema_df.reset_index()
+    different_underlying_index_df = schema_df.copy()
+    different_underlying_index_df['id'] = pd.Series([9, 8, 7, 6], dtype='float64')
     assert not _is_valid_schema(different_underlying_index_df, schema)
 
     not_unique_df = schema_df.replace({3: 1})


### PR DESCRIPTION
- Adds `_is_valid_schema` check that confirms whether a schema passed to `Accessor.init` is valid for the dataframe.
- Allows initializing the Accessor's schema with a valid Schema object.
- Closes #486 , #487 
