### PR TITLE
Add ability to call DataFrame methods from Accessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Add WoodworkTableAccessor class that performs type inference and stores Schema (:pr:`514`)
         * Allow initializing Accessor schema with a valid Schema object (:pr:`522`)
         * Add ability to read in a csv and create a DataFrame with an initialized Woodwork Schema (:pr:`534`)
+        * Add ability to call pandas methods from Accessor (:pr:`538`)
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
         * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -31,4 +31,9 @@ class OutdatedSchemaWarning(UserWarning):
 
 class SchemaInvalidatedWarning(UserWarning):
     def get_warning_message(self, attr, invalid_reason):
-        return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n {invalid_reason}. Reinitialize the typing information with DataFrame.ww.init.')
+        return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n {invalid_reason}.\n Please reinitialize Woodwork with DataFrame.ww.init')
+
+
+class CannotInitSchemaWarning(UserWarning):
+    def get_warning_message(self, attr, invalid_reason):
+        return (f'DataFrame created by {attr} is not valid for the given typing information:\n {invalid_reason}.\n Please initialize Woodwork with DataFrame.ww.init')

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -31,4 +31,4 @@ class OutdatedSchemaWarning(UserWarning):
 
 class SchemaInvalidatedWarning(UserWarning):
     def get_warning_message(self, attr, invalid_reason):
-        return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n {invalid_reason}')
+        return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n {invalid_reason}. Reinitialize the typing information with DataFrame.ww.init.')

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -29,15 +29,8 @@ class OutdatedSchemaWarning(UserWarning):
                 % (saved_version_str))
 
 
-class SchemaInvalidatedWarning(UserWarning):
+class TypingInfoMismatchWarning(UserWarning):
     def get_warning_message(self, attr, invalid_reason):
         return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n '
-                f'{invalid_reason}.\n '
-                'Please reinitialize Woodwork with DataFrame.ww.init')
-
-
-class CannotInitSchemaWarning(UserWarning):
-    def get_warning_message(self, attr, invalid_reason):
-        return (f'DataFrame created by {attr} is not valid for the given typing information:\n '
                 f'{invalid_reason}.\n '
                 'Please initialize Woodwork with DataFrame.ww.init')

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -27,3 +27,8 @@ class OutdatedSchemaWarning(UserWarning):
                 '%s is no longer supported by this version '
                 'of woodwork. Attempting to load woodwork.DataTable ...'
                 % (saved_version_str))
+
+
+class SchemaInvalidatedWarning(UserWarning):
+    def get_warning_message(self, attr):
+        return (f'Operation performed by {attr} has invalidated the Woodwork typing information.')

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -31,9 +31,13 @@ class OutdatedSchemaWarning(UserWarning):
 
 class SchemaInvalidatedWarning(UserWarning):
     def get_warning_message(self, attr, invalid_reason):
-        return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n {invalid_reason}.\n Please reinitialize Woodwork with DataFrame.ww.init')
+        return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n '
+                f'{invalid_reason}.\n '
+                'Please reinitialize Woodwork with DataFrame.ww.init')
 
 
 class CannotInitSchemaWarning(UserWarning):
     def get_warning_message(self, attr, invalid_reason):
-        return (f'DataFrame created by {attr} is not valid for the given typing information:\n {invalid_reason}.\n Please initialize Woodwork with DataFrame.ww.init')
+        return (f'DataFrame created by {attr} is not valid for the given typing information:\n '
+                f'{invalid_reason}.\n '
+                'Please initialize Woodwork with DataFrame.ww.init')

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -30,5 +30,5 @@ class OutdatedSchemaWarning(UserWarning):
 
 
 class SchemaInvalidatedWarning(UserWarning):
-    def get_warning_message(self, attr):
-        return (f'Operation performed by {attr} has invalidated the Woodwork typing information.')
+    def get_warning_message(self, attr, invalid_reason):
+        return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n {invalid_reason}')

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -2,10 +2,7 @@ import warnings
 
 import pandas as pd
 
