### PR TITLE
Allow updates to semantic tags on a DataFrame's Schema

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Release Notes
         * Add semantic tag update methods to column accessor (:pr:`573`)
         * Add ``describe`` and ``describe_dict`` to WoodworkTableAccessor (:pr:`579`)
         * Add ``init_series`` util function for initializing a series with dtype change (:pr:`581`)
-
+        * Add semantic tag update methods to table schema (:pr:`591`)
     * Fixes
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -22,7 +22,7 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
     type_string = ClassNameDescriptor()
     pandas_dtype = 'string'
     backup_dtype = None
-    standard_tags = {}
+    standard_tags = set()
 
     def __eq__(self, other, deep=False):
         return isinstance(other, self.__class__) and _get_specified_ltype_params(other) == _get_specified_ltype_params(self)

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -176,6 +176,11 @@ class Schema(object):
             _validate_not_setting_index_tags(new_semantic_tags, col_name)
             self.columns[col_name]['semantic_tags'] = new_semantic_tags
 
+            if retain_index_tags and self.index == col_name:
+                self._set_index_tags(col_name)
+            if retain_index_tags and self.time_index == col_name:
+                self._set_time_index_tags(col_name)
+
     # --> for each col do _set_semantic_tags passing semantic tags, standard tags, and use standard tags
 
     def add_semantic_tags(self, semantic_tags):
@@ -191,9 +196,12 @@ class Schema(object):
         """
         _check_semantic_tags(self.columns.keys(), semantic_tags)
         # --> should also be checking for index tags in this and all places!!!
-        for col_name, new_tags in semantic_tags.items():
-            new_semantic_tags = _add_semantic_tags(new_tags, self.semantic_tags[col_name], col_name)
-            _validate_not_setting_index_tags(new_semantic_tags, col_name)
+        for col_name, tags_to_add in semantic_tags.items():
+            tags_to_add = _convert_input_to_set(tags_to_add)
+            _validate_not_setting_index_tags(tags_to_add, col_name)
+            # --> going to cause a problem if the index is set
+            new_semantic_tags = _add_semantic_tags(tags_to_add, self.semantic_tags[col_name], col_name)
+            # --> if its' the index column retain tags
             self.columns[col_name]['semantic_tags'] = new_semantic_tags
 
             # --> each col takes in new tags and current tags and name
@@ -248,8 +256,14 @@ class Schema(object):
 
         for col_name in columns:
             new_semantic_tags = _reset_semantic_tags(self.logical_types[col_name].standard_tags, self.use_standard_tags)
+            # retain index tags possibly - add back in if the col is an index
             # --> why is the set here necessary????
             self.columns[col_name]['semantic_tags'] = set(new_semantic_tags)
+
+            if retain_index_tags and self.index == col_name:
+                self._set_index_tags(col_name)
+            if retain_index_tags and self.time_index == col_name:
+                self._set_time_index_tags(col_name)
 
 # --> det how to handle retain index tags param
     # --> pass standard tags and use standard tags

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -229,7 +229,7 @@ class Schema(object):
             self.columns[col_name]['semantic_tags'] = new_semantic_tags
     # --> each col takes in tags to remove current tags name standard tags and use standard tags
 
-    def reset_semantic_tags(self, columns=None, retain_index_tags=True):
+    def reset_semantic_tags(self, columns=None, retain_index_tags=False):
         """Reset the semantic tags for the specified columns to the default values and
         return a new DataTable. The default values will be either an empty set or a set
         of the standard tags based on the column logical type, controlled by the

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -166,9 +166,15 @@ class Schema(object):
             woodwork.DataTable: DataTable with updated logical types and specified semantic tags set.
         """
         # --> in the future will just allow setting logical type but will need to be called by table_accessor
+        semantic_tags = semantic_tags or {}
         _check_semantic_tags(self.columns.keys(), semantic_tags)
 
-        pass
+        for col_name, new_tags in semantic_tags.items():
+            new_semantic_tags = _set_semantic_tags(semantic_tags[col_name],
+                                                   self.logical_types[col_name].standard_tags,
+                                                   self.use_standard_tags)
+            self.columns[col_name]['semantic_tags'] = new_semantic_tags
+
     # --> for each col do _set_semantic_tags passing semantic tags, standard tags, and use standard tags
 
     def add_semantic_tags(self, semantic_tags):

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -3,7 +3,13 @@ import collections
 import pandas as pd
 
 import woodwork as ww
-from woodwork.schema_column import _get_column_dict, _set_semantic_tags, _add_semantic_tags, _reset_semantic_tags, _remove_semantic_tags
+from woodwork.schema_column import (
+    _add_semantic_tags,
+    _get_column_dict,
+    _remove_semantic_tags,
+    _reset_semantic_tags,
+    _set_semantic_tags
+)
 from woodwork.type_sys.utils import _get_ltype_class
 from woodwork.utils import _convert_input_to_set
 
@@ -231,7 +237,7 @@ class Schema(object):
                                                       self.use_standard_tags)
             # If the index is removed, reinsert any standard tags not explicetly removed
             original_tags = self.semantic_tags[col_name]
-            if 'index' in original_tags and 'index' not in new_semantic_tags:
+            if self.use_standard_tags and 'index' in original_tags and 'index' not in new_semantic_tags:
                 standard_tags_removed = tags_to_remove.intersection(standard_tags)
                 standard_tags_to_reinsert = standard_tags.difference(standard_tags_removed)
                 new_semantic_tags = new_semantic_tags.union(standard_tags_to_reinsert)
@@ -286,7 +292,8 @@ class Schema(object):
         """
         columns = {}
         for name in column_names:
