### PR TITLE
Add `select` to Accessor

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -11,6 +11,7 @@ WoodworkTableAccessor
 
     WoodworkTableAccessor
     WoodworkTableAccessor.init
+    WoodworkTableAccessor.select
 
 
 Schema

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Add ability to call pandas methods from Accessor (:pr:`538`)
         * Add helpers for checking if a column is one of Boolean, Datetime, numeric, or categorical (:pr:`553`)
         * Add ability to load demo retail dataset with a Woodwork Accessor (:pr:`556`)
+        * Add ``select`` to WoodworkTableAccessor (:pr:`548`)
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
         * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -241,9 +241,9 @@ class Schema(object):
         new_semantic_tags = {}
         new_column_descriptions = {}
         new_column_metadata = {}
-        for col_name, col in self.columns.items():
-            if col_name not in subset_cols:
-                continue
+        for col_name in subset_cols:
+            col = col = self.columns[col_name]
+
             new_logical_types[col_name] = col['logical_type']
             new_semantic_tags[col_name] = col['semantic_tags']
             new_column_descriptions[col_name] = col['description']

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -230,6 +230,12 @@ class Schema(object):
 
     def _new_schema_including(self, subset_cols):
         '''
+        Creates a new Schema with specified columns, retainig typing information.
+
+        Args:
+            subset_cols (list[str]): subset of columns from which to create the new Schema
+        Returns:
+            Schema: New Schema with attributes from original Schema
         '''
         new_logical_types = {}
         new_semantic_tags = {}

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -228,7 +228,7 @@ class Schema(object):
 
         return list(cols_to_include)
 
-    def _new_schema_including(self, subset_cols):
+    def _get_subset_schema(self, subset_cols):
         '''
         Creates a new Schema with specified columns, retainig typing information.
 

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -184,7 +184,7 @@ class Schema(object):
 
     def _filter_cols(self, include):
         """Return list of columns filtered in specified way. In case of collision, favors logical types
-        then semantic tag then column name.
+        then semantic tag.
 
         Args:
             include (str or LogicalType or list[str or LogicalType]): parameter or list of parameters to
@@ -230,7 +230,7 @@ class Schema(object):
 
     def _get_subset_schema(self, subset_cols):
         '''
-        Creates a new Schema with specified columns, retainig typing information.
+        Creates a new Schema with specified columns, retaining typing information.
 
         Args:
             subset_cols (list[str]): subset of columns from which to create the new Schema

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -126,8 +126,8 @@ class WoodworkTableAccessor:
         return self._schema
 
     def select(self, include):
-        """Create a DataFrame with Woodowork typing information initialized 
-        that includes only columns whose Logical Type and semantic tags are 
+        """Create a DataFrame with Woodowork typing information initialized
+        that includes only columns whose Logical Type and semantic tags are
         specified in the list of types and tags to include.
         If no matching columns are found, an empty DataFrame will be returned.
 
