### PR TITLE
Support numpy 1.20.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Add ``get_valid_mi_types`` function to list LogicalTypes valid for mutual information calculation (:pr:`517`)
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
+        * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)
     * Changes
     * Documentation Changes
         * Add Alteryx OSS Twitter link (:pr:`519`)
@@ -15,7 +16,7 @@ Release Notes
     * Testing Changes
 
 Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 **v0.0.8 January 25, 2021**
     * Enhancements

--- a/koalas-requirements.txt
+++ b/koalas-requirements.txt
@@ -1,2 +1,3 @@
 pyspark>=3.0.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
 koalas>=1.3.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
+numpy<1.20.0

--- a/koalas-requirements.txt
+++ b/koalas-requirements.txt
@@ -1,3 +1,3 @@
 pyspark>=3.0.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
 koalas>=1.3.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
-numpy<1.20.0
+numpy<1.20.0 # remove when koalas supports 1.20.0

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -102,8 +102,8 @@ def dump_table(datatable, path, **kwargs):
         file = os.path.join(path, 'table_description.json')
         with open(file, 'w') as file:
             json.dump(description, file)
-    except TypeError as e:
-        raise TypeError('DataTable is not json serializable: ' + e.args[0].replace("'", ""))
+    except TypeError:
+        raise TypeError('DataTable is not json serializable. Check table and column metadata for values that may not be serializable.')
 
 
 def write_table_data(datatable, path, format='csv', **kwargs):

--- a/woodwork/tests/datatable/test_serialization.py
+++ b/woodwork/tests/datatable/test_serialization.py
@@ -127,7 +127,7 @@ def test_to_dictionary(sample_df):
 def test_unserializable_table(sample_df, tmpdir):
     dt = DataTable(sample_df, table_metadata={'not_serializable': sample_df['is_registered'].dtype})
 
-    error = "DataTable is not json serializable: Object of type dtype is not JSON serializable"
+    error = "DataTable is not json serializable. Check table and column metadata for values that may not be serializable."
     with pytest.raises(TypeError, match=error):
         dt.to_csv(str(tmpdir), encoding='utf-8', engine='python')
 


### PR DESCRIPTION
- Changes serialization test error to not rely on external package 
- Restricts numpy version for Koalaz