### PR TITLE
Allow series calls from the accessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
         * Add WoodworkTableAccessor class that performs type inference and stores Schema (:pr:`514`)
         * Allow initializing Accessor schema with a valid Schema object (:pr:`522`)
         * Add ability to read in a csv and create a DataFrame with an initialized Woodwork Schema (:pr:`534`)
-        * Add ability to call pandas methods from Accessor (:pr:`538`)
+        * Add ability to call pandas methods from Accessor (:pr:`538`, :pr:`589`)
         * Add helpers for checking if a column is one of Boolean, Datetime, numeric, or categorical (:pr:`553`)
         * Add ability to load demo retail dataset with a Woodwork Accessor (:pr:`556`)
         * Add ``select`` to WoodworkTableAccessor (:pr:`548`)
@@ -18,6 +18,7 @@ Release Notes
         * Add semantic tag update methods to column accessor (:pr:`573`)
         * Add ``describe`` and ``describe_dict`` to WoodworkTableAccessor (:pr:`579`)
         * Add ``init_series`` util function for initializing a series with dtype change (:pr:`581`)
+
     * Fixes
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -92,7 +92,7 @@ class WoodworkColumnAccessor:
     def __getattr__(self, attr):
         '''
             If the method is present on the Accessor, uses that method.
-            If the method is present on DataFrame, uses that method.
+            If the method is present on Series, uses that method.
         '''
         if self._schema is None:
             raise AttributeError("Woodwork not initialized for this Series. Initialize by calling Series.ww.init")

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 
 import pandas as pd
@@ -124,8 +125,9 @@ class WoodworkColumnAccessor:
                 # Try to initialize Woodwork with the existing Schema
                 if isinstance(result, pd.Series):
                     if result.dtype == self._schema['logical_type'].pandas_dtype:
+                        schema = copy.deepcopy(self._schema)
                         # We don't need to pass dtype from the schema to init
-                        schema = {key: value for key, value in self._schema.items() if key != 'dtype'}
+                        _ = schema.pop('dtype')
                         result.ww.init(**schema)
                     else:
                         invalid_schema_message = f'Operation performed by {attr} has invalidated the Woodwork ' \

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -127,15 +127,15 @@ class WoodworkColumnAccessor:
                     if result.dtype == self._schema['logical_type'].pandas_dtype:
                         schema = copy.deepcopy(self._schema)
                         # We don't need to pass dtype from the schema to init
-                        _ = schema.pop('dtype')
+                        del schema['dtype']
                         result.ww.init(**schema)
                     else:
-                        invalid_schema_message = f'Operation performed by {attr} has invalidated the Woodwork ' \
-                            'typing information:\n' \
-                            f'dtype mismatch between original dtype, {self._schema["logical_type"].pandas_dtype}, ' \
-                            f'and returned dtype, {result.dtype}.\n' \
-                            'Please initialize Woodwork with Series.ww.init'
-                        warnings.warn(invalid_schema_message, TypingInfoMismatchWarning)
+                        invalid_schema_message = 'dtype mismatch between original dtype, ' \
+                            f'{self._schema["logical_type"].pandas_dtype}, and returned dtype, {result.dtype}'
+                        warning_message = TypingInfoMismatchWarning().get_warning_message(attr,
+                                                                                          invalid_schema_message,
+                                                                                          'Series')
+                        warnings.warn(warning_message, TypingInfoMismatchWarning)
                 # Always return the results of the Series operation whether or not Woodwork is initialized
                 return result
             return wrapper

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -30,10 +30,10 @@ class OutdatedSchemaWarning(UserWarning):
 
 
 class TypingInfoMismatchWarning(UserWarning):
-    def get_warning_message(self, attr, invalid_reason):
+    def get_warning_message(self, attr, invalid_reason, object_type):
         return (f'Operation performed by {attr} has invalidated the Woodwork typing information:\n '
                 f'{invalid_reason}.\n '
-                'Please initialize Woodwork with DataFrame.ww.init')
+                f'Please initialize Woodwork with {object_type}.ww.init')
 
 
 class TypeConversionError(Exception):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -197,7 +197,7 @@ class WoodworkTableAccessor:
                 if isinstance(result, pd.DataFrame):
                     invalid_schema_message = _get_invalid_schema_message(result, self._schema)
                     if invalid_schema_message:
-                        warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message),
+                        warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message, 'DataFrame'),
                                       TypingInfoMismatchWarning)
                     else:
                         result.ww.init(schema=self._schema)