-            semantic_tags_for_col = _convert_input_to_set((semantic_tags or {}).get(name))
+            semantic_tags_for_col = _convert_input_to_set((semantic_tags or {}).get(name),
+                                                          error_language=f'semantic_tags for {name}')
             _validate_not_setting_index_tags(semantic_tags_for_col, name)
             description = (column_descriptions or {}).get(name)
             metadata_for_col = (column_metadata or {}).get(name)

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -154,12 +154,10 @@ class Schema(object):
         return None
 
     def set_types(self, semantic_tags=None, retain_index_tags=True):
-        """Update the logical type and semantic tags for any columns names in the provided types
-        dictionary, updating the Woodwork typing information for the DataFrame.
+        """Update the semantic tags for any columns names in the provided types dictionary,
+        updating the Woodwork typing information for the DataFrame.
 
         Args:
-            logical_types (dict[str -> str], optional): A dictionary defining the new logical types for the
-                specified columns.
             semantic_tags (dict[str -> str/list/set], optional): A dictionary defining the new semantic_tags for the
                 specified columns.
             retain_index_tags (bool, optional): If True, will retain any index or time_index
@@ -184,7 +182,7 @@ class Schema(object):
                 self._set_time_index_tags(col_name)
 
     def add_semantic_tags(self, semantic_tags):
-        """Adds specified semantic tags to columns, updating the Woodwork typing infromation.
+        """Adds specified semantic tags to columns, updating the Woodwork typing information.
         Will retain any previously set values.
 
         Args:
@@ -205,7 +203,7 @@ class Schema(object):
 
         Args:
             semantic_tags (dict[str -> str/list/set]): A dictionary mapping the columns
-                in the DataFrame to the tags that should be removed to the column's semantic tags
+                in the DataFrame to the tags that should be removed from the column's semantic tags
         """
         _check_semantic_tags(self.columns.keys(), semantic_tags)
         for col_name, tags_to_remove in semantic_tags.items():
@@ -217,7 +215,7 @@ class Schema(object):
                                                       col_name,
                                                       standard_tags,
                                                       self.use_standard_tags)
-            # If the index is removed, reinsert any standard tags not explicetly removed
+            # If the index is removed, reinsert any standard tags not explicitly removed
             original_tags = self.semantic_tags[col_name]
             if self.use_standard_tags and 'index' in original_tags and 'index' not in new_semantic_tags:
                 standard_tags_removed = tags_to_remove.intersection(standard_tags)
@@ -229,7 +227,7 @@ class Schema(object):
         """Reset the semantic tags for the specified columns to the default values.
         The default values will be either an empty set or a set of the standard tags
         based on the column logical type, controlled by the use_standard_tags property on the table.
-        Columns names can be provided as a single string, a list of strings or a set of strings.
+        Column names can be provided as a single string, a list of strings or a set of strings.
         If columns is not specified, tags will be reset for all columns.
 
         Args:

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -44,16 +44,6 @@ def _get_column_dict(name,
     }
 
 
-def _validate_tags(semantic_tags):
-    """Verify user has not supplied tags that cannot be set directly"""
-    if 'index' in semantic_tags:
-        raise ValueError("Cannot add 'index' tag directly. To set a column as the index, "
-                         "use Schema.set_index() instead.")
-    if 'time_index' in semantic_tags:
-        raise ValueError("Cannot add 'time_index' tag directly. To set a column as the time index, "
-                         "use Schema.set_time_index() instead.")
-
-
 def _validate_logical_type(logical_type):
     ltype_class = _get_ltype_class(logical_type)
 
@@ -75,8 +65,6 @@ def _validate_metadata(column_metadata):
 
 def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name):
     semantic_tags = _convert_input_to_set(semantic_tags, error_language=f'semantic_tags for {name}')
-
-    _validate_tags(semantic_tags)
 
     if use_standard_tags:
         semantic_tags = semantic_tags.union(logical_type.standard_tags)

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -343,9 +343,7 @@ def test_set_semantic_tags_with_index(sample_column_names, sample_inferred_logic
     assert schema.semantic_tags['id'] == {'index', 'new_tag'}
 
     schema.set_types(semantic_tags=new_tags, retain_index_tags=False)
-    # --> should this add the numeric tag????????
     assert schema.semantic_tags['id'] == {'new_tag'}
-# --> do this in a situation where standard tags change? Is that even possible??
 
 
 def test_set_semantic_tags_with_time_index(sample_column_names, sample_inferred_logical_types):
@@ -384,9 +382,6 @@ def test_add_semantic_tags(sample_column_names, sample_inferred_logical_types):
     assert schema.semantic_tags['id'] == {'set_tag', 'index'}
 
 
-# --> add check where were setting on an index or time index column
-
-
 def test_reset_all_semantic_tags(sample_column_names, sample_inferred_logical_types):
     semantic_tags = {
         'full_name': 'tag1',
@@ -412,7 +407,6 @@ def test_reset_semantic_tags_with_index(sample_column_names, sample_inferred_log
     schema.reset_semantic_tags('id', retain_index_tags=True)
     assert schema.semantic_tags['id'] == {'index'}
 
-    # --> this should probably have numeric as a tag????
     schema.reset_semantic_tags('id')
     assert schema.semantic_tags['id'] == set()
 
@@ -458,8 +452,6 @@ def test_remove_semantic_tags(sample_column_names, sample_inferred_logical_types
     assert schema.semantic_tags['age'] == {'age'}
     assert schema.semantic_tags['id'] == {'tag2'}
 
-# --> test removing semantic tags that's an index????
-
 
 def test_raises_error_setting_index_tag_directly(sample_column_names, sample_inferred_logical_types):
     error_msg = re.escape("Cannot add 'index' tag directly for column id. To set a column as the index, "
@@ -485,32 +477,59 @@ def test_raises_error_setting_time_index_tag_directly(sample_column_names, sampl
 
 
 def test_removes_index_via_tags(sample_column_names, sample_inferred_logical_types):
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    # Check setting tags
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id', use_standard_tags=True)
     schema.set_types(semantic_tags={'id': 'new_tag'}, retain_index_tags=False)
     assert schema.semantic_tags['id'] == {'numeric', 'new_tag'}
     assert schema.index is None
 
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='full_name')
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id', use_standard_tags=False)
+    schema.set_types(semantic_tags={'id': 'new_tag'}, retain_index_tags=False)
+    assert schema.semantic_tags['id'] == {'new_tag'}
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='full_name', use_standard_tags=True)
     schema.set_types(semantic_tags={'full_name': 'new_tag'}, retain_index_tags=False)
     assert schema.semantic_tags['full_name'] == {'new_tag'}
     assert schema.index is None
 
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    # Check removing tags
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id', use_standard_tags=True)
     schema.remove_semantic_tags(semantic_tags={'id': 'index'})
     assert schema.semantic_tags['id'] == {'numeric'}
     assert schema.index is None
 
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='full_name')
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id', use_standard_tags=False)
+    schema.remove_semantic_tags(semantic_tags={'id': 'index'})
+    assert schema.semantic_tags['id'] == set()
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='full_name', use_standard_tags=True)
     schema.remove_semantic_tags(semantic_tags={'full_name': 'index'})
     assert schema.semantic_tags['full_name'] == set()
     assert schema.index is None
 
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    # Check resetting tags
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id', use_standard_tags=True,)
     schema.reset_semantic_tags('id')
     assert schema.semantic_tags['id'] == {'numeric'}
     assert schema.index is None
 
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='full_name')
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id', use_standard_tags=False)
+    schema.reset_semantic_tags('id')
+    assert schema.semantic_tags['id'] == set()
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='full_name', use_standard_tags=True)
     schema.reset_semantic_tags('full_name')
     assert schema.semantic_tags['full_name'] == set()
     assert schema.index is None

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -344,6 +344,7 @@ def test_set_semantic_tags_with_index(sample_column_names, sample_inferred_logic
     # --> deal with retain index tags - is it only relevant at table and not columns?
     # schema.set_types(semantic_tags=new_tags, retain_index_tags=False)
     # assert schema.semantic_tags['id'] == {'new_tag'}
+# --> do this in a situation where standard tags change? Is that even possible??
 
 
 def test_set_semantic_tags_with_time_index(sample_column_names, sample_inferred_logical_types):
@@ -379,6 +380,7 @@ def test_add_semantic_tags(sample_column_names, sample_inferred_logical_types):
     assert schema.semantic_tags['full_name'] == {'tag1', 'list_tag'}
     assert schema.semantic_tags['age'] == {'numeric', 'age', 'str_tag'}
     assert schema.semantic_tags['id'] == {'set_tag'}
+# --> add check where were setting on an index or time index column
 
 
 def test_reset_all_semantic_tags(sample_column_names, sample_inferred_logical_types):
@@ -449,6 +451,8 @@ def test_remove_semantic_tags(sample_column_names, sample_inferred_logical_types
     assert schema.semantic_tags['age'] == {'age'}
     assert schema.semantic_tags['id'] == {'tag2'}
 
+# --> test removing semantic tags that's an index????
+
 
 def test_raises_error_setting_index_tag_directly(sample_column_names, sample_inferred_logical_types):
     error_msg = re.escape("Cannot add 'index' tag directly for column id. To set a column as the index, "
@@ -471,3 +475,8 @@ def test_raises_error_setting_time_index_tag_directly(sample_column_names, sampl
         schema.add_semantic_tags({'signup_date': 'time_index'})
     with pytest.raises(ValueError, match=error_msg):
         schema.set_types(semantic_tags={'signup_date': 'time_index'})
+
+
+# --> test directly setting index tags and directly removing index tags
+def test_removes_indices_via_tags(sample_column_names, sample_inferred_logical_types):
+    pass

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -305,3 +305,141 @@ def test_get_subset_schema_all_params(sample_column_names, sample_inferred_logic
     copy_schema = schema._get_subset_schema(sample_column_names)
 
     assert schema == copy_schema
+
+
+def test_set_semantic_tags(sample_column_names, sample_inferred_logical_types):
+    semantic_tags = {
+        'full_name': 'tag1',
+        'age': ['numeric', 'age']
+    }
+    expected_tags = {
+        'full_name': {'tag1'},
+        'age': {'numeric', 'age'}
+    }
+    schema = Schema(sample_column_names, sample_inferred_logical_types, semantic_tags=semantic_tags)
+    assert schema.semantic_tags['full_name'] == expected_tags['full_name']
+    assert schema.semantic_tags['age'] == expected_tags['age']
+
+    new_tags = {
+        'full_name': ['new_tag'],
+        'age': 'numeric',
+    }
+    schema.set_types(semantic_tags=new_tags)
+
+    assert schema.semantic_tags['full_name'] == {'new_tag'}
+    assert schema.semantic_tags['age'] == {'numeric'}
+
+
+# def test_set_semantic_tags_with_index(sample_df):
+#     dt = DataTable(sample_df, index='id', use_standard_tags=False)
+#     assert dt.columns['id'].semantic_tags == {'index'}
+
+#     new_tags = {
+#         'id': 'new_tag',
+#     }
+#     dt = dt.set_types(semantic_tags=new_tags)
+#     assert dt.columns['id'].semantic_tags == {'index', 'new_tag'}
+#     dt = dt.set_types(semantic_tags=new_tags, retain_index_tags=False)
+#     assert dt.columns['id'].semantic_tags == {'new_tag'}
+
+
+# def test_set_semantic_tags_with_time_index(sample_df):
+#     dt = DataTable(sample_df, time_index='signup_date', use_standard_tags=False)
+#     assert dt.columns['signup_date'].semantic_tags == {'time_index'}
+
+#     new_tags = {
+#         'signup_date': 'new_tag',
+#     }
+#     dt = dt.set_types(semantic_tags=new_tags)
+#     assert dt.columns['signup_date'].semantic_tags == {'time_index', 'new_tag'}
+#     dt = dt.set_types(semantic_tags=new_tags, retain_index_tags=False)
+#     assert dt.columns['signup_date'].semantic_tags == {'new_tag'}
+
+
+def test_add_semantic_tags(sample_column_names, sample_inferred_logical_types):
+    semantic_tags = {
+        'full_name': 'tag1',
+        'age': ['numeric', 'age']
+    }
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    semantic_tags=semantic_tags, use_standard_tags=False)
+
+    new_tags = {
+        'full_name': ['list_tag'],
+        'age': 'str_tag',
+        'id': {'set_tag'}
+    }
+    schema.add_semantic_tags(new_tags)
+
+    assert schema.semantic_tags['full_name'] == {'tag1', 'list_tag'}
+    assert schema.semantic_tags['age'] == {'numeric', 'age', 'str_tag'}
+    assert schema.semantic_tags['id'] == {'set_tag'}
+
+
+def test_reset_all_semantic_tags(sample_column_names, sample_inferred_logical_types):
+    semantic_tags = {
+        'full_name': 'tag1',
+        'age': 'age'
+    }
+    schema = Schema(sample_column_names, sample_inferred_logical_types, semantic_tags=semantic_tags, use_standard_tags=True)
+
+    schema.reset_semantic_tags()
+    assert schema.semantic_tags['full_name'] == set()
+    assert schema.semantic_tags['age'] == {'numeric'}
+
+
+# def test_reset_semantic_tags_with_index(sample_df):
+#     semantic_tags = {
+#         'id': 'tag1',
+#     }
+#     dt = DataTable(sample_df,
+#                    index='id',
+#                    semantic_tags=semantic_tags,
+#                    use_standard_tags=False)
+#     assert dt['id'].semantic_tags == {'index', 'tag1'}
+#     dt = dt.reset_semantic_tags('id', retain_index_tags=True)
+#     assert dt['id'].semantic_tags == {'index'}
+#     dt = dt.reset_semantic_tags('id')
+#     assert dt['id'].semantic_tags == set()
+
+
+# def test_reset_semantic_tags_with_time_index(sample_df):
+#     semantic_tags = {
+#         'signup_date': 'tag1',
+#     }
+#     dt = DataTable(sample_df,
+#                    time_index='signup_date',
+#                    semantic_tags=semantic_tags,
+#                    use_standard_tags=False)
+#     assert dt['signup_date'].semantic_tags == {'time_index', 'tag1'}
+#     dt = dt.reset_semantic_tags('signup_date', retain_index_tags=True)
+#     assert dt['signup_date'].semantic_tags == {'time_index'}
+#     dt = dt.reset_semantic_tags('signup_date')
+#     assert dt['signup_date'].semantic_tags == set()
+
+
+def test_reset_semantic_tags_invalid_column(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types,)
+    error_msg = "Input contains columns that are not present in dataframe: 'invalid_column'"
+    with pytest.raises(LookupError, match=error_msg):
+        schema.reset_semantic_tags('invalid_column')
+
+
+def test_remove_semantic_tags(sample_column_names, sample_inferred_logical_types):
+    semantic_tags = {
+        'full_name': ['tag1', 'tag2', 'tag3'],
+        'age': ['numeric', 'age'],
+        'id': ['tag1', 'tag2']
+    }
+    schema = Schema(sample_column_names, sample_inferred_logical_types, semantic_tags=semantic_tags, use_standard_tags=False)
+    tags_to_remove = {
+        'full_name': ['tag1', 'tag3'],
+        'age': 'numeric',
+        'id': {'tag1'}
+    }
+    schema.remove_semantic_tags(tags_to_remove)
+    assert schema.semantic_tags['full_name'] == {'tag2'}
+    assert schema.semantic_tags['age'] == {'age'}
+    assert schema.semantic_tags['id'] == {'tag2'}
+
+# --> add test where we set index and time index tags directly

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -341,9 +341,9 @@ def test_set_semantic_tags_with_index(sample_column_names, sample_inferred_logic
     }
     schema.set_types(semantic_tags=new_tags)
     assert schema.semantic_tags['id'] == {'index', 'new_tag'}
-    # --> deal with retain index tags - is it only relevant at table and not columns?
-    # schema.set_types(semantic_tags=new_tags, retain_index_tags=False)
-    # assert schema.semantic_tags['id'] == {'new_tag'}
+
+    schema.set_types(semantic_tags=new_tags, retain_index_tags=False)
+    assert schema.semantic_tags['id'] == {'new_tag'}
 # --> do this in a situation where standard tags change? Is that even possible??
 
 
@@ -357,9 +357,9 @@ def test_set_semantic_tags_with_time_index(sample_column_names, sample_inferred_
     }
     schema.set_types(semantic_tags=new_tags)
     assert schema.semantic_tags['signup_date'] == {'time_index', 'new_tag'}
-    # --> deal with retain index tags - is it only relevant at table and not columns?
-    # schema.set_types(semantic_tags=new_tags, retain_index_tags=False)
-    # assert schema.semantic_tags['signup_date'] == {'new_tag'}
+
+    schema.set_types(semantic_tags=new_tags, retain_index_tags=False)
+    assert schema.semantic_tags['signup_date'] == {'new_tag'}
 
 
 def test_add_semantic_tags(sample_column_names, sample_inferred_logical_types):
@@ -368,7 +368,8 @@ def test_add_semantic_tags(sample_column_names, sample_inferred_logical_types):
         'age': ['numeric', 'age']
     }
     schema = Schema(sample_column_names, sample_inferred_logical_types,
-                    semantic_tags=semantic_tags, use_standard_tags=False)
+                    semantic_tags=semantic_tags, use_standard_tags=False,
+                    index='id')
 
     new_tags = {
         'full_name': ['list_tag'],
@@ -379,7 +380,9 @@ def test_add_semantic_tags(sample_column_names, sample_inferred_logical_types):
 
     assert schema.semantic_tags['full_name'] == {'tag1', 'list_tag'}
     assert schema.semantic_tags['age'] == {'numeric', 'age', 'str_tag'}
-    assert schema.semantic_tags['id'] == {'set_tag'}
+    assert schema.semantic_tags['id'] == {'set_tag', 'index'}
+
+
 # --> add check where were setting on an index or time index column
 
 
@@ -404,9 +407,10 @@ def test_reset_semantic_tags_with_index(sample_column_names, sample_inferred_log
                     semantic_tags=semantic_tags,
                     use_standard_tags=False)
     assert schema.semantic_tags['id'] == {'index', 'tag1'}
-    # --> add back in once deal with index
-    # dt = dt.reset_semantic_tags('id', retain_index_tags=True)
-    # assert dt['id'].semantic_tags == {'index'}
+
+    schema.reset_semantic_tags('id', retain_index_tags=True)
+    assert schema.semantic_tags['id'] == {'index'}
+
     schema.reset_semantic_tags('id')
     assert schema.semantic_tags['id'] == set()
 
@@ -420,9 +424,10 @@ def test_reset_semantic_tags_with_time_index(sample_column_names, sample_inferre
                     semantic_tags=semantic_tags,
                     use_standard_tags=False)
     assert schema.semantic_tags['signup_date'] == {'time_index', 'tag1'}
-    # --> deal with time index
-    # schema.reset_semantic_tags('signup_date', retain_index_tags=True)
-    # assert schema['signup_date'].semantic_tags == {'time_index'}
+
+    schema.reset_semantic_tags('signup_date', retain_index_tags=True)
+    assert schema['signup_date'].semantic_tags == {'time_index'}
+
     schema.reset_semantic_tags('signup_date')
     assert schema.semantic_tags['signup_date'] == set()
 

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -517,7 +517,7 @@ def test_removes_index_via_tags(sample_column_names, sample_inferred_logical_typ
 
     # Check resetting tags
     schema = Schema(sample_column_names, sample_inferred_logical_types,
-                    index='id', use_standard_tags=True,)
+                    index='id', use_standard_tags=True)
     schema.reset_semantic_tags('id')
     assert schema.semantic_tags['id'] == {'numeric'}
     assert schema.index is None

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -484,6 +484,50 @@ def test_raises_error_setting_time_index_tag_directly(sample_column_names, sampl
         schema.set_types(semantic_tags={'signup_date': 'time_index'})
 
 
-# --> test directly setting index tags and directly removing index tags
-def test_removes_indices_via_tags(sample_column_names, sample_inferred_logical_types):
-    pass
+def test_removes_index_via_tags(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    schema.set_types(semantic_tags={'id': 'new_tag'}, retain_index_tags=False)
+    assert schema.semantic_tags['id'] == {'numeric', 'new_tag'}
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='full_name')
+    schema.set_types(semantic_tags={'full_name': 'new_tag'}, retain_index_tags=False)
+    assert schema.semantic_tags['full_name'] == {'new_tag'}
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    schema.remove_semantic_tags(semantic_tags={'id': 'index'})
+    assert schema.semantic_tags['id'] == {'numeric'}
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='full_name')
+    schema.remove_semantic_tags(semantic_tags={'full_name': 'index'})
+    assert schema.semantic_tags['full_name'] == set()
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    schema.reset_semantic_tags('id')
+    assert schema.semantic_tags['id'] == {'numeric'}
+    assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='full_name')
+    schema.reset_semantic_tags('full_name')
+    assert schema.semantic_tags['full_name'] == set()
+    assert schema.index is None
+
+
+def test_removes_time_index_via_tags(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types, time_index='signup_date')
+    schema.set_types(semantic_tags={'signup_date': 'new_tag'}, retain_index_tags=False)
+    assert schema.semantic_tags['signup_date'] == {'new_tag'}
+    assert schema.time_index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, time_index='signup_date')
+    schema.remove_semantic_tags(semantic_tags={'signup_date': 'time_index'})
+    assert schema.semantic_tags['signup_date'] == set()
+    assert schema.time_index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, time_index='signup_date')
+    schema.reset_semantic_tags('signup_date')
+    assert schema.semantic_tags['signup_date'] == set()
+    assert schema.time_index is None

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -343,6 +343,7 @@ def test_set_semantic_tags_with_index(sample_column_names, sample_inferred_logic
     assert schema.semantic_tags['id'] == {'index', 'new_tag'}
 
     schema.set_types(semantic_tags=new_tags, retain_index_tags=False)
+    # --> should this add the numeric tag????????
     assert schema.semantic_tags['id'] == {'new_tag'}
 # --> do this in a situation where standard tags change? Is that even possible??
 
@@ -411,6 +412,7 @@ def test_reset_semantic_tags_with_index(sample_column_names, sample_inferred_log
     schema.reset_semantic_tags('id', retain_index_tags=True)
     assert schema.semantic_tags['id'] == {'index'}
 
+    # --> this should probably have numeric as a tag????
     schema.reset_semantic_tags('id')
     assert schema.semantic_tags['id'] == set()
 
@@ -426,7 +428,7 @@ def test_reset_semantic_tags_with_time_index(sample_column_names, sample_inferre
     assert schema.semantic_tags['signup_date'] == {'time_index', 'tag1'}
 
     schema.reset_semantic_tags('signup_date', retain_index_tags=True)
-    assert schema['signup_date'].semantic_tags == {'time_index'}
+    assert schema.semantic_tags['signup_date'] == {'time_index'}
 
     schema.reset_semantic_tags('signup_date')
     assert schema.semantic_tags['signup_date'] == set()

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -82,34 +82,6 @@ def test_get_column_dict_params():
     assert column.get('metadata') == {'created_by': 'user1'}
 
 
-def test_raises_error_setting_index_tag_directly():
-    error_msg = re.escape("Cannot add 'index' tag directly. To set a column as the index, "
-                          "use Schema.set_index() instead.")
-    with pytest.raises(ValueError, match=error_msg):
-        _get_column_dict('column', Integer, semantic_tags='index')
-
-    # --> add back when schema updates are implemented
-    # Schema = Schema(sample_df)
-    # with pytest.raises(ValueError, match=error_msg):
-    #     schema.add_semantic_tags({'id': 'index'})
-    # with pytest.raises(ValueError, match=error_msg):
-    #     schema.set_semantic_tags({'id': 'index'})
-
-
-def test_raises_error_setting_time_index_tag_directly():
-    error_msg = re.escape("Cannot add 'time_index' tag directly. To set a column as the time index, "
-                          "use Schema.set_time_index() instead.")
-    with pytest.raises(ValueError, match=error_msg):
-        _get_column_dict('column', Integer, semantic_tags='time_index')
-
-    # --> add back when schema updates are implemented
-    # schema = Schema(sample_series)
-    # with pytest.raises(ValueError, match=error_msg):
-    #     schema.add_semantic_tags({'signup_date': 'time_index'})
-    # with pytest.raises(ValueError, match=error_msg):
-    #     schema.set_semantic_tags({'signup_date': 'time_index'})
-
-
 def test_is_col_numeric():
     int_column = _get_column_dict('ints', Integer)
     assert _is_col_numeric(int_column)

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -222,6 +222,28 @@ def test_schema_init_with_logical_type_classes(sample_column_names, sample_infer
     assert schema.logical_types == full_logical_types
 
 
+def test_raises_error_setting_index_tag_directly(sample_column_names, sample_inferred_logical_types):
+    error_msg = re.escape("Cannot add 'index' tag directly for column id. To set a column as the index, "
+                          "use DataFrame.ww.set_index() instead.")
+    with pytest.raises(ValueError, match=error_msg):
+        semantic_tags = {'id': 'index'}
+        schema = Schema(sample_column_names, sample_inferred_logical_types,
+                        name='schema',
+                        semantic_tags=semantic_tags,
+                        use_standard_tags=False)
+
+
+def test_raises_error_setting_time_index_tag_directly(sample_column_names, sample_inferred_logical_types):
+    error_msg = re.escape("Cannot add 'time_index' tag directly for column signup_date. To set a column as the time index, "
+                          "use DataFrame.ww.set_time_index() instead.")
+    with pytest.raises(ValueError, match=error_msg):
+        semantic_tags = {'signup_date': 'time_index'}
+        schema = Schema(sample_column_names, sample_inferred_logical_types,
+                        name='schema',
+                        semantic_tags=semantic_tags,
+                        use_standard_tags=False)
+
+
 def test_schema_init_with_semantic_tags(sample_column_names, sample_inferred_logical_types):
     semantic_tags = {'id': 'custom_tag'}
     schema = Schema(sample_column_names, sample_inferred_logical_types,

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -227,10 +227,10 @@ def test_raises_error_setting_index_tag_directly(sample_column_names, sample_inf
                           "use DataFrame.ww.set_index() instead.")
     with pytest.raises(ValueError, match=error_msg):
         semantic_tags = {'id': 'index'}
-        schema = Schema(sample_column_names, sample_inferred_logical_types,
-                        name='schema',
-                        semantic_tags=semantic_tags,
-                        use_standard_tags=False)
+        Schema(sample_column_names, sample_inferred_logical_types,
+               name='schema',
+               semantic_tags=semantic_tags,
+               use_standard_tags=False)
 
 
 def test_raises_error_setting_time_index_tag_directly(sample_column_names, sample_inferred_logical_types):
@@ -238,10 +238,10 @@ def test_raises_error_setting_time_index_tag_directly(sample_column_names, sampl
                           "use DataFrame.ww.set_time_index() instead.")
     with pytest.raises(ValueError, match=error_msg):
         semantic_tags = {'signup_date': 'time_index'}
-        schema = Schema(sample_column_names, sample_inferred_logical_types,
-                        name='schema',
-                        semantic_tags=semantic_tags,
-                        use_standard_tags=False)
+        Schema(sample_column_names, sample_inferred_logical_types,
+               name='schema',
+               semantic_tags=semantic_tags,
+               use_standard_tags=False)
 
 
 def test_schema_init_with_semantic_tags(sample_column_names, sample_inferred_logical_types):


### PR DESCRIPTION
- Adds `add_semantic_tags`, `remove_semantic_tags`, and `reset_semantic_tags` as well as `set_types` that just includes the semantic_tags parameter for now
- Handles index logic as it relates to semantic tags
    - validating that users aren't trying to set the index or time index directly - completely removed this kind of validation from the `schema_column` file
    - Allowing users to remove indices via tag changes
    - Handling standard tags as they relate to the `index` tag
- Closes #585 