### PR TITLE
Add column helpers for checking if columns are of a certain type

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,7 @@ Release Notes
         * Allow initializing Accessor schema with a valid Schema object (:pr:`522`)
         * Add ability to read in a csv and create a DataFrame with an initialized Woodwork Schema (:pr:`534`)
         * Add ability to call pandas methods from Accessor (:pr:`538`)
+        * Add helpers for checking if a column is one of Boolean, Datetime, numeric, or categorical (:pr:`553`)
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
         * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -2,6 +2,8 @@ import woodwork as ww
 from woodwork.type_sys.utils import _get_ltype_class
 from woodwork.utils import _convert_input_to_set
 
+from woodwork.logical_types import Boolean, Datetime, Ordinal
+
 
 def _get_column_dict(name,
                      logical_type,
@@ -53,7 +55,7 @@ def _validate_logical_type(logical_type):
 
     if ltype_class not in ww.type_system.registered_types:
         raise TypeError(f'logical_type {logical_type} is not a registered LogicalType.')
-    if ltype_class == ww.logical_types.Ordinal and not isinstance(logical_type, ww.logical_types.Ordinal):
+    if ltype_class == Ordinal and not isinstance(logical_type, Ordinal):
         raise TypeError("Must use an Ordinal instance with order values defined")
 
 
@@ -75,3 +77,21 @@ def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name):
         semantic_tags = semantic_tags.union(logical_type.standard_tags)
 
     return semantic_tags
+
+
+def _is_numeric(col_dict):
+    return 'numeric' in col_dict['logical_type'].standard_tags
+
+
+def _is_categorical(col_dict):
+    return 'category' in col_dict['logical_type'].standard_tags
+
+
+def _is_datetime(col_dict):
+    # --> what should we do if it's been deregistered??
+    # have a backup??
+    return _get_ltype_class(col_dict['logical_type']) == Datetime
+
+
+def _is_boolean(col_dict):
+    return _get_ltype_class(col_dict['logical_type']) == Boolean

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -1,8 +1,7 @@
 import woodwork as ww
+from woodwork.logical_types import Boolean, Datetime, Ordinal
 from woodwork.type_sys.utils import _get_ltype_class
 from woodwork.utils import _convert_input_to_set
-
-from woodwork.logical_types import Boolean, Datetime, Ordinal
 
 
 def _get_column_dict(name,

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -79,19 +79,17 @@ def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name):
     return semantic_tags
 
 
-def _is_numeric(col_dict):
+def _is_col_numeric(col_dict):
     return 'numeric' in col_dict['logical_type'].standard_tags
 
 
-def _is_categorical(col_dict):
+def _is_col_categorical(col_dict):
     return 'category' in col_dict['logical_type'].standard_tags
 
 
-def _is_datetime(col_dict):
-    # --> what should we do if it's been deregistered??
-    # have a backup??
+def _is_col_datetime(col_dict):
     return _get_ltype_class(col_dict['logical_type']) == Datetime
 
 
