### PR TITLE
Fix issue with setting koalas option

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
         * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)
+        * Move Koalas option setting to DataTable init instead of import (:pr:`543`)
     * Changes
     * Documentation Changes
         * Add Alteryx OSS Twitter link (:pr:`519`)

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -26,8 +26,6 @@ from woodwork.utils import (
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
-if ks:
-    ks.set_option('compute.ops_on_diff_frames', True)
 
 
 class DataTable(object):
@@ -83,6 +81,8 @@ class DataTable(object):
                          table_metadata, column_metadata, semantic_tags, make_index, column_descriptions)
 
         self._dataframe = dataframe
+        if ks and isinstance(dataframe, ks.DataFrame) and not ks.get_option('compute.ops_on_diff_frames'):
+            ks.set_option('compute.ops_on_diff_frames', True)
 
         self.make_index = make_index or None
         if self.make_index:


### PR DESCRIPTION
- Fix issue with setting koalas option
- Closes #541 

Update so that Kolas `'compute.ops_on_diff_frames'` is only set if user is working with Koalas dataframes, rather than setting in import.