@@ -142,7 +142,7 @@ class WoodworkTableAccessor:
             information initialized.
         """
         cols_to_include = self._schema._filter_cols(include)
-        return self._new_df_with_schema_from_cols(cols_to_include)
+        return self._get_subset_df_with_schema(cols_to_include)
 
     def _sort_columns(self, already_sorted):
         if dd and isinstance(self._dataframe, dd.DataFrame) or (ks and isinstance(self._dataframe, ks.DataFrame)):
@@ -218,15 +218,16 @@ class WoodworkTableAccessor:
         # Directly return non-callable DataFrame attributes
         return dataframe_attr
 
-    def _new_df_with_schema_from_cols(self, cols_to_include):
-        '''
+
+== == == =
+>>>>>> > cleanup
         Creates a new DataFrame from a list of column names with Woodwork initialized,
         retaining all typing information and maintaining the DataFrame's column order.
         '''
         assert all([col_name in self._schema.columns for col_name in cols_to_include])
         cols_to_include = [col_name for col_name in self._dataframe.columns if col_name in cols_to_include]
 
-        new_schema = self._schema._new_schema_including(cols_to_include)
+        new_schema = self._schema._get_subset_schema(cols_to_include)
 
         new_df = self._dataframe[cols_to_include]
         new_df.ww.init(schema=new_schema)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -126,8 +126,21 @@ class WoodworkTableAccessor:
         return self._schema
 
     def select(self, include):
-        '''
-        '''
+        """Create a DataFrame with Woodowork typing information initialized 
+        that includes only columns whose Logical Type and semantic tags are 
+        specified in the list of types and tags to include.
+        If no matching columns are found, an empty DataFrame will be returned.
+
+        Args:
+            include (str or LogicalType or list[str or LogicalType]): Logical
+                types, semantic tags to include
+                in the DataFrame.
+
+        Returns:
+            DataFrame: The subset of the original DataFrame that contains just the
+            logical types and semantic tags in ``include``. Has Woodwork typing
+            information initialized.
+        """
         cols_to_include = self._schema._filter_cols(include)
         return self._new_df_with_schema_from_cols(cols_to_include)
 
@@ -206,7 +219,10 @@ class WoodworkTableAccessor:
         return dataframe_attr
 
     def _new_df_with_schema_from_cols(self, cols_to_include):
-        # confirm order is the same and all columns are present
+        '''
+        Creates a new DataFrame from a list of column names with Woodwork initialized,
+        retaining all typing information and maintaining the DataFrame's column order.
+        '''
         assert all([col_name in self._schema.columns for col_name in cols_to_include])
         cols_to_include = [col_name for col_name in self._dataframe.columns if col_name in cols_to_include]
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -133,8 +133,7 @@ class WoodworkTableAccessor:
 
         Args:
             include (str or LogicalType or list[str or LogicalType]): Logical
-                types, semantic tags to include
-                in the DataFrame.
+                types, semantic tags to include in the DataFrame.
 
         Returns:
             DataFrame: The subset of the original DataFrame that contains just the

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -218,9 +218,8 @@ class WoodworkTableAccessor:
         # Directly return non-callable DataFrame attributes
         return dataframe_attr
 
-
-== == == =
->>>>>> > cleanup
+    def _get_subset_df_with_schema(self, cols_to_include):
+        '''
         Creates a new DataFrame from a list of column names with Woodwork initialized,
         retaining all typing information and maintaining the DataFrame's column order.
         '''

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1235,3 +1235,30 @@ def test_select_semantic_tags_no_match(sample_df):
 
     df_unused_ltype = schema_df.ww.select(['date_of_birth', 'doesnt_exist', ZIPCode, Integer])
     assert len(df_unused_ltype.columns) == 3
+
+
+def test_select_repetitive(sample_df):
+    xfail_dask_and_koalas(sample_df)
+
+    schema_df = sample_df.copy()
+    schema_df.ww.init(time_index='signup_date',
+                      index='id',
+                      name='df_name',
+                      logical_types={
+                          'full_name': FullName,
+                          'email': EmailAddress,
+                          'phone_number': PhoneNumber,
+                          'signup_date': Datetime(datetime_format='%Y-%m-%d'),
+                      }, semantic_tags={
+                          'full_name': ['new_tag', 'tag2'],
+                          'age': 'numeric',
+                          'signup_date': 'date_of_birth',
+                          'email': 'tag2'
+                      })
+    df_repeat_tags = schema_df.ww.select(['new_tag', 'new_tag'])
+    assert len(df_repeat_tags.columns) == 1
+    assert set(df_repeat_tags.columns) == {'full_name'}
+
+    df_repeat_ltypes = schema_df.ww.select(['PhoneNumber', PhoneNumber, 'phone_number'])
+    assert len(df_repeat_ltypes.columns) == 1
+    assert set(df_repeat_ltypes.columns) == {'phone_number'}

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1,13 +1,11 @@
-from woodwork.utils import import_or_none
-from woodwork.tests.testing_utils import to_pandas, validate_subset_schema
-from woodwork.table_accessor import (
-    _check_index,
-    _check_logical_types,
-    _check_time_index,
-    _check_unique_column_names,
-    _get_invalid_schema_message
-)
-from woodwork.schema import Schema
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import woodwork as ww
+from woodwork.exceptions import TypingInfoMismatchWarning
 from woodwork.logical_types import (
     URL,
     Boolean,
@@ -27,17 +25,16 @@ from woodwork.logical_types import (
     SubRegionCode,
     ZIPCode
 )
-import woodwork as ww
-from woodwork.exceptions import TypingInfoMismatchWarning
-import re
-
-import numpy as np
-import pandas as pd
-import pytest
-
-<< << << < HEAD
-== == == =
->>>>>> > Implement select on Table Accessor
+from woodwork.schema import Schema
+from woodwork.table_accessor import (
+    _check_index,
+    _check_logical_types,
+    _check_time_index,
+    _check_unique_column_names,
+    _get_invalid_schema_message
+)
+from woodwork.tests.testing_utils import to_pandas, validate_subset_schema
+from woodwork.utils import import_or_none
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -247,7 +247,7 @@ def test_get_subset_schema_all_params(sample_column_names, sample_inferred_logic
         'column_descriptions': {'age': 'this is a description'}
     }
 
-    # Confirm all possible params to DataTable init are present with non-default values where possible
+    # Confirm all possible params to Schema init are present with non-default values where possible
     assert set(possible_dt_params) == set(kwargs.keys())
 
     schema = Schema(**kwargs)

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -225,15 +225,15 @@ def test_filter_schema_errors(sample_column_names, sample_inferred_logical_types
         schema._filter_cols(Datetime())
 
 
-def test_new_schema_including(sample_column_names, sample_inferred_logical_types):
+def test_get_subset_schema(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types)
-    new_schema = schema._new_schema_including(sample_column_names[1:4])
+    new_schema = schema._get_subset_schema(sample_column_names[1:4])
     for col in new_schema.columns:
         assert new_schema.semantic_tags[col] == schema.semantic_tags[col]
         assert new_schema.logical_types[col] == schema.logical_types[col]
 
 
-def test_new_schema_including_all_params(sample_column_names, sample_inferred_logical_types):
+def test_get_subset_schema_all_params(sample_column_names, sample_inferred_logical_types):
     # The first element is self, so it won't be included in kwargs
     possible_dt_params = inspect.getfullargspec(Schema.__init__)[0][1:]
 
@@ -254,6 +254,6 @@ def test_new_schema_including_all_params(sample_column_names, sample_inferred_lo
     assert set(possible_dt_params) == set(kwargs.keys())
 
     schema = Schema(**kwargs)
-    copy_schema = schema._new_schema_including(sample_column_names)
+    copy_schema = schema._get_subset_schema(sample_column_names)
 
     assert schema == copy_schema

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -180,15 +180,12 @@ def test_filter_schema_cols(sample_column_names, sample_inferred_logical_types):
 
     filtered_log_type_string = schema._filter_cols(include='NaturalLanguage')
     filtered_log_type = schema._filter_cols(include=NaturalLanguage)
+    expected = {'full_name', 'email', 'phone_number'}
     assert filtered_log_type == filtered_log_type_string
+    assert set(filtered_log_type) == expected
 
     filtered_semantic_tag = schema._filter_cols(include='numeric')
     assert filtered_semantic_tag == ['age']
-
-    filtered_multiple = schema._filter_cols(include=['numeric'])
-    expected = ['phone_number', 'age']
-    for col in filtered_multiple:
-        assert col in expected
 
     # --> add back in when describe is implemented
     # filtered_multiple_overlap = schema._filter_cols(include=['NaturalLanguage', 'email'], col_names=True)

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -314,8 +314,8 @@ def test_new_dt_including(sample_df_pandas):
     dt = ww.DataTable(sample_df_pandas)
     new_dt = _new_dt_including(dt, sample_df_pandas.iloc[:, 1:4])
     for col in new_dt.columns:
-        assert new_dt.semantic_tags[col] == new_dt.semantic_tags[col]
-        assert new_dt.logical_types[col] == new_dt.logical_types[col]
+        assert new_dt.semantic_tags[col] == dt.semantic_tags[col]
+        assert new_dt.logical_types[col] == dt.logical_types[col]
 
 
 def test_new_dt_including_all_params(sample_df):

--- a/woodwork/tests/testing_utils/__init__.py
+++ b/woodwork/tests/testing_utils/__init__.py
@@ -3,5 +3,6 @@ from .datatable_utils import (
     check_column_order,
     mi_between_cols,
     to_pandas,
-    validate_subset_dt
+    validate_subset_dt,
+    validate_subset_schema
 )

--- a/woodwork/tests/testing_utils/datatable_utils.py
+++ b/woodwork/tests/testing_utils/datatable_utils.py
@@ -18,6 +18,16 @@ def validate_subset_dt(subset_dt, dt):
         assert to_pandas(subset_col.to_series()).equals(to_pandas(col.to_series()))
 
 
+def validate_subset_schema(subset_schema, schema):
+    assert subset_schema.name == schema.name
+    for subset_col_name, subset_col in subset_schema.columns.items():
+        assert subset_col_name in schema.columns
+        col = schema.columns[subset_col_name]
+        assert subset_col['logical_type'] == col['logical_type']
+        assert subset_col['semantic_tags'] == col['semantic_tags']
+        assert subset_col['dtype'] == col['dtype']
+
+
 def mi_between_cols(col1, col2, df):
     mi_series = df.loc[df['column_1'] == col1].loc[df['column_2'] == col2]['mutual_info']
 


### PR DESCRIPTION
- Allows for selecting columns from your DataFrame based on the Woodwork typing info (logical type, semantic tags)
- Part of #489 

Adds in several helper functions that will be useful for future Woodwork methods
- Schema._filter_cols
- Schema._get_subset_schema
- WoodworkTableAccessor._get_subset_df_with_schema

Adds `use_standard_tags` attribute to the Schema so we can successfully get a subset Schema