@@ -206,7 +206,7 @@ class WoodworkTableAccessor:
                     # Important for inplace operations
                     invalid_schema_message = _get_invalid_schema_message(self._dataframe, self._schema)
                     if invalid_schema_message:
-                        warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message),
+                        warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message, 'DataFrame'),
                                       TypingInfoMismatchWarning)
                         self._schema = None
 

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -426,8 +426,8 @@ def test_series_methods_on_accessor_returning_series_invalid_schema(sample_serie
     series = sample_series.astype('category')
     series.ww.init()
 
-    warning = "Operation performed by astype has invalidated the Woodwork typing information:\n" \
-        "dtype mismatch between original dtype, category, and returned dtype, string.\n" \
+    warning = "Operation performed by astype has invalidated the Woodwork typing information:\n " \
+        "dtype mismatch between original dtype, category, and returned dtype, string.\n " \
         "Please initialize Woodwork with Series.ww.init"
 
     with pytest.warns(TypingInfoMismatchWarning, match=warning):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from woodwork.exceptions import DuplicateTagsWarning
+from woodwork.exceptions import DuplicateTagsWarning, TypingInfoMismatchWarning
 from woodwork.logical_types import (
     Categorical,
     CountryCode,
@@ -387,26 +387,80 @@ def test_remove_semantic_tags_raises_error_with_invalid_tag(sample_series):
         series.ww.remove_semantic_tags('invalid_tagname')
 
 
-# def test_shape(sample_series):
-#     col = DataColumn(sample_series)
-#     col_shape = col.shape
-#     series_shape = col.to_series().shape
-#     if dd and isinstance(sample_series, dd.Series):
-#         col_shape = (col_shape[0].compute(),)
-#         series_shape = (series_shape[0].compute(),)
-#     assert col_shape == (4,)
-#     assert col_shape == series_shape
+def test_series_methods_on_accessor(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init()
+
+    copied_series = series.ww.copy()
+    assert copied_series is not series
+    assert copied_series.ww._schema == series.ww._schema
+    pd.testing.assert_series_equal(series, copied_series)
 
 
-# def test_len(sample_series):
-#     col = DataColumn(sample_series)
-#     assert len(col) == len(sample_series) == 4
+def test_series_methods_on_accessor_returning_series_valid_schema(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init()
+
+    sorted_series = series.ww.sort_values()
+    assert sorted_series.ww._schema == series.ww._schema
+    assert sorted_series.ww._schema is not series.ww._schema
+    pd.testing.assert_series_equal(sorted_series, series.sort_values())
 
 
-# def test_dtype_update_on_init(sample_datetime_series):
-#     dc = DataColumn(sample_datetime_series,
-#                     logical_type='DateTime')
-#     assert dc._series.dtype == 'datetime64[ns]'
+def test_series_methods_on_accessor_inplace(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init()
+
+    original_schema = series.ww._schema.copy()
+    val = series.ww.pop(0)
+    assert series.ww._schema == original_schema
+    assert len(series) == 3
+    assert val == 'a'
+
+
+def test_series_methods_on_accessor_returning_series_invalid_schema(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init()
+
+    warning = "Operation performed by astype has invalidated the Woodwork typing information:\n" \
+        "dtype mismatch between original dtype, category, and returned dtype, string.\n" \
+        "Please initialize Woodwork with Series.ww.init"
+
+    with pytest.warns(TypingInfoMismatchWarning, match=warning):
+        new_series = series.ww.astype('string')
+
+    assert new_series.ww._schema is None
+
+
+def test_series_methods_on_accessor_other_returns(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init()
+    col_shape = series.ww.shape
+    series_shape = series.shape
+    assert col_shape == (4,)
+    assert col_shape == series_shape
+
+    assert series.name == series.ww.name
+    assert series.nunique() == series.ww.nunique()
+
+
+def test_series_getattr_errors(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+
+    error_message = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
+    with pytest.raises(AttributeError, match=error_message):
+        series.ww.shape
+
+    series.ww.init()
+    error_message = "Woodwork has no attribute 'invalid_attr'"
+    with pytest.raises(AttributeError, match=error_message):
+        series.ww.invalid_attr
 
 
 # def test_dtype_update_on_ltype_change():


### PR DESCRIPTION
- Allow series calls from the accessor
- Closes #547 

Adds a `__getattr__` method to the series accessor to pass down any valid attribute/method calls from the accessor to the series, for anything not implemented on the accessor. For calls the return a new series, reinitializes Woodwork if the series dtype has not changed.