### PR TITLE
API reference and docstring cleanup

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -10,29 +10,28 @@ DataTable
     :toctree: generated/
 
     DataTable
-    DataTable.shape
     DataTable.add_semantic_tags
-    DataTable.remove_semantic_tags
-    DataTable.reset_semantic_tags
-    DataTable.select
-    DataTable.iloc
-    DataTable.set_index
-    DataTable.set_types
-    DataTable.set_time_index
-    DataTable.to_dataframe
     DataTable.describe
     DataTable.describe_dict
+    DataTable.drop
+    DataTable.head
+    DataTable.iloc
     DataTable.mutual_information
     DataTable.mutual_information_dict
-    DataTable.value_counts
-    DataTable.to_csv
-    DataTable.to_pickle
-    DataTable.to_parquet
+    DataTable.remove_semantic_tags
     DataTable.rename
+    DataTable.reset_semantic_tags
+    DataTable.select
+    DataTable.set_index
+    DataTable.set_time_index
+    DataTable.set_types
+    DataTable.shape
+    DataTable.to_csv
+    DataTable.to_dataframe
+    DataTable.to_parquet
+    DataTable.to_pickle
     DataTable.update_dataframe
-    DataTable.head
-    DataTable.drop
-
+    DataTable.value_counts
 
 DataColumn
 ==========
@@ -42,15 +41,14 @@ DataColumn
     :toctree: generated/
 
     DataColumn
-    DataColumn.shape
-    DataColumn.iloc
     DataColumn.add_semantic_tags
+    DataColumn.iloc
     DataColumn.remove_semantic_tags
     DataColumn.reset_semantic_tags
     DataColumn.set_logical_type
     DataColumn.set_semantic_tags
+    DataColumn.shape
     DataColumn.to_series
-
 
 Logical Types
 =============
@@ -64,10 +62,10 @@ Logical Types
     CountryCode
     Datetime
     Double
-    Integer
     EmailAddress
     Filepath
     FullName
+    Integer
     IPAddress
     LatLong
     NaturalLanguage
@@ -116,8 +114,8 @@ General Utils
     :toctree: generated
     :nosignatures:
 
-    read_csv
     get_valid_mi_types
+    read_csv
 
 Demo Data
 =========

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -18,6 +18,7 @@ DataTable
     DataTable.iloc
     DataTable.mutual_information
     DataTable.mutual_information_dict
+    DataTable.pop
     DataTable.remove_semantic_tags
     DataTable.rename
     DataTable.reset_semantic_tags
@@ -87,6 +88,7 @@ TypeSystem
     TypeSystem.add_type
     TypeSystem.infer_logical_type
     TypeSystem.remove_type
+    TypeSystem.reset_defaults
     TypeSystem.update_inference_function
     TypeSystem.update_relationship
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Add Alteryx OSS Twitter link (:pr:`519`)
         * Update logo and add new favicon (:pr:`521`)
         * Multiple improvements to Getting Started page and guides (:pr:`527`)
+        * Clean up API Reference and docstrings (:pr:`536`)
     * Testing Changes
 
 Thanks to the following people for contributing to this release:

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -491,7 +491,7 @@ class DataTable(object):
 
         Args:
             time_index (str): The name of the column to set as the time index.
-        
+
         Returns:
             woodwork.DataTable: DataTable with the specified time index column set.
         """

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -491,6 +491,9 @@ class DataTable(object):
 
         Args:
             time_index (str): The name of the column to set as the time index.
+        
+        Returns:
+            woodwork.DataTable: DataTable with the specified time index column set.
         """
         new_dt = self._new_dt_from_cols(self._dataframe.columns)
         _update_time_index(new_dt, time_index, self.time_index)


### PR DESCRIPTION
- API reference and docstring cleanup
- Closes #334 

Alphebetize the methods listed in the API reference. Add missing public methods to API reference. Minor docstring cleanup.