-from woodwork.exceptions import (
-    CannotInitSchemaWarning,
-    SchemaInvalidatedWarning
-)
+from woodwork.exceptions import TypingInfoMismatchWarning
 from woodwork.logical_types import Datetime, LatLong, Ordinal
 from woodwork.schema import Schema
 from woodwork.type_sys.utils import (
@@ -183,17 +180,18 @@ class WoodworkTableAccessor:
                 if isinstance(result, pd.DataFrame):
                     invalid_schema_message = _get_invalid_schema_message(result, self._schema)
                     if invalid_schema_message:
-                        warnings.warn(CannotInitSchemaWarning().get_warning_message(attr, invalid_schema_message),
-                                      CannotInitSchemaWarning)
+                        warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message),
+                                      TypingInfoMismatchWarning)
                     else:
                         result.ww.init(schema=self._schema)
-                # Confirm that the Schema is still valid on original DataFrame
-                # Important for inplace operations
-                invalid_schema_message = _get_invalid_schema_message(self._dataframe, self._schema)
-                if invalid_schema_message:
-                    warnings.warn(SchemaInvalidatedWarning().get_warning_message(attr, invalid_schema_message),
-                                  SchemaInvalidatedWarning)
-                    self._schema = None
+                else:
+                    # Confirm that the Schema is still valid on original DataFrame
+                    # Important for inplace operations
+                    invalid_schema_message = _get_invalid_schema_message(self._dataframe, self._schema)
+                    if invalid_schema_message:
+                        warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message),
+                                      TypingInfoMismatchWarning)
+                        self._schema = None
 
                 # Always return the results of the DataFrame operation whether or not Woodwork is initialized
                 return result

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -339,11 +339,11 @@ def _get_invalid_schema_message(dataframe, schema):
         return f'The following columns in the typing information were missing from the DataFrame: '\
             f'{schema_cols_not_in_df}'
     for name in dataframe.columns:
-        df_dtype = str(dataframe[name].dtype)
+        df_dtype = dataframe[name].dtype
         schema_dtype = schema.logical_types[name].pandas_dtype
         if df_dtype != schema_dtype:
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
-                f'{df_dtype}, and LogicalType dtype, {schema_dtype}'
+                f'{df_dtype}, and {schema.logical_types[name]} dtype, {schema_dtype}'
     if schema.index is not None:
         if not all(dataframe.index == dataframe[schema.index]):
             return 'Index mismatch between DataFrame and typing information'

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -28,7 +28,14 @@ class WoodworkTableAccessor:
         self._dataframe = dataframe
         self._schema = None
 
