### PR TITLE
Move mutual info functions to statistics_utils file

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -21,6 +21,7 @@ Release Notes
     * Fixes
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)
+        * Move mutual information logic to statistics utils file (:pr:`584`)
     * Documentation Changes
     * Testing Changes
         * Update branch reference in tests workflow (:pr:`552`)

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -10,6 +10,7 @@ from woodwork.datacolumn import DataColumn
 from woodwork.exceptions import ColumnNameMismatchWarning
 from woodwork.indexers import _iLocIndexer
 from woodwork.logical_types import Boolean, Datetime, Double, LatLong
+from woodwork.statistics_utils import _get_mode
 from woodwork.type_sys.utils import (
     _get_ltype_class,
     _is_numeric_series,
@@ -17,7 +18,6 @@ from woodwork.type_sys.utils import (
 )
 from woodwork.utils import (
     _convert_input_to_set,
-    _get_mode,
     _new_dt_including,
     get_valid_mi_types,
     import_or_none,

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -9,7 +9,7 @@ from woodwork.schema_column import (
     _is_col_numeric
 )
 from woodwork.type_sys.utils import _get_ltype_class
-from woodwork.utils import _get_mode, import_or_none  # --> move over get mode
+from woodwork.utils import import_or_none  # --> move over get mode
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
@@ -99,6 +99,14 @@ def _get_describe_dict(dataframe, include=None):
         values["semantic_tags"] = semantic_tags
         results[column_name] = values
     return results
+
+
+def _get_mode(series):
+    """Get the mode value for a series"""
+    mode_values = series.mode()
+    if len(mode_values) > 0:
+        return mode_values[0]
+    return None
 
 
 def _replace_nans_for_mutual_info(schema, data):

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pandas as pd
 
-from woodwork.logical_types import Datetime, LatLong
+from woodwork.logical_types import Datetime, Double, LatLong
 from woodwork.schema_column import (
     _is_col_boolean,
     _is_col_categorical,
@@ -8,7 +9,7 @@ from woodwork.schema_column import (
     _is_col_numeric
 )
 from woodwork.type_sys.utils import _get_ltype_class
-from woodwork.utils import _get_mode, import_or_none
+from woodwork.utils import _get_mode, import_or_none  # --> move over get mode
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
@@ -98,3 +99,61 @@ def _get_describe_dict(dataframe, include=None):
         values["semantic_tags"] = semantic_tags
         results[column_name] = values
     return results
+
+
+def _replace_nans_for_mutual_info(schema, data):
+    """
+    Replace NaN values in the dataframe so that mutual information can be calculated
+
+    Args:
+        schema (woodwork.Schema): Woodwork typing info for the data
+        data (pd.DataFrame): dataframe to use for calculating mutual information
+
+    Returns:
+        pd.DataFrame: data with nans replaced with either mean or mode
+
+    """
+    # replace or remove null values
+    for column_name in data.columns[data.isnull().any()]:
+        column = schema.columns[column_name]
+        series = data[column_name]
+
+        if _is_col_numeric(column) or _is_col_datetime(column):
+            mean = series.mean()
+            if isinstance(mean, float) and not _get_ltype_class(column['logical_type']) == Double:
+                data[column_name] = series.astype('float')
+            data[column_name] = series.fillna(mean)
+        elif _is_col_categorical(column) or _is_col_boolean(column):
+            mode = _get_mode(series)
+            data[column_name] = series.fillna(mode)
+    return data
+
+
+def _make_categorical_for_mutual_info(schema, data, num_bins):
+    """Transforms dataframe columns into numeric categories so that
+    mutual information can be calculated
+
+    Args:
+        schema (woodwork.Schema): Woodwork typing info for the data
+        data (pd.DataFrame): dataframe to use for caculating mutual information
+        num_bins (int): Determines number of bins to use for converting
+            numeric features into categorical.
+
+    Returns:
+        pd.DataFrame: data with values transformed and binned into numeric categorical values
+    """
+
+    for col_name in data.columns:
+        column = schema.columns[col_name]
+        if _is_col_numeric(column):
+            # bin numeric features to make categories
+            data[col_name] = pd.qcut(data[col_name], num_bins, duplicates="drop")
+        # Convert Datetimes to total seconds - an integer - and bin
+        if _is_col_datetime(column):
+            data[col_name] = pd.qcut(data[col_name].astype('int64'), num_bins, duplicates="drop")
+        # convert categories to integers
+        new_col = data[col_name]
+        if str(new_col.dtype) != 'category':
+            new_col = new_col.astype('category')
+        data[col_name] = new_col.cat.codes
+    return data

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from sklearn.metrics.cluster import normalized_mutual_info_score
 
 from woodwork.logical_types import Datetime, Double, LatLong
 from woodwork.schema_column import (
@@ -9,7 +10,7 @@ from woodwork.schema_column import (
     _is_col_numeric
 )
 from woodwork.type_sys.utils import _get_ltype_class
-from woodwork.utils import import_or_none  # --> move over get mode
+from woodwork.utils import get_valid_mi_types, import_or_none
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
@@ -165,3 +166,69 @@ def _make_categorical_for_mutual_info(schema, data, num_bins):
             new_col = new_col.astype('category')
         data[col_name] = new_col.cat.codes
     return data
+
+
+def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None):
+    """
+    Calculates mutual information between all pairs of columns in the DataFrame that
+    support mutual information. Logical Types that support mutual information are as
+    follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
+    SubRegionCode, and ZIPCode
+
+    Args:
+        dataframe (pd.DataFrame): Data containing Woodwork typing information
+            from which to calculate mutual information.
+        num_bins (int): Determines number of bins to use for converting
+            numeric features into categorical.
+        nrows (int): The number of rows to sample for when determining mutual info.
+        If specified, samples the desired number of rows from the data.
+            Defaults to using all rows.
+
+    Returns:
+        list(dict): A list containing dictionaries that have keys `column_1`,
+        `column_2`, and `mutual_info` that is sorted in decending order by mutual info.
+        Mutual information values are between 0 (no mutual information) and 1
+        (perfect dependency).
+        """
+    valid_types = get_valid_mi_types()
+    valid_columns = [col_name for col_name, col in dataframe.ww.columns.items() if (
+        col_name != dataframe.ww.index and _get_ltype_class(col['logical_type']) in valid_types)]
+
+    data = dataframe[valid_columns]
+    if dd and isinstance(data, dd.DataFrame):
+        data = data.compute()
+    if ks and isinstance(dataframe, ks.DataFrame):
+        data = data.to_pandas()
+
+    # cut off data if necessary
+    if nrows is not None and nrows < data.shape[0]:
+        data = data.sample(nrows)
+
+    # remove fully null columns
+    not_null_cols = data.columns[data.notnull().any()]
+    if set(not_null_cols) != set(valid_columns):
+        data = data.loc[:, not_null_cols]
+    # remove columns that are unique
+    not_unique_cols = [col for col in data.columns if not data[col].is_unique]
+    if set(not_unique_cols) != set(valid_columns):
+        data = data.loc[:, not_unique_cols]
+
+    data = _replace_nans_for_mutual_info(dataframe.ww.schema, data)
+    data = _make_categorical_for_mutual_info(dataframe.ww.schema, data, num_bins)
+
+    # calculate mutual info for all pairs of columns
+    mutual_info = []
+    col_names = data.columns.to_list()
+    for i, a_col in enumerate(col_names):
+        for j in range(i, len(col_names)):
+            b_col = col_names[j]
+            if a_col == b_col:
+                # Ignore because the mutual info for a column with itself will always be 1
+                continue
+            else:
+                mi_score = normalized_mutual_info_score(data[a_col], data[b_col])
+                mutual_info.append(
+                    {"column_1": a_col, "column_2": b_col, "mutual_info": mi_score}
+                )
+    mutual_info.sort(key=lambda mi: mi['mutual_info'], reverse=True)
+    return mutual_info

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -273,7 +273,7 @@ class WoodworkTableAccessor:
             Mutual information values are between 0 (no mutual information) and 1
             (perfect dependency).
         """
-        mutual_info = _get_mutual_information_dict(self._dataframe, num_bins=num_bins, nrows=nrows)
+        mutual_info = self.mutual_information_dict(num_bins, nrows)
         return pd.DataFrame(mutual_info)
 
     def describe_dict(self, include=None):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -8,9 +8,7 @@ from woodwork.logical_types import Datetime
 from woodwork.schema import Schema
 from woodwork.statistics_utils import (
     _get_describe_dict,
-    _get_mutual_information_dict,
-    _make_categorical_for_mutual_info,
-    _replace_nans_for_mutual_info
+    _get_mutual_information_dict
 )
 from woodwork.type_sys.utils import (
     _get_ltype_class,

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -15,10 +15,7 @@ from woodwork.type_sys.utils import (
     _is_numeric_series,
     col_is_datetime
 )
-from woodwork.utils import (
-    _get_column_logical_type,
-    import_or_none
-)
+from woodwork.utils import _get_column_logical_type, import_or_none
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -23,6 +23,7 @@ from woodwork.logical_types import (
 )
 from woodwork.statistics_utils import (
     _get_describe_dict,
+    _get_mode,
     _make_categorical_for_mutual_info,
     _replace_nans_for_mutual_info
 )
@@ -35,6 +36,27 @@ from woodwork.utils import import_or_none
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
+
+
+def test_get_mode():
+    series_list = [
+        pd.Series([1, 2, 3, 4, 2, 2, 3]),
+        pd.Series(['a', 'b', 'b', 'c', 'b']),
+        pd.Series([3, 2, 3, 2]),
+        pd.Series([np.nan, np.nan, np.nan]),
+        pd.Series([pd.NA, pd.NA, pd.NA]),
+        pd.Series([1, 2, np.nan, 2, np.nan, 3, 2]),
+        pd.Series([1, 2, pd.NA, 2, pd.NA, 3, 2])
+    ]
+
+    answer_list = [2, 'b', 2, None, None, 2, 2]
+
+    for series, answer in zip(series_list, answer_list):
+        mode = _get_mode(series)
+        if answer is None:
+            assert mode is None
+        else:
+            assert mode == answer
 
 
 def test_accessor_replace_nans_for_mutual_info():

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -21,7 +21,11 @@ from woodwork.logical_types import (
     Timedelta,
     ZIPCode
 )
-from woodwork.statistics_utils import _get_describe_dict
+from woodwork.statistics_utils import (
+    _get_describe_dict,
+    _make_categorical_for_mutual_info,
+    _replace_nans_for_mutual_info
+)
 from woodwork.tests.testing_utils import (
     mi_between_cols,
     to_pandas,
@@ -44,7 +48,7 @@ def test_accessor_replace_nans_for_mutual_info():
         'dates': pd.Series(['2020-01-01', None, '2020-01-02', '2020-01-03'])
     })
     df_nans.ww.init()
-    formatted_df = df_nans.ww._replace_nans_for_mutual_info(df_nans.copy())
+    formatted_df = _replace_nans_for_mutual_info(df_nans.ww.schema, df_nans.copy())
 
     assert isinstance(formatted_df, pd.DataFrame)
 
@@ -66,7 +70,7 @@ def test_accessor_make_categorical_for_mutual_info():
         'dates': pd.Series(['2020-01-01', '2019-01-02', '2020-08-03', '1997-01-04'])
     })
     df.ww.init()
-    formatted_num_bins_df = df.ww._make_categorical_for_mutual_info(df.copy(), num_bins=4)
+    formatted_num_bins_df = _make_categorical_for_mutual_info(df.ww.schema, df.copy(), num_bins=4)
 
     assert isinstance(formatted_num_bins_df, pd.DataFrame)
 

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -29,7 +29,6 @@ from woodwork.type_sys.utils import (
 from woodwork.utils import (
     _convert_input_to_set,
     _get_column_logical_type,
-    _get_mode,
     _is_null_latlong,
     _is_s3,
     _is_url,
@@ -134,27 +133,6 @@ def test_list_semantic_tags():
         if name not in ['index', 'time_index', 'date_of_birth']:
             for log_type in log_type_list:
                 assert name in log_type.standard_tags
-
-
-def test_get_mode():
-    series_list = [
-        pd.Series([1, 2, 3, 4, 2, 2, 3]),
-        pd.Series(['a', 'b', 'b', 'c', 'b']),
-        pd.Series([3, 2, 3, 2]),
-        pd.Series([np.nan, np.nan, np.nan]),
-        pd.Series([pd.NA, pd.NA, pd.NA]),
-        pd.Series([1, 2, np.nan, 2, np.nan, 3, 2]),
-        pd.Series([1, 2, pd.NA, 2, pd.NA, 3, 2])
-    ]
-
-    answer_list = [2, 'b', 2, None, None, 2, 2]
-
-    for series, answer in zip(series_list, answer_list):
-        mode = _get_mode(series)
-        if answer is None:
-            assert mode is None
-        else:
-            assert mode == answer
 
 
 def test_read_csv_no_params(sample_df_pandas, tmpdir):

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -50,14 +50,6 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags'):
     return semantic_tags
 
 
-def _get_mode(series):
-    """Get the mode value for a series"""
-    mode_values = series.mode()
-    if len(mode_values) > 0:
-        return mode_values[0]
-    return None
-
-
 def read_csv(filepath=None,
              name=None,
              index=None,


### PR DESCRIPTION
- Moves `_replace_nans_for_mutual_info`, `_make_categorical_for_mutual_info`, and `_get_mutual_information_dict` from `table_accessor.py`
- also moves `_get_mode` from `utils.py`
- Closes #577 