### PR TITLE
add read_csv_to_accessor that creates a DataFrame with the Schema initialized

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Add Schema class that holds typing info (:pr:`499`)
         * Add WoodworkTableAccessor class that performs type inference and stores Schema (:pr:`514`)
         * Allow initializing Accessor schema with a valid Schema object (:pr:`522`)
+        * Add ability to read in a csv and create a DataFrame with an initialized Woodwork Schema (:pr:`534`)
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
         * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -3,7 +3,7 @@ from .config import config
 from .datatable import DataColumn, DataTable
 from .type_sys import type_system
 from .type_sys.utils import list_logical_types, list_semantic_tags
-from .utils import read_csv
+from .utils import read_csv, read_csv_to_accessor
 from .version import __version__
 
 import woodwork.demo

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -211,6 +211,64 @@ def test_read_csv_with_pandas_params(sample_df_pandas, tmpdir):
     pd.testing.assert_frame_equal(dt_from_csv.to_dataframe(), dt.to_dataframe().head(nrows))
 
 
+def test_read_csv_to_accessor_no_params(sample_df_pandas, tmpdir):
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    sample_df_pandas.to_csv(filepath, index=False)
+
+    df_from_csv = ww.read_csv_to_accessor(filepath=filepath)
+    assert isinstance(df_from_csv.ww.schema, ww.schema.Schema)
+
+    schema_df = sample_df_pandas.copy()
+    schema_df.ww.init()
+
+    assert df_from_csv.ww.schema == schema_df.ww.schema
+    pd.testing.assert_frame_equal(schema_df, df_from_csv)
+
+
+def test_read_csv_to_accessor_with_woodwork_params(sample_df_pandas, tmpdir):
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    sample_df_pandas.to_csv(filepath, index=False)
+    logical_types = {
+        'full_name': 'NaturalLanguage',
+        'phone_number': 'PhoneNumber'
+    }
+    semantic_tags = {
+        'age': ['tag1', 'tag2'],
+        'is_registered': ['tag3', 'tag4']
+    }
+    df_from_csv = ww.read_csv_to_accessor(filepath=filepath,
+                                          index='id',
+                                          time_index='signup_date',
+                                          logical_types=logical_types,
+                                          semantic_tags=semantic_tags)
+    assert isinstance(df_from_csv.ww.schema, ww.schema.Schema)
+
+    schema_df = sample_df_pandas.copy()
+    schema_df.ww.init(index='id',
+                      time_index='signup_date',
+                      logical_types=logical_types,
+                      semantic_tags=semantic_tags)
+
+    assert df_from_csv.ww.schema == schema_df.ww.schema
+    pd.testing.assert_frame_equal(schema_df, df_from_csv)
+
+
+def test_read_csv_to_accessor_with_pandas_params(sample_df_pandas, tmpdir):
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    sample_df_pandas.to_csv(filepath, index=False)
+    nrows = 2
+
+    df_from_csv = ww.read_csv_to_accessor(filepath=filepath, nrows=nrows)
+    assert isinstance(df_from_csv.ww.schema, ww.schema.Schema)
+
+    schema_df = sample_df_pandas.copy()
+    schema_df.ww.init()
+
+    assert df_from_csv.ww.schema == schema_df.ww.schema
+    assert len(df_from_csv) == nrows
+    pd.testing.assert_frame_equal(df_from_csv, schema_df.head(nrows))
+
+
 def test_is_numeric_datetime_series(time_index_df):
     assert _is_numeric_series(time_index_df['ints'], None)
     assert _is_numeric_series(time_index_df['ints'], Double)

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -103,6 +103,51 @@ def read_csv(filepath=None,
                         use_standard_tags=use_standard_tags)
 
 
+def read_csv_to_accessor(filepath=None,
+                         name=None,
+                         index=None,
+                         time_index=None,
+                         semantic_tags=None,
+                         logical_types=None,
+                         use_standard_tags=True,
+                         **kwargs):
+    """Read data from the specified CSV file and return a DataFrame with initialized Woodwork typing information.
+
+    Args:
+        filepath (str): A valid string path to the file to read
+        name (str, optional): Name used to identify the DataFrame.
+        index (str, optional): Name of the index column.
+        time_index (str, optional): Name of the time index column.
+        semantic_tags (dict, optional): Dictionary mapping column names in the dataframe to the
+            semantic tags for the column. The keys in the dictionary should be strings
+            that correspond to columns in the underlying dataframe. There are two options for
+            specifying the dictionary values:
+            (str): If only one semantic tag is being set, a single string can be used as a value.
+            (list[str] or set[str]): If multiple tags are being set, a list or set of strings can be
+            used as the value.
+            Semantic tags will be set to an empty set for any column not included in the
+            dictionary.
+        logical_types (dict[str -> LogicalType], optional): Dictionary mapping column names in
+            the dataframe to the LogicalType for the column. LogicalTypes will be inferred
+            for any columns not present in the dictionary.
+        use_standard_tags (bool, optional): If True, will add standard semantic tags to columns based
+            on the inferred or specified logical type for the column. Defaults to True.
+        **kwargs: Additional keyword arguments to pass to the underlying ``pandas.read_csv`` function. For more
+            information on available keywords refer to the pandas documentation.
+
+    Returns:
+        woodwork.DataTable: DataTable created from the specified CSV file
+    """
+    dataframe = pd.read_csv(filepath, **kwargs)
+    dataframe.ww.init(name=name,
+                      index=index,
+                      time_index=time_index,
+                      semantic_tags=semantic_tags,
+                      logical_types=logical_types,
+                      use_standard_tags=use_standard_tags)
+    return dataframe
+
+
 def _new_dt_including(datatable, new_data):
     '''
     Creates a new DataTable with specified data and columns


### PR DESCRIPTION
-  The util function is named read_csv_to_accessor but should be changed when we remove the DataTable logic from Woodwork
- Closes #502 