-    def init(self, index=None, time_index=None, logical_types=None, make_index=False, already_sorted=False, schema=None, **kwargs):
+    def init(self,
+             index=None,
+             time_index=None,
+             logical_types=None,
+             make_index=False,
+             already_sorted=False,
+             schema=None,
+             **kwargs):
         '''Initializes Woodwork typing information for a DataFrame.
 
         Args:
@@ -202,17 +209,20 @@ def _check_unique_column_names(dataframe):
 def _check_index(dataframe, index, make_index=False):
     if not make_index and index not in dataframe.columns:
         # User specifies an index that is not in the dataframe, without setting make_index to True
-        raise LookupError(f'Specified index column `{index}` not found in dataframe. To create a new index column, set make_index to True.')
+        raise LookupError(f'Specified index column `{index}` not found in dataframe. '
+                          'To create a new index column, set make_index to True.')
     if index is not None and not make_index and isinstance(dataframe, pd.DataFrame) and not dataframe[index].is_unique:
         # User specifies an index that is in the dataframe but not unique
         # Does not check for Dask as Dask does not support is_unique
         raise IndexError('Index column must be unique')
     if make_index and index is not None and index in dataframe.columns:
         # User sets make_index to True, but supplies an index name that matches a column already present
-        raise IndexError('When setting make_index to True, the name specified for index cannot match an existing column name')
+        raise IndexError('When setting make_index to True, '
+                         'the name specified for index cannot match an existing column name')
     if make_index and index is None:
         # User sets make_index to True, but does not supply a name for the index
-        raise IndexError('When setting make_index to True, the name for the new index must be specified in the index parameter')
+        raise IndexError('When setting make_index to True, '
+                         'the name for the new index must be specified in the index parameter')
 
 
 def _check_time_index(dataframe, time_index, datetime_format=None, logical_type=None):
@@ -302,15 +312,18 @@ def _get_invalid_schema_message(dataframe, schema):
 
     df_cols_not_in_schema = dataframe_cols - schema_cols
     if df_cols_not_in_schema:
-        return f'The following columns in the DataFrame were missing from the typing information: {df_cols_not_in_schema}'
+        return f'The following columns in the DataFrame were missing from the typing information: '\
+            f'{df_cols_not_in_schema}'
     schema_cols_not_in_df = schema_cols - dataframe_cols
     if schema_cols_not_in_df:
-        return f'The following columns in the typing information were missing from the DataFrame: {schema_cols_not_in_df}'
+        return f'The following columns in the typing information were missing from the DataFrame: '\
+            f'{schema_cols_not_in_df}'
     for name in dataframe.columns:
         df_dtype = str(dataframe[name].dtype)
         schema_dtype = schema.logical_types[name].pandas_dtype
         if df_dtype != schema_dtype:
-            return f'dtype mismatch for column {name} between DataFrame dtype, {df_dtype}, and LogicalType dtype, {schema_dtype}'
+            return f'dtype mismatch for column {name} between DataFrame dtype, '\
+                f'{df_dtype}, and LogicalType dtype, {schema_dtype}'
     if schema.index is not None:
         if not all(dataframe.index == dataframe[schema.index]):
             return 'Index mismatch between DataFrame and typing information'

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -110,7 +110,6 @@ class WoodworkTableAccessor:
                 return wrapper
             return schema_attr
         if hasattr(self._dataframe, attr):
-            # --> should do a lot of manual testing here to see what sorts of things we can get returned via callable and not
             dataframe_attr = getattr(self._dataframe, attr)
 
             if callable(dataframe_attr):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -124,7 +124,6 @@ class WoodworkTableAccessor:
                     '''
                     result = dataframe_attr(*args, **kwargs)
                     if isinstance(result, pd.DataFrame):
-                        # --> check valid schema before init so we can have better error message
                         invalid_schema_message = _get_invalid_schema_message(result, self._schema)
                         if invalid_schema_message:
                             raise ValueError(f'Cannot perform operation {attr}: {invalid_schema_message}')

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -115,7 +115,7 @@ class WoodworkTableAccessor:
 
             if callable(dataframe_attr):
                 def wrapper(*args, **kwargs):
-                    '''Makes the method call on the DataFrame, intercepting it prior to return in order
+                    '''Makes the method call on the DataFrame, intercepting its result prior to return in order
                     to initialize Woodwork if the return object is also a DataFrame.
                     Will error if the Schema is not valid for the new DataFrame.
                     '''

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -97,6 +97,7 @@ class WoodworkTableAccessor:
         '''
             If the method is present on the Accessor, uses that method.
             If the method is present on Schema, uses that method.
