### PR TITLE
Avoid fatal errors at import-time from koalas

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
         * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)
+        * Avoid fatal errors at import-time from koalas (:pr:`542`)
     * Changes
     * Documentation Changes
         * Add Alteryx OSS Twitter link (:pr:`519`)

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -1,9 +1,13 @@
 # flake8: noqa
+import warnings
+
 from .config import config
 from .datatable import DataColumn, DataTable
 from .type_sys import type_system
 from .type_sys.utils import list_logical_types, list_semantic_tags
-from .utils import read_csv
+from .utils import import_and_configure_koalas, read_csv
 from .version import __version__
 
 import woodwork.demo
+
+ks = import_and_configure_koalas()

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -26,8 +26,6 @@ from woodwork.utils import (
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
-if ks:
-    ks.set_option('compute.ops_on_diff_frames', True)
 
 
 class DataTable(object):

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -1,7 +1,7 @@
-
 import ast
 import importlib
 import re
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -21,6 +21,41 @@ def import_or_none(library):
         return importlib.import_module(library)
     except ImportError:
         return None
+
+
+def import_or_raise(library, error_msg):
+    '''
+    Attempts to import the requested library.  If the import fails, raises an
+    ImportError with the supplied error message.
+
+    Args:
+        library (str): the name of the library
+        error_msg (str): error message to return if the import fails
+    '''
+    try:
+        return importlib.import_module(library)
+    except ImportError:
+        raise ImportError(error_msg)
+
+
+def import_and_configure_koalas(compute_ops_on_diff_frames=True):
+    """
+    Import the koalas library. Set the compute.ops_on_diff_frames as an optimization.
+
+    Args:
+        compute_ops_on_diff_frames (bool): the koalas compute.ops_on_diff_frames argum,ent
+
+    Returns:
+        A reference to the koalas module
+    """
+    ks = import_or_none('databricks.koalas')
+    if ks is None:
+        return None
+    try:
+        ks.set_option('compute.ops_on_diff_frames', compute_ops_on_diff_frames)
+    except Exception as e:
+        warnings.warn('Unable to set compute.ops_on_diff_frames for koalas: ' + str(e))
+    return ks
 
 
 def camel_to_snake(s):
@@ -145,21 +180,6 @@ def _new_dt_including(datatable, new_data):
                         table_metadata=datatable.metadata,
                         column_metadata=new_column_metadata,
                         column_descriptions=new_column_descriptions)
-
-
-def import_or_raise(library, error_msg):
-    '''
-    Attempts to import the requested library.  If the import fails, raises an
-    ImportError with the supplied error message.
-
-    Args:
-        library (str): the name of the library
-        error_msg (str): error message to return if the import fails
-    '''
-    try:
-        return importlib.import_module(library)
-    except ImportError:
-        raise ImportError(error_msg)
 
 
 def _is_s3(string):


### PR DESCRIPTION
For #541 

This PR will prevent the call to `koalas.set_option` from crashing import.

This doesn't solve the root cause of #541, but it will hopefully prevent a crash at import-time resulting from that issue.