-def _is_boolean(col_dict):
+def _is_col_boolean(col_dict):
     return _get_ltype_class(col_dict['logical_type']) == Boolean

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -6,10 +6,10 @@ import woodwork as ww
 from woodwork.logical_types import Boolean, Categorical, Datetime, Double, Integer, NaturalLanguage, Ordinal
 from woodwork.schema_column import (
     _get_column_dict,
-    _is_boolean,
-    _is_categorical,
-    _is_datetime,
-    _is_numeric,
+    _is_col_boolean,
+    _is_col_categorical,
+    _is_col_datetime,
+    _is_col_numeric,
     _validate_description,
     _validate_logical_type,
     _validate_metadata,
@@ -103,71 +103,69 @@ def test_raises_error_setting_time_index_tag_directly():
     #     schema.set_semantic_tags({'signup_date': 'time_index'})
 
 
-def test_is_numeric():
+def test_is_col_numeric():
     int_column = _get_column_dict('ints', Integer)
-    assert _is_numeric(int_column)
+    assert _is_col_numeric(int_column)
 
     double_column = _get_column_dict('floats', Double)
-    assert _is_numeric(double_column)
+    assert _is_col_numeric(double_column)
 
     nl_column = _get_column_dict('text', NaturalLanguage)
-    assert not _is_numeric(nl_column)
+    assert not _is_col_numeric(nl_column)
 
     manually_added = _get_column_dict('text', NaturalLanguage, semantic_tags='numeric')
-    assert not _is_numeric(manually_added)
+    assert not _is_col_numeric(manually_added)
 
     no_standard_tags = _get_column_dict('ints', Integer, use_standard_tags=False)
-    assert _is_numeric(no_standard_tags)
+    assert _is_col_numeric(no_standard_tags)
 
     instantiated_column = _get_column_dict('ints', Integer())
-    assert _is_numeric(instantiated_column)
+    assert _is_col_numeric(instantiated_column)
 
 
-def test_is_categorical():
+def test_is_col_categorical():
     categorical_column = _get_column_dict('cats', Categorical)
-    assert _is_categorical(categorical_column)
+    assert _is_col_categorical(categorical_column)
 
     ordinal_column = _get_column_dict('ordinal', Ordinal(order=['a', 'b']))
-    assert _is_categorical(ordinal_column)
+    assert _is_col_categorical(ordinal_column)
 
     nl_column = _get_column_dict('text', NaturalLanguage)
-    assert not _is_categorical(nl_column)
+    assert not _is_col_categorical(nl_column)
 
     manually_added = _get_column_dict('text', NaturalLanguage, semantic_tags='category')
-    assert not _is_categorical(manually_added)
+    assert not _is_col_categorical(manually_added)
 
     no_standard_tags = _get_column_dict('cats', Categorical, use_standard_tags=False)
-    assert _is_categorical(no_standard_tags)
+    assert _is_col_categorical(no_standard_tags)
 
 
-def test_is_boolean():
+def test_is_col_boolean():
     boolean_column = _get_column_dict('bools', Boolean)
-    assert _is_boolean(boolean_column)
+    assert _is_col_boolean(boolean_column)
 
     instantiated_column = _get_column_dict('bools', Boolean())
-    assert _is_boolean(instantiated_column)
+    assert _is_col_boolean(instantiated_column)
 
     ordinal_column = _get_column_dict('ordinal', Ordinal(order=['a', 'b']))
-    assert not _is_boolean(ordinal_column)
+    assert not _is_col_boolean(ordinal_column)
 
     nl_column = _get_column_dict('text', NaturalLanguage)
-    assert not _is_boolean(nl_column)
-
-    # --> might be worth defining boolean and datetime by dtype???
+    assert not _is_col_boolean(nl_column)
 
 
-def test_is_datetime():
+def test_is_col_datetime():
     datetime_column = _get_column_dict('dates', Datetime)
-    assert _is_datetime(datetime_column)
+    assert _is_col_datetime(datetime_column)
 
     formatted_datetime_column = _get_column_dict('dates', Datetime(datetime_format='%Y-%m%d'))
-    assert _is_datetime(formatted_datetime_column)
+    assert _is_col_datetime(formatted_datetime_column)
 
     instantiated_datetime_column = _get_column_dict('dates', Datetime())
-    assert _is_datetime(instantiated_datetime_column)
+    assert _is_col_datetime(instantiated_datetime_column)
 
     nl_column = _get_column_dict('text', NaturalLanguage)
-    assert not _is_datetime(nl_column)
+    assert not _is_col_datetime(nl_column)
 
     double_column = _get_column_dict('floats', Double)
-    assert not _is_datetime(double_column)
+    assert not _is_col_datetime(double_column)

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -3,12 +3,16 @@ import re
 import pytest
 
 import woodwork as ww
-from woodwork.logical_types import Integer, Ordinal
+from woodwork.logical_types import Boolean, Categorical, Datetime, Double, Integer, NaturalLanguage, Ordinal
 from woodwork.schema_column import (
     _get_column_dict,
+    _is_boolean,
+    _is_categorical,
+    _is_datetime,
+    _is_numeric,
     _validate_description,
     _validate_logical_type,
-    _validate_metadata
+    _validate_metadata,
 )
 
 
@@ -85,7 +89,7 @@ def test_raises_error_setting_index_tag_directly():
     #     schema.set_semantic_tags({'id': 'index'})
 
 
-def test_raises_error_setting_time_index_tag_directly(sample_column_names, sample_inferred_logical_types):
+def test_raises_error_setting_time_index_tag_directly():
     error_msg = re.escape("Cannot add 'time_index' tag directly. To set a column as the time index, "
                           "use Schema.set_time_index() instead.")
     with pytest.raises(ValueError, match=error_msg):
@@ -97,3 +101,73 @@ def test_raises_error_setting_time_index_tag_directly(sample_column_names, sampl
     #     schema.add_semantic_tags({'signup_date': 'time_index'})
     # with pytest.raises(ValueError, match=error_msg):
     #     schema.set_semantic_tags({'signup_date': 'time_index'})
+
+
+def test_is_numeric():
+    int_column = _get_column_dict('ints', Integer)
+    assert _is_numeric(int_column)
+
+    double_column = _get_column_dict('floats', Double)
+    assert _is_numeric(double_column)
+
+    nl_column = _get_column_dict('text', NaturalLanguage)
+    assert not _is_numeric(nl_column)
+
+    manually_added = _get_column_dict('text', NaturalLanguage, semantic_tags='numeric')
+    assert not _is_numeric(manually_added)
+
+    no_standard_tags = _get_column_dict('ints', Integer, use_standard_tags=False)
+    assert _is_numeric(no_standard_tags)
+
+    instantiated_column = _get_column_dict('ints', Integer())
+    assert _is_numeric(instantiated_column)
+
+
+def test_is_categorical():
+    categorical_column = _get_column_dict('cats', Categorical)
+    assert _is_categorical(categorical_column)
+
+    ordinal_column = _get_column_dict('ordinal', Ordinal(order=['a', 'b']))
+    assert _is_categorical(ordinal_column)
+
+    nl_column = _get_column_dict('text', NaturalLanguage)
+    assert not _is_categorical(nl_column)
+
+    manually_added = _get_column_dict('text', NaturalLanguage, semantic_tags='category')
+    assert not _is_categorical(manually_added)
+
+    no_standard_tags = _get_column_dict('cats', Categorical, use_standard_tags=False)
+    assert _is_categorical(no_standard_tags)
+
+
+def test_is_boolean():
+    boolean_column = _get_column_dict('bools', Boolean)
+    assert _is_boolean(boolean_column)
+
+    instantiated_column = _get_column_dict('bools', Boolean())
+    assert _is_boolean(instantiated_column)
+
+    ordinal_column = _get_column_dict('ordinal', Ordinal(order=['a', 'b']))
+    assert not _is_boolean(ordinal_column)
+
+    nl_column = _get_column_dict('text', NaturalLanguage)
+    assert not _is_boolean(nl_column)
+
+    # --> might be worth defining boolean and datetime by dtype???
+
+
+def test_is_datetime():
+    datetime_column = _get_column_dict('dates', Datetime)
+    assert _is_datetime(datetime_column)
+
+    formatted_datetime_column = _get_column_dict('dates', Datetime(datetime_format='%Y-%m%d'))
+    assert _is_datetime(formatted_datetime_column)
+
+    instantiated_datetime_column = _get_column_dict('dates', Datetime())
+    assert _is_datetime(instantiated_datetime_column)
+
+    nl_column = _get_column_dict('text', NaturalLanguage)
+    assert not _is_datetime(nl_column)
+
+    double_column = _get_column_dict('floats', Double)
+    assert not _is_datetime(double_column)

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -3,7 +3,15 @@ import re
 import pytest
 
 import woodwork as ww
-from woodwork.logical_types import Boolean, Categorical, Datetime, Double, Integer, NaturalLanguage, Ordinal
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Datetime,
+    Double,
+    Integer,
+    NaturalLanguage,
+    Ordinal
+)
 from woodwork.schema_column import (
     _get_column_dict,
     _is_col_boolean,
@@ -12,7 +20,7 @@ from woodwork.schema_column import (
     _is_col_numeric,
     _validate_description,
     _validate_logical_type,
-    _validate_metadata,
+    _validate_metadata
 )
 
 


### PR DESCRIPTION
Adds the following helpers to `schema_column.py`:
- `_is_col_boolean`
- `_is_col_categorical`
- `_is_col_datetime`
- `_is_col_numeric`

Closes #402 
Closes #403 

These are being added in preparation for adding `mutual_information` to the Table Accessor