+            If the method is present on DataFrame, uses that method.
         '''
         # schema = object.__getattribute__(self, '_schema')
         if self._schema is None:

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -860,6 +860,10 @@ def test_dataframe_methods_on_accessor(sample_df):
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(copied_df))
 
+    # --> test iloc as full copy
+
+    # --> add check that invalidates
+
 
 def test_dataframe_methods_on_accessor_inplace(sample_df):
     xfail_dask_and_koalas(sample_df)
@@ -874,17 +878,36 @@ def test_dataframe_methods_on_accessor_inplace(sample_df):
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(df_pre_sort.sort_values(['full_name'])))
 
+# --> add option that ends up throwing error - astype
+
 
 def test_dataframe_methods_on_accessor_returning_series(sample_df):
     xfail_dask_and_koalas(sample_df)
-    pass
+
+    schema_df = sample_df.copy()
+    schema_df.ww.init(name='test_schema')
+
+    dtypes = schema_df.ww.dtypes
+
+    assert schema_df.ww.name == 'test_schema'
+    pd.testing.assert_series_equal(dtypes, schema_df.dtypes)
+
+    memory = schema_df.ww.memory_usage()
+    assert schema_df.ww.name == 'test_schema'
+    pd.testing.assert_series_equal(memory, schema_df.memory_usage())
+    # --> test pop
 
 
 def test_dataframe_methods_on_accessor_other_returns(sample_df):
     xfail_dask_and_koalas(sample_df)
-    pass
+    schema_df = sample_df.copy()
+    schema_df.ww.init(name='test_schema')
 
+    shape = schema_df.ww.shape
 
-def test_erroring_dataframe_methods_on_accessor(sample_df):
-    xfail_dask_and_koalas(sample_df)
-    pass
+    assert schema_df.ww.name == 'test_schema'
+    assert shape == schema_df.shape
+
+    keys = schema_df.ww.keys()
+    assert schema_df.ww.name == 'test_schema'
+    pd.testing.assert_index_equal(keys, schema_df.keys())

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -884,25 +884,6 @@ def test_dataframe_methods_on_accessor_inplace(sample_df):
     assert 'new_name' in schema_df.columns
 
 
-def test_dataframe_methods_on_accessor_returning_indexer(sample_df):
-    xfail_dask_and_koalas(sample_df)
-
-    schema_df = sample_df.copy()
-    schema_df.ww.init(name='test_schema')
-
-    iloc_df = schema_df.ww.iloc()[2:, :]
-    assert iloc_df.ww.schema is None
-    pd.testing.assert_frame_equal(to_pandas(schema_df.iloc[2:, :]), to_pandas(iloc_df))
-
-    iloc_df.ww.init(schema=schema_df.ww.schema)
-    assert iloc_df.ww.name == 'test_schema'
-
-    error = 'Woodwork typing information is not valid for this DataFrame.'
-    with pytest.raises(ValueError, match=error):
-        iloc_df = schema_df.ww.iloc()[:, 2:]
-        iloc_df.ww.init(schema=schema_df.ww.schema)
-
-
 def test_dataframe_methods_on_accessor_returning_series(sample_df):
     xfail_dask_and_koalas(sample_df)
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -880,7 +880,7 @@ def test_dataframe_methods_on_accessor_inplace(sample_df):
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(df_pre_sort.sort_values(['full_name'])))
 
-    warning = "Operation performed by rename has invalidated the Woodwork typing information:\n The following columns in the DataFrame were missing from the typing information: {'new_name'}"
+    warning = "Operation performed by rename has invalidated the Woodwork typing information:\n The following columns in the DataFrame were missing from the typing information: {'new_name'}. Reinitialize the typing information with DataFrame.ww.init."
     with pytest.warns(SchemaInvalidatedWarning, match=warning):
         schema_df.ww.rename({'id': 'new_name'}, inplace=True, axis=1)
     assert 'new_name' in schema_df.columns
@@ -902,7 +902,7 @@ def test_dataframe_methods_on_accessor_returning_series(sample_df):
     assert schema_df.ww.name == 'test_schema'
     pd.testing.assert_series_equal(memory, schema_df.memory_usage())
 
-    warning = "Operation performed by pop has invalidated the Woodwork typing information:\n The following columns in the typing information were missing from the DataFrame: {'id'}"
+    warning = "Operation performed by pop has invalidated the Woodwork typing information:\n The following columns in the typing information were missing from the DataFrame: {'id'}. Reinitialize the typing information with DataFrame.ww.init."
     with pytest.warns(SchemaInvalidatedWarning, match=warning):
         schema_df.ww.pop('id')
     assert 'id' not in schema_df.columns

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -154,7 +154,7 @@ def test_init_accessor_with_schema_errors(sample_df):
     with pytest.raises(TypeError, match=error):
         iloc_df.ww.init(schema=int)
 
-    error = 'Invalid typing information presented at init. Cannot set Woodwork on DataFrame.'
+    error = 'Woodwork typing information is not valid for this DataFrame.'
     with pytest.raises(ValueError, match=error):
         iloc_df.ww.init(schema=schema)
 
@@ -844,3 +844,47 @@ def test_is_valid_schema(sample_df):
 
     different_dtype_df = schema_df.astype({'id': 'Int64'}, copy=True)
     assert not _is_valid_schema(different_dtype_df, schema)
+
+
+def test_dataframe_methods_on_accessor(sample_df):
+    xfail_dask_and_koalas(sample_df)
+
+    schema_df = sample_df.copy()
+    schema_df.ww.init(name='test_schema')
+
+    copied_df = schema_df.ww.copy()
+
+    assert schema_df is not copied_df
+    assert isinstance(copied_df.ww.schema, Schema)
+    assert copied_df.ww.schema == schema_df.ww.schema
+
+    pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(copied_df))
+
+
+def test_dataframe_methods_on_accessor_inplace(sample_df):
+    xfail_dask_and_koalas(sample_df)
+
+    schema_df = sample_df.copy()
+    schema_df.ww.init(name='test_schema')
+
+    df_pre_sort = schema_df.copy()
+
+    schema_df.ww.sort_values(['full_name'], inplace=True)
+    assert schema_df.ww.name == 'test_schema'
+
+    pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(df_pre_sort.sort_values(['full_name'])))
+
+
+def test_dataframe_methods_on_accessor_returning_series(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    pass
+
+
+def test_dataframe_methods_on_accessor_other_returns(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    pass
+
+
+def test_erroring_dataframe_methods_on_accessor(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    pass

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -4,7 +4,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from woodwork.exceptions import CannotInitSchemaWarning, SchemaInvalidatedWarning
+from woodwork.exceptions import (
+    CannotInitSchemaWarning,
+    SchemaInvalidatedWarning
+)
 from woodwork.logical_types import (
     URL,
     Boolean,

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from woodwork.exceptions import SchemaInvalidatedWarning
 from woodwork.logical_types import (
     URL,
     Boolean,
@@ -863,6 +864,7 @@ def test_dataframe_methods_on_accessor(sample_df):
     error = 'Woodwork typing information is not valid for this DataFrame.'
     with pytest.raises(ValueError, match=error):
         schema_df.ww.astype({'id': 'string'})
+    assert schema_df.ww.schema is not None
 
 
 def test_dataframe_methods_on_accessor_inplace(sample_df):
@@ -878,10 +880,11 @@ def test_dataframe_methods_on_accessor_inplace(sample_df):
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(df_pre_sort.sort_values(['full_name'])))
 
-    error = 'Woodwork typing information is not valid for this DataFrame.'
-    with pytest.raises(ValueError, match=error):
+    warning = 'Operation performed by rename has invalidated the Woodwork typing information.'
+    with pytest.warns(SchemaInvalidatedWarning, match=warning):
         schema_df.ww.rename({'id': 'new_name'}, inplace=True, axis=1)
     assert 'new_name' in schema_df.columns
+    assert schema_df.ww.schema is None
 
 
 def test_dataframe_methods_on_accessor_returning_series(sample_df):
@@ -899,10 +902,11 @@ def test_dataframe_methods_on_accessor_returning_series(sample_df):
     assert schema_df.ww.name == 'test_schema'
     pd.testing.assert_series_equal(memory, schema_df.memory_usage())
 
-    error = 'Woodwork typing information is not valid for this DataFrame.'
-    with pytest.raises(ValueError, match=error):
+    warning = 'Operation performed by pop has invalidated the Woodwork typing information.'
+    with pytest.warns(SchemaInvalidatedWarning, match=warning):
         schema_df.ww.pop('id')
     assert 'id' not in schema_df.columns
+    assert schema_df.ww.schema is None
 
 
 def test_dataframe_methods_on_accessor_other_returns(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -4,10 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from woodwork.exceptions import (
-    CannotInitSchemaWarning,
-    SchemaInvalidatedWarning
-)
+from woodwork.exceptions import TypingInfoMismatchWarning
 from woodwork.logical_types import (
     URL,
     Boolean,
@@ -869,10 +866,10 @@ def test_dataframe_methods_on_accessor(sample_df):
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(copied_df))
 
-    warning = 'DataFrame created by astype is not valid for the given typing information:\n '\
+    warning = 'Operation performed by astype has invalidated the Woodwork typing information:\n '\
         'dtype mismatch for column id between DataFrame dtype, string, and Integer dtype, Int64.\n '\
         'Please initialize Woodwork with DataFrame.ww.init'
-    with pytest.warns(CannotInitSchemaWarning, match=warning):
+    with pytest.warns(TypingInfoMismatchWarning, match=warning):
         new_df = schema_df.ww.astype({'id': 'string'})
     assert new_df['id'].dtype == 'string'
     assert new_df.ww.schema is None
@@ -894,8 +891,8 @@ def test_dataframe_methods_on_accessor_inplace(sample_df):
 
     warning = "Operation performed by rename has invalidated the Woodwork typing information:\n "\
         "The following columns in the DataFrame were missing from the typing information: {'new_name'}.\n "\
-        "Please reinitialize Woodwork with DataFrame.ww.init"
-    with pytest.warns(SchemaInvalidatedWarning, match=warning):
+        "Please initialize Woodwork with DataFrame.ww.init"
+    with pytest.warns(TypingInfoMismatchWarning, match=warning):
         schema_df.ww.rename({'id': 'new_name'}, inplace=True, axis=1)
     assert 'new_name' in schema_df.columns
     assert schema_df.ww.schema is None
@@ -918,8 +915,8 @@ def test_dataframe_methods_on_accessor_returning_series(sample_df):
 
     warning = "Operation performed by pop has invalidated the Woodwork typing information:\n "\
         "The following columns in the typing information were missing from the DataFrame: {'id'}.\n "\
-        "Please reinitialize Woodwork with DataFrame.ww.init"
-    with pytest.warns(SchemaInvalidatedWarning, match=warning):
+        "Please initialize Woodwork with DataFrame.ww.init"
+    with pytest.warns(TypingInfoMismatchWarning, match=warning):
         schema_df.ww.pop('id')
     assert 'id' not in schema_df.columns
     assert schema_df.ww.schema is None

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -158,7 +158,8 @@ def test_init_accessor_with_schema_errors(sample_df):
     with pytest.raises(TypeError, match=error):
         iloc_df.ww.init(schema=int)
 
-    error = "Woodwork typing information is not valid for this DataFrame: The following columns in the typing information were missing from the DataFrame: {'is_registered'}"
+    error = ("Woodwork typing information is not valid for this DataFrame: "
+             "The following columns in the typing information were missing from the DataFrame: {'is_registered'}")
     with pytest.raises(ValueError, match=error):
         iloc_df.ww.init(schema=schema)
 
@@ -829,20 +830,24 @@ def test_get_invalid_schema_message(sample_df):
     schema = schema_df.ww.schema
 
     assert _get_invalid_schema_message(schema_df, schema) is None
-    assert _get_invalid_schema_message(sample_df, schema) == 'dtype mismatch for column id between DataFrame dtype, int64, and LogicalType dtype, float64'
+    assert (_get_invalid_schema_message(sample_df, schema) ==
+            'dtype mismatch for column id between DataFrame dtype, int64, and Double dtype, float64')
 
     sampled_df = schema_df.sample(2)
     assert _get_invalid_schema_message(sampled_df, schema) is None
 
     dropped_df = schema_df.drop('id', axis=1)
-    assert _get_invalid_schema_message(dropped_df, schema) == "The following columns in the typing information were missing from the DataFrame: {'id'}"
+    assert (_get_invalid_schema_message(dropped_df, schema) ==
+            "The following columns in the typing information were missing from the DataFrame: {'id'}")
 
     renamed_df = schema_df.rename({'id': 'new_col'}, axis=1)
-    assert _get_invalid_schema_message(renamed_df, schema) == "The following columns in the DataFrame were missing from the typing information: {'new_col'}"
+    assert (_get_invalid_schema_message(renamed_df, schema) ==
+            "The following columns in the DataFrame were missing from the typing information: {'new_col'}")
 
     different_underlying_index_df = schema_df.copy()
     different_underlying_index_df['id'] = pd.Series([9, 8, 7, 6], dtype='float64')
-    assert _get_invalid_schema_message(different_underlying_index_df, schema) == "Index mismatch between DataFrame and typing information"
+    assert (_get_invalid_schema_message(different_underlying_index_df, schema) ==
+            "Index mismatch between DataFrame and typing information")
 
     not_unique_df = schema_df.replace({3: 1})
     not_unique_df.index = not_unique_df['id']
@@ -864,7 +869,9 @@ def test_dataframe_methods_on_accessor(sample_df):
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(copied_df))
 
-    warning = 'DataFrame created by astype is not valid for the given typing information:\n dtype mismatch for column id between DataFrame dtype, string, and LogicalType dtype, Int64.\n Please initialize Woodwork with DataFrame.ww.init'
+    warning = 'DataFrame created by astype is not valid for the given typing information:\n '\
+        'dtype mismatch for column id between DataFrame dtype, string, and Integer dtype, Int64.\n '\
+        'Please initialize Woodwork with DataFrame.ww.init'
     with pytest.warns(CannotInitSchemaWarning, match=warning):
         new_df = schema_df.ww.astype({'id': 'string'})
     assert new_df['id'].dtype == 'string'
@@ -885,7 +892,9 @@ def test_dataframe_methods_on_accessor_inplace(sample_df):
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(df_pre_sort.sort_values(['full_name'])))
 
-    warning = "Operation performed by rename has invalidated the Woodwork typing information:\n The following columns in the DataFrame were missing from the typing information: {'new_name'}.\n Please reinitialize Woodwork with DataFrame.ww.init"
+    warning = "Operation performed by rename has invalidated the Woodwork typing information:\n "\
+        "The following columns in the DataFrame were missing from the typing information: {'new_name'}.\n "\
+        "Please reinitialize Woodwork with DataFrame.ww.init"
     with pytest.warns(SchemaInvalidatedWarning, match=warning):
         schema_df.ww.rename({'id': 'new_name'}, inplace=True, axis=1)
     assert 'new_name' in schema_df.columns
@@ -907,7 +916,9 @@ def test_dataframe_methods_on_accessor_returning_series(sample_df):
     assert schema_df.ww.name == 'test_schema'
     pd.testing.assert_series_equal(memory, schema_df.memory_usage())
 
-    warning = "Operation performed by pop has invalidated the Woodwork typing information:\n The following columns in the typing information were missing from the DataFrame: {'id'}.\n Please reinitialize Woodwork with DataFrame.ww.init"
+    warning = "Operation performed by pop has invalidated the Woodwork typing information:\n "\
+        "The following columns in the typing information were missing from the DataFrame: {'id'}.\n "\
+        "Please reinitialize Woodwork with DataFrame.ww.init"
     with pytest.warns(SchemaInvalidatedWarning, match=warning):
         schema_df.ww.pop('id')
     assert 'id' not in schema_df.columns
@@ -924,6 +935,5 @@ def test_dataframe_methods_on_accessor_other_returns(sample_df):
     assert schema_df.ww.name == 'test_schema'
     assert shape == schema_df.shape
 
-    keys = schema_df.ww.keys()
     assert schema_df.ww.name == 'test_schema'
-    pd.testing.assert_index_equal(keys, schema_df.keys())
+    pd.testing.assert_index_equal(schema_df.ww.keys(), schema_df.keys())


### PR DESCRIPTION
- Allows for things like `df.ww.sample` while throwing errors for operation that invalidates the original DataFrame + Schema or a new DataFrame + Schema
- Closes #490 