### PR TITLE
Load demo data with accessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
         * Add ability to read in a csv and create a DataFrame with an initialized Woodwork Schema (:pr:`534`)
         * Add ability to call pandas methods from Accessor (:pr:`538`)
         * Add helpers for checking if a column is one of Boolean, Datetime, numeric, or categorical (:pr:`553`)
+        * Add ability to load demo retail dataset with a Woodwork Accessor (:pr:`556`)
     * Fixes
         * Handle missing values in Datetime columns when calculating mutual information (:pr:`516`)
         * Support numpy 1.20.0 by restricting version for koalas and changing serialization error message (:pr:`532`)

--- a/woodwork/demo/api.py
+++ b/woodwork/demo/api.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from .retail import load_retail
+from .retail import load_retail, load_retail_to_accessor

--- a/woodwork/demo/retail.py
+++ b/woodwork/demo/retail.py
@@ -65,3 +65,56 @@ def load_retail(id='demo_retail_data', nrows=None, return_dataframe=False):
                       logical_types=logical_types)
 
     return dt
+
+
+def load_retail_to_accessor(id='demo_retail_data', nrows=None, init_woodwork=True):
+    """Load a demo retail dataset into a DataFrame, optionally initializing Woodwork's typing information.
+
+    Args:
+        id (str, optional): The name to assign to the DataTable, if returning a DataTable.
+            If not returning a DataTable, this will be ignored. Defaults to ``demo_retail_data``.
+        nrows (int, optional): The number of rows to return in the dataset. If None, will
+            return all possible rows. Defaults to None.
+        init_woodwork (bool): If True, will return a pandas DataFrame with Woodwork
+        typing information initialized. If False, will return a DataFrame without
+        Woodwork initialized. Defaults to False.
+
+    Returns:
+         pd.DataFrame or pd.DataFrame + Woodwork: A DataFrame containing the demo data.
+    """
+    csv_s3_gz = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv.gz?version=" + ww.__version__
+    csv_s3 = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv?version=" + ww.__version__
+    # Try to read in gz compressed file
+    try:
+        df = pd.read_csv(csv_s3_gz,
+                         nrows=nrows,
+                         parse_dates=["order_date"])
+    # Fall back to uncompressed
+    except Exception:
+        df = pd.read_csv(csv_s3,
+                         nrows=nrows,
+                         parse_dates=["order_date"])
+    # Add unique column for index
+    df.insert(0, 'order_product_id', range(len(df)))
+
+    if init_woodwork:
+        logical_types = {
+            'order_product_id': Categorical,
+            'order_id': Categorical,
+            'product_id': Categorical,
+            'description': NaturalLanguage,
+            'quantity': Integer,
+            'order_date': Datetime,
+            'unit_price': Double,
+            'customer_name': Categorical,
+            'country': Categorical,
+            'total': Double,
+            'cancelled': Boolean,
+        }
+
+        df.ww.init(name=id,
+                   index='order_product_id',
+                   time_index='order_date',
+                   logical_types=logical_types)
+
+    return df

--- a/woodwork/demo/retail.py
+++ b/woodwork/demo/retail.py
@@ -82,7 +82,7 @@ def load_retail_to_accessor(id='demo_retail_data', nrows=None, init_woodwork=Tru
 
     Returns:
          pd.DataFrame: A DataFrame containing the demo data with Woodwork typing initialized.
-            If `init_woodwork` is False, will return an uninitialized DataFrame. 
+            If `init_woodwork` is False, will return an uninitialized DataFrame.
     """
     csv_s3_gz = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv.gz?version=" + ww.__version__
     csv_s3 = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv?version=" + ww.__version__

--- a/woodwork/demo/retail.py
+++ b/woodwork/demo/retail.py
@@ -71,8 +71,9 @@ def load_retail_to_accessor(id='demo_retail_data', nrows=None, init_woodwork=Tru
     """Load a demo retail dataset into a DataFrame, optionally initializing Woodwork's typing information.
 
     Args:
-        id (str, optional): The name to assign to the DataTable, if returning a DataTable.
-            If not returning a DataTable, this will be ignored. Defaults to ``demo_retail_data``.
+        id (str, optional): The name to assign to the DataFrame, if returning a DataFrame with Woodwork
+            typing information initialized. If not returning a DataFrame with Woodwork initialized,
+            this will be ignored. Defaults to ``demo_retail_data``.
         nrows (int, optional): The number of rows to return in the dataset. If None, will
             return all possible rows. Defaults to None.
         init_woodwork (bool): If True, will return a pandas DataFrame with Woodwork
@@ -80,7 +81,8 @@ def load_retail_to_accessor(id='demo_retail_data', nrows=None, init_woodwork=Tru
         Woodwork initialized. Defaults to False.
 
     Returns:
-         pd.DataFrame or pd.DataFrame + Woodwork: A DataFrame containing the demo data.
+         pd.DataFrame: A DataFrame containing the demo data with Woodwork typing initialized.
+            If `init_woodwork` is False, will return an uninitialized DataFrame. 
     """
     csv_s3_gz = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv.gz?version=" + ww.__version__
     csv_s3 = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv?version=" + ww.__version__

--- a/woodwork/tests/demo_tests/test_retail.py
+++ b/woodwork/tests/demo_tests/test_retail.py
@@ -3,7 +3,7 @@ import urllib.request
 import pytest
 
 from woodwork import DataTable
-from woodwork.demo import load_retail
+from woodwork.demo import load_retail, load_retail_to_accessor
 from woodwork.logical_types import (
     Boolean,
     Categorical,
@@ -12,6 +12,7 @@ from woodwork.logical_types import (
     Integer,
     NaturalLanguage
 )
+from woodwork.schema import Schema
 
 
 @pytest.fixture(autouse=True)
@@ -58,3 +59,44 @@ def test_load_retail_datatable():
     assert dt.time_index == 'order_date'
     assert dt.columns['order_product_id'].semantic_tags == {'index'}
     assert dt.columns['order_date'].semantic_tags == {'time_index'}
+
+
+def test_load_retail_to_accessor_diff():
+    nrows = 10
+    df = load_retail_to_accessor(nrows=nrows, init_woodwork=False)
+    assert df.ww.schema is None
+    assert df.shape[0] == nrows
+    nrows_second = 11
+    df = load_retail_to_accessor(nrows=nrows_second, init_woodwork=False)
+    assert df.ww.schema is None
+    assert df.shape[0] == nrows_second
+
+    assert 'order_product_id' in df.columns
+    assert df['order_product_id'].is_unique
+
+
+def test_load_retail_to_accessor():
+    df = load_retail_to_accessor(nrows=10, init_woodwork=True)
+    assert isinstance(df.ww.schema, Schema)
+
+    expected_logical_types = {
+        'order_product_id': Categorical,
+        'order_id': Categorical,
+        'product_id': Categorical,
+        'description': NaturalLanguage,
+        'quantity': Integer,
+        'order_date': Datetime,
+        'unit_price': Double,
+        'customer_name': Categorical,
+        'country': Categorical,
+        'total': Double,
+        'cancelled': Boolean,
+    }
+
+    for column in df.ww.columns.values():
+        assert column['logical_type'] == expected_logical_types[column['name']]
+
+    assert df.ww.index == 'order_product_id'
+    assert df.ww.time_index == 'order_date'
+    assert df.ww.semantic_tags['order_product_id'] == {'index'}
+    assert df.ww.semantic_tags['order_date'] == {'time_index'}


### PR DESCRIPTION
- Adds `load_retail_to_accessor` to allow loading the demo dataset in a way that returns a DataFrame with the Woodwork accessor initialized
- Closes #546 