### PR TITLE
Sanity check

### DIFF
--- a/release.md
+++ b/release.md
@@ -11,7 +11,7 @@ Before starting the release process, verify the following:
 * Get agreement on the version number to use for the release.
 
 #### Version Numbering
-
+#### ADDING COMMENT SO I CAN SANITY CHECK TESTS NOT PASSING
 Woodwork uses [semantic versioning](https://semver.org/). Every release has a major, minor and patch version number, and are displayed like so: `<majorVersion>.<minorVersion>.<patchVersion>`.
 
 If you'd like to create a development release, which won't be deployed to pypi and conda and marked as a generally-available production release, please add a "dev" prefix to the patch version, i.e. `X.X.devX`. Note this claims the patch number--if the previous release was `0.12.0`, a subsequent dev release would be `0.12.dev1`, and the following release would be `0.12.2`, *not* `0.12.1`. Development releases deploy to [test.pypi.org](https://test.pypi.org/project/woodwork/) instead of to [pypi.org](https://pypi.org/project/woodwork).


### PR DESCRIPTION
Sanity checking build the docs test failing

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*