### PR TITLE
Add set_logical_type method to series accessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,6 +18,7 @@ Release Notes
         * Add semantic tag update methods to column accessor (:pr:`573`)
         * Add ``describe`` and ``describe_dict`` to WoodworkTableAccessor (:pr:`579`)
         * Add ``init_series`` util function for initializing a series with dtype change (:pr:`581`)
+        * Add ``set_logical_type`` method to WoodworkColumnAccessor (:pr:`590`)
     * Fixes
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -73,8 +73,8 @@ def _update_column_dtype(series, logical_type):
                 series.name = name
             elif ks and isinstance(series, ks.Series):
                 series = ks.Series(ks.to_datetime(series.to_numpy(),
-                                                    format=logical_type.datetime_format),
-                                    name=series.name)
+                                                  format=logical_type.datetime_format),
+                                   name=series.name)
             else:
                 series = pd.to_datetime(series, format=logical_type.datetime_format)
         else:

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -63,29 +63,29 @@ def _update_column_dtype(series, logical_type):
             series = ks.from_pandas(formatted_series)
         else:
             series = series.apply(_reformat_to_latlong)
-
-    # Update the underlying series
-    try:
-        if _get_ltype_class(logical_type) == Datetime:
-            if dd and isinstance(series, dd.Series):
-                name = series.name
-                series = dd.to_datetime(series, format=logical_type.datetime_format)
-                series.name = name
-            elif ks and isinstance(series, ks.Series):
-                series = ks.Series(ks.to_datetime(series.to_numpy(),
-                                                  format=logical_type.datetime_format),
-                                   name=series.name)
+    if logical_type.pandas_dtype != str(series.dtype):
+        # Update the underlying series
+        try:
+            if _get_ltype_class(logical_type) == Datetime:
+                if dd and isinstance(series, dd.Series):
+                    name = series.name
+                    series = dd.to_datetime(series, format=logical_type.datetime_format)
+                    series.name = name
+                elif ks and isinstance(series, ks.Series):
+                    series = ks.Series(ks.to_datetime(series.to_numpy(),
+                                                      format=logical_type.datetime_format),
+                                       name=series.name)
+                else:
+                    series = pd.to_datetime(series, format=logical_type.datetime_format)
             else:
-                series = pd.to_datetime(series, format=logical_type.datetime_format)
-        else:
-            if ks and isinstance(series, ks.Series) and logical_type.backup_dtype:
-                new_dtype = logical_type.backup_dtype
-            else:
-                new_dtype = logical_type.pandas_dtype
-            series = series.astype(new_dtype)
-    except (TypeError, ValueError):
-        error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
-            f'to type {logical_type.pandas_dtype}. Please confirm the underlying data is consistent with ' \
-            f'logical type {logical_type}.'
-        raise TypeConversionError(error_msg)
+                if ks and isinstance(series, ks.Series) and logical_type.backup_dtype:
+                    new_dtype = logical_type.backup_dtype
+                else:
+                    new_dtype = logical_type.pandas_dtype
+                series = series.astype(new_dtype)
+        except (TypeError, ValueError):
+            error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
+                f'to type {logical_type.pandas_dtype}. Please confirm the underlying data is consistent with ' \
+                f'logical type {logical_type}.'
+            raise TypeConversionError(error_msg)
     return series

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -64,29 +64,28 @@ def _update_column_dtype(series, logical_type):
         else:
             series = series.apply(_reformat_to_latlong)
 
-    if logical_type.pandas_dtype != str(series.dtype):
-        # Update the underlying series
-        try:
-            if _get_ltype_class(logical_type) == Datetime:
-                if dd and isinstance(series, dd.Series):
-                    name = series.name
-                    series = dd.to_datetime(series, format=logical_type.datetime_format)
-                    series.name = name
-                elif ks and isinstance(series, ks.Series):
-                    series = ks.Series(ks.to_datetime(series.to_numpy(),
-                                                      format=logical_type.datetime_format),
-                                       name=series.name)
-                else:
-                    series = pd.to_datetime(series, format=logical_type.datetime_format)
+    # Update the underlying series
+    try:
+        if _get_ltype_class(logical_type) == Datetime:
+            if dd and isinstance(series, dd.Series):
+                name = series.name
+                series = dd.to_datetime(series, format=logical_type.datetime_format)
+                series.name = name
+            elif ks and isinstance(series, ks.Series):
+                series = ks.Series(ks.to_datetime(series.to_numpy(),
+                                                    format=logical_type.datetime_format),
+                                    name=series.name)
             else:
-                if ks and isinstance(series, ks.Series) and logical_type.backup_dtype:
-                    new_dtype = logical_type.backup_dtype
-                else:
-                    new_dtype = logical_type.pandas_dtype
-                series = series.astype(new_dtype)
-        except (TypeError, ValueError):
-            error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
-                f'to type {logical_type.pandas_dtype}. Please confirm the underlying data is consistent with ' \
-                f'logical type {logical_type}.'
-            raise TypeConversionError(error_msg)
+                series = pd.to_datetime(series, format=logical_type.datetime_format)
+        else:
+            if ks and isinstance(series, ks.Series) and logical_type.backup_dtype:
+                new_dtype = logical_type.backup_dtype
+            else:
+                new_dtype = logical_type.pandas_dtype
+            series = series.astype(new_dtype)
+    except (TypeError, ValueError):
+        error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
+            f'to type {logical_type.pandas_dtype}. Please confirm the underlying data is consistent with ' \
+            f'logical type {logical_type}.'
+        raise TypeConversionError(error_msg)
     return series

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -195,7 +195,11 @@ class WoodworkColumnAccessor:
         Returns:
             Series: A new series with the updated logical type.
         """
-        return init_series(self._series,
+        # Create a new series without a schema to prevent new series from sharing a common
+        # schema with current series
+        new_series = self._series.copy()
+        new_series._schema = None
+        return init_series(new_series,
                            logical_type=logical_type,
                            semantic_tags=None,
                            use_standard_tags=self.use_standard_tags,

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -195,8 +195,6 @@ class WoodworkColumnAccessor:
         Returns:
             Series: A new series with the updated logical type.
         """
-        logical_type = _get_column_logical_type(self._series, logical_type, self._series.name)
-
         return init_series(self._series,
                            logical_type=logical_type,
                            semantic_tags=None,

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -134,6 +134,21 @@ class WoodworkColumnAccessor:
         self._schema['semantic_tags'] = _reset_semantic_tags(self.logical_type.standard_tags,
                                                              self.use_standard_tags)
 
+    def set_logical_type(self, logical_type):
+        """Update the logical type for the series. If the dtype of the new logical type
+        is not compatible with the current series dtype, an error will be raised. Changing
+        the logical type of a column will cause any previously set semantic tags to be cleared.
+
+        Args:
+            logical_type (LogicalType, str): The new logical type to set for the series.
+        """
+        logical_type = _get_column_logical_type(self._series, logical_type, self._series.name)
+        if self._series.dtype != logical_type.pandas_dtype:
+            raise TypeError
+
+        self._schema['logical_type'] = logical_type
+        self.reset_semantic_tags()
+
     def set_semantic_tags(self, semantic_tags):
         """Replace current semantic tags with new values. If `use_standard_tags` is set
         to True for the series, any standard tags associated with the LogicalType of the

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -96,10 +96,10 @@ class WoodworkColumnAccessor:
         """Validates that a logical type is consistent with the series dtype. Performs additional type
         specific validation, as required."""
         if logical_type.pandas_dtype != str(self._series.dtype):
-            raise ValueError(f"Cannot initialize Woodwork. Series dtype '{self._series.dtype}' is "
+            raise ValueError(f"Cannot set the specified LogicalType. Series dtype '{self._series.dtype}' is "
                              f"incompatible with {logical_type} dtype. Try converting series "
-                             f"dtype to '{logical_type.pandas_dtype}' before initializing or use the "
-                             "woodwork.init_series function to initialize.")
+                             f"dtype to '{logical_type.pandas_dtype}' or use the "
+                             "woodwork.init_series function to initialize a new series.")
 
         if isinstance(logical_type, Ordinal):
             logical_type._validate_data(self._series)
@@ -143,8 +143,7 @@ class WoodworkColumnAccessor:
             logical_type (LogicalType, str): The new logical type to set for the series.
         """
         logical_type = _get_column_logical_type(self._series, logical_type, self._series.name)
-        if self._series.dtype != logical_type.pandas_dtype:
-            raise TypeError
+        self._validate_logical_type(logical_type)
 
         self._schema['logical_type'] = logical_type
         self.reset_semantic_tags()

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -265,30 +265,30 @@ def test_warns_on_setting_duplicate_tag(sample_series):
     assert record[0].message.args[0] == expected_message
 
 
-# def test_set_logical_type_with_standard_tags(sample_series):
-#     data_col = DataColumn(sample_series,
-#                           logical_type=NaturalLanguage,
-#                           semantic_tags='original_tag',
-#                           use_standard_tags=True)
+def test_set_logical_type_with_standard_tags(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
 
-#     new_col = data_col.set_logical_type(Categorical)
-#     assert isinstance(new_col, DataColumn)
-#     assert new_col is not data_col
-#     assert new_col.logical_type == Categorical
-#     assert new_col.semantic_tags == {'category'}
+    series.ww.init(logical_type='Categorical',
+                   semantic_tags='original_tag',
+                   use_standard_tags=True)
+
+    series.ww.set_logical_type('CountryCode')
+    assert series.ww.logical_type == CountryCode
+    assert series.ww.semantic_tags == {'category'}
 
 
-# def test_set_logical_type_without_standard_tags(sample_series):
-#     data_col = DataColumn(sample_series,
-#                           logical_type=NaturalLanguage,
-#                           semantic_tags='original_tag',
-#                           use_standard_tags=False)
+def test_set_logical_type_without_standard_tags(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
 
-#     new_col = data_col.set_logical_type(Categorical)
-#     assert isinstance(new_col, DataColumn)
-#     assert new_col is not data_col
-#     assert new_col.logical_type == Categorical
-#     assert new_col.semantic_tags == set()
+    series.ww.init(logical_type='Categorical',
+                   semantic_tags='original_tag',
+                   use_standard_tags=False)
+
+    series.ww.set_logical_type('CountryCode')
+    assert series.ww.logical_type == CountryCode
+    assert series.ww.semantic_tags == set()
 
 
 # def test_set_logical_type_retains_index_tag(sample_series):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -291,34 +291,6 @@ def test_set_logical_type_without_standard_tags(sample_series):
     assert series.ww.semantic_tags == set()
 
 
-# def test_set_logical_type_retains_index_tag(sample_series):
-#     data_col = DataColumn(sample_series,
-#                           logical_type=NaturalLanguage,
-#                           semantic_tags='original_tag',
-#                           use_standard_tags=False)
-
-#     data_col._set_as_index()
-#     assert data_col.semantic_tags == {'index', 'original_tag'}
-#     new_col = data_col.set_logical_type(Categorical)
-#     assert new_col.semantic_tags == {'index'}
-#     new_col = data_col.set_logical_type(Categorical, retain_index_tags=False)
-#     assert new_col.semantic_tags == set()
-
-
-# def test_set_logical_type_retains_time_index_tag(sample_datetime_series):
-#     data_col = DataColumn(sample_datetime_series,
-#                           logical_type=Datetime,
-#                           semantic_tags='original_tag',
-#                           use_standard_tags=False)
-
-#     data_col._set_as_time_index()
-#     assert data_col.semantic_tags == {'time_index', 'original_tag'}
-#     new_col = data_col.set_logical_type(Categorical)
-#     assert new_col.semantic_tags == {'time_index'}
-#     new_col = data_col.set_logical_type(Categorical, retain_index_tags=False)
-#     assert new_col.semantic_tags == set()
-
-
 def test_reset_semantic_tags_with_standard_tags(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series.astype('category')
@@ -401,20 +373,6 @@ def test_remove_semantic_tags_raises_error_with_invalid_tag(sample_series):
 # def test_len(sample_series):
 #     col = DataColumn(sample_series)
 #     assert len(col) == len(sample_series) == 4
-
-
-# def test_dtype_update_on_init(sample_datetime_series):
-#     dc = DataColumn(sample_datetime_series,
-#                     logical_type='DateTime')
-#     assert dc._series.dtype == 'datetime64[ns]'
-
-
-# def test_dtype_update_on_ltype_change():
-#     dc = DataColumn(pd.Series([1, 2, 3]),
-#                     logical_type='Integer')
-#     assert dc._series.dtype == 'Int64'
-#     dc = dc.set_logical_type('Double')
-#     assert dc._series.dtype == 'float64'
 
 
 def test_ordinal_requires_instance_on_init(sample_series):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -54,9 +54,9 @@ def test_accessor_init_with_logical_type(sample_series):
 def test_accessor_init_with_invalid_logical_type(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series
-    error_message = "Cannot initialize Woodwork. Series dtype 'object' is incompatible with " \
-        "NaturalLanguage dtype. Try converting series dtype to 'string' before initializing " \
-        "or use the woodwork.init_series function to initialize."
+    error_message = "Cannot set the specified LogicalType. Series dtype 'object' is incompatible with " \
+        "NaturalLanguage dtype. Try converting series dtype to 'string' " \
+        "or use the woodwork.init_series function to initialize a new series."
     with pytest.raises(ValueError, match=error_message):
         series.ww.init(logical_type=NaturalLanguage)
 
@@ -291,6 +291,17 @@ def test_set_logical_type_without_standard_tags(sample_series):
     assert series.ww.semantic_tags == set()
 
 
+def test_accessor_set_logical_type_warning(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init(logical_type='Categorical')
+    error_message = "Cannot set the specified LogicalType. Series dtype 'category' is incompatible " \
+        "with NaturalLanguage dtype. Try converting series dtype to 'string' or use the " \
+        "woodwork.init_series function to initialize a new series."
+    with pytest.raises(ValueError, match=error_message):
+        series.ww.set_logical_type(logical_type=NaturalLanguage)
+
+
 def test_reset_semantic_tags_with_standard_tags(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series.astype('category')
@@ -384,29 +395,33 @@ def test_ordinal_requires_instance_on_init(sample_series):
         sample_series.ww.init(logical_type="Ordinal")
 
 
-# def test_ordinal_requires_instance_on_update(sample_series):
-#     dc = DataColumn(sample_series, logical_type="NaturalLanguage")
+def test_ordinal_requires_instance_on_update(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init(logical_type="Categorical")
 
-#     error_msg = 'Must use an Ordinal instance with order values defined'
-#     with pytest.raises(TypeError, match=error_msg):
-#         dc.set_logical_type(Ordinal)
-#     with pytest.raises(TypeError, match=error_msg):
-#         dc.set_logical_type("Ordinal")
+    error_msg = 'Must use an Ordinal instance with order values defined'
+    with pytest.raises(TypeError, match=error_msg):
+        series.ww.set_logical_type(Ordinal)
+    with pytest.raises(TypeError, match=error_msg):
+        series.ww.set_logical_type("Ordinal")
 
 
-# def test_ordinal_with_order(sample_series):
-#     if (ks and isinstance(sample_series, ks.Series)) or (dd and isinstance(sample_series, dd.Series)):
-#         pytest.xfail('Fails with Dask and Koalas - ordinal data validation not compatible')
+def test_ordinal_with_order(sample_series):
+    if (ks and isinstance(sample_series, ks.Series)) or (dd and isinstance(sample_series, dd.Series)):
+        pytest.xfail('Fails with Dask and Koalas - ordinal data validation not compatible')
 
-#     ordinal_with_order = Ordinal(order=['a', 'b', 'c'])
-#     dc = DataColumn(sample_series, logical_type=ordinal_with_order)
-#     assert isinstance(dc.logical_type, Ordinal)
-#     assert dc.logical_type.order == ['a', 'b', 'c']
+    series = sample_series.astype('category')
+    ordinal_with_order = Ordinal(order=['a', 'b', 'c'])
+    series.ww.init(logical_type=ordinal_with_order)
+    assert isinstance(series.ww.logical_type, Ordinal)
+    assert series.ww.logical_type.order == ['a', 'b', 'c']
 
-#     dc = DataColumn(sample_series, logical_type="NaturalLanguage")
-#     new_dc = dc.set_logical_type(ordinal_with_order)
-#     assert isinstance(new_dc.logical_type, Ordinal)
-#     assert new_dc.logical_type.order == ['a', 'b', 'c']
+    series = sample_series.astype('category')
+    series.ww.init(logical_type='Categorical')
+    series.ww.set_logical_type(ordinal_with_order)
+    assert isinstance(series.ww.logical_type, Ordinal)
+    assert series.ww.logical_type.order == ['a', 'b', 'c']
 
 
 def test_ordinal_with_incomplete_ranking(sample_series):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -54,8 +54,8 @@ def test_accessor_init_with_logical_type(sample_series):
 def test_accessor_init_with_invalid_logical_type(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series
-    error_message = "Cannot initialize Woodwork. Series dtype 'object' is incompatible " \
-        "with NaturalLanguage dtype. Try converting series dtype to 'string' before initializing " \
+    error_message = "Cannot initialize Woodwork. Series dtype 'object' is incompatible with " \
+        "NaturalLanguage dtype. Try converting series dtype to 'string' before initializing " \
         "or use the woodwork.init_series function to initialize."
     with pytest.raises(ValueError, match=error_message):
         series.ww.init(logical_type=NaturalLanguage)


### PR DESCRIPTION
- Add set_logical_type method to series accessor
- Closes #567 

This PR adds a set_logical_type method to the series accessor. A few things to note, as this behaves somewhat differently than the previous DataColumn method:

- Tests related to retaining index and time_index tags have been removed. Since the table accessor does not rely on series having index or time_index tags any longer, these tags are now treated just like any other tags on the column accessor
- Test related to updating the dtype on init or on a logical type change have been removed. Since it is not possible to change a series dtype in place, these tests no longer apply and users will need to use the `ww.init_series()` helper function to initialize a series with a dtype change.
- Attempting to set a logical type that is incompatible with the dtype of the underlying series will not result in an error.