### PR TITLE
Create new schema object when going through pandas operations

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -22,6 +22,7 @@ Release Notes
         * Add semantic tag update methods to table schema (:pr:`591`)
         * Better warning when accessing column properties before init (:pr:`596`)
     * Fixes
+        * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)
         * Move mutual information logic to statistics utils file (:pr:`584`)

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -382,14 +382,14 @@ class Schema(object):
             new_semantic_tags[new_time_index] = new_semantic_tags[new_time_index].difference({'time_index'})
 
         return Schema(subset_cols,
-                      new_logical_types,
+                      new_logical_types,  # --> might also be worth a copy here
                       name=self.name,
                       index=new_index,
                       time_index=new_time_index,
-                      semantic_tags=new_semantic_tags,
+                      semantic_tags=new_semantic_tags.copy(),  # --> might need to deep copy all of these
                       use_standard_tags=self.use_standard_tags,
-                      table_metadata=self.metadata,
-                      column_metadata=new_column_metadata,
+                      table_metadata=self.metadata.copy(),
+                      column_metadata=new_column_metadata.copy(),
                       column_descriptions=new_column_descriptions)
 
 

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 
 import pandas as pd
 
@@ -382,14 +383,14 @@ class Schema(object):
             new_semantic_tags[new_time_index] = new_semantic_tags[new_time_index].difference({'time_index'})
 
         return Schema(subset_cols,
-                      new_logical_types,  # --> might also be worth a copy here
+                      new_logical_types,
                       name=self.name,
                       index=new_index,
                       time_index=new_time_index,
-                      semantic_tags=new_semantic_tags.copy(),  # --> might need to deep copy all of these
+                      semantic_tags=copy.deepcopy(new_semantic_tags),
                       use_standard_tags=self.use_standard_tags,
-                      table_metadata=self.metadata.copy(),
-                      column_metadata=new_column_metadata.copy(),
+                      table_metadata=copy.deepcopy(self.metadata),
+                      column_metadata=copy.deepcopy(new_column_metadata),
                       column_descriptions=new_column_descriptions)
 
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -68,7 +68,7 @@ class WoodworkTableAccessor:
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             schema (Woodwork.Schema, optional): Typing information to use for the DataFrame instead of performing inference.
                 Any other arguments provided will be ignored. Note that any changes made to the typing information
-                after passing in the typing information will propogate to the original object. It is not advised to 
+                after passing in the typing information will propogate to the original object. It is not advised to
                 share typing information between DataFrames.
         '''
         _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
@@ -124,7 +124,10 @@ class WoodworkTableAccessor:
 
     @property
     def schema(self):
-        return self._schema
+        ''' A copy of the Woodwork typing information for the DataFrame.
+        '''
+        if self._schema:
+            return self._schema._get_subset_schema(list(self.columns.keys()))
 
     def select(self, include):
         """Create a DataFrame with Woodowork typing information initialized

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -67,7 +67,9 @@ class WoodworkTableAccessor:
                 specified logical type for the column. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             schema (Woodwork.Schema, optional): Typing information to use for the DataFrame instead of performing inference.
-                Any other arguments provided will be ignored.
+                Any other arguments provided will be ignored. Note that any changes made to the typing information
+                after passing in the typing information will propogate to the original object. It is not advised to 
+                share typing information between DataFrames.
         '''
         _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
         if schema is not None:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -67,9 +67,9 @@ class WoodworkTableAccessor:
                 specified logical type for the column. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             schema (Woodwork.Schema, optional): Typing information to use for the DataFrame instead of performing inference.
-                Any other arguments provided will be ignored. Note that any changes made to the typing information
-                after passing in the typing information will propogate to the original object. It is not advised to
-                share typing information between DataFrames.
+                Any other arguments provided will be ignored. Note that any changes made to the schema object after
+                initialization will propagate to the DataFrame. Similarly, to avoid unintended typing information changes,
+                the same schema object should not be shared between DataFrames.
         '''
         _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
         if schema is not None:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -200,7 +200,8 @@ class WoodworkTableAccessor:
                         warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message, 'DataFrame'),
                                       TypingInfoMismatchWarning)
                     else:
-                        result.ww.init(schema=self._schema)
+                        copied_schema = self._schema._get_subset_schema(list(self._dataframe.columns))
+                        result.ww.init(schema=copied_schema)
                 else:
                     # Confirm that the Schema is still valid on original DataFrame
                     # Important for inplace operations

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -469,6 +469,11 @@ def test_series_methods_on_accessor_other_returns(sample_series):
     assert series.nunique() == series.ww.nunique()
 
 
+def test_series_methods_on_accessor_new_schema_dict(sample_series):
+    pass
+    # --> confirm that the object is different and thant changing metadata or semantic tags doesnt happen to both
+
+
 def test_series_getattr_errors(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series.astype('category')

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -470,8 +470,23 @@ def test_series_methods_on_accessor_other_returns(sample_series):
 
 
 def test_series_methods_on_accessor_new_schema_dict(sample_series):
-    pass
-    # --> confirm that the object is different and thant changing metadata or semantic tags doesnt happen to both
+    xfail_dask_and_koalas(sample_series)
+
+    series = sample_series.astype('category')
+    series.ww.init(semantic_tags=['new_tag', 'tag2'], metadata={'important_keys': [1, 2, 3]})
+
+    copied_series = series.ww.copy()
+
+    assert copied_series.ww._schema == series.ww._schema
+    assert copied_series.ww._schema is not series.ww._schema
+
+    copied_series.ww.metadata['important_keys'].append(4)
+    assert copied_series.ww.metadata['important_keys'] == [1, 2, 3, 4]
+    assert series.ww.metadata['important_keys'] == [1, 2, 3]
+
+    copied_series.ww.add_semantic_tags(['tag3'])
+    assert copied_series.ww.semantic_tags == {'category', 'new_tag', 'tag2', 'tag3'}
+    assert series.ww.semantic_tags == {'category', 'new_tag', 'tag2'}
 
 
 def test_series_getattr_errors(sample_series):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -106,6 +106,15 @@ def test_accessor_init(sample_df):
     assert isinstance(sample_df.ww.schema, Schema)
 
 
+def test_accessor_schema_property(sample_df):
+    xfail_dask_and_koalas(sample_df)
+
+    sample_df.ww.init()
+
+    assert sample_df.ww._schema is not sample_df.ww.schema
+    assert sample_df.ww._schema == sample_df.ww.schema
+
+
 def test_accessor_separation_of_params(sample_df):
     xfail_dask_and_koalas(sample_df)
     # mix up order of acccessor and schema params
@@ -123,13 +132,13 @@ def test_init_accessor_with_schema(sample_df):
 
     schema_df = sample_df.copy()
     schema_df.ww.init(name='test_schema', semantic_tags={'id': 'test_tag'}, index='id')
-    schema = schema_df.ww.schema
+    schema = schema_df.ww._schema
 
     head_df = schema_df.head(2)
     assert head_df.ww.schema is None
     head_df.ww.init(schema=schema)
 
-    assert head_df.ww.schema is schema
+    assert head_df.ww._schema is schema
     assert head_df.ww.name == 'test_schema'
     assert head_df.ww.semantic_tags['id'] == {'index', 'test_tag'}
 
@@ -137,7 +146,7 @@ def test_init_accessor_with_schema(sample_df):
     assert iloc_df.ww.schema is None
     iloc_df.ww.init(schema=schema, logical_types={'id': NaturalLanguage})
 
-    assert iloc_df.ww.schema is schema
+    assert iloc_df.ww._schema is schema
     assert iloc_df.ww.name == 'test_schema'
     assert iloc_df.ww.semantic_tags['id'] == {'index', 'test_tag'}
     # Extra parameters do not take effect
@@ -864,7 +873,7 @@ def test_dataframe_methods_on_accessor(sample_df):
     copied_df = schema_df.ww.copy()
 
     assert schema_df is not copied_df
-    assert schema_df.ww.schema is not copied_df.ww.schema
+    assert schema_df.ww._schema is not copied_df.ww._schema
     assert copied_df.ww.schema == schema_df.ww.schema
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(copied_df))
@@ -890,7 +899,7 @@ def test_dataframe_methods_on_accessor_new_schema_object(sample_df):
     copied_df = sample_df.ww.copy()
 
     assert sample_df.ww.schema == copied_df.ww.schema
-    assert sample_df.ww.schema is not copied_df.ww.schema
+    assert sample_df.ww._schema is not copied_df.ww._schema
 
     copied_df.ww.metadata['contributors'].append('user3')
     assert copied_df.ww.metadata == {'contributors': ['user1', 'user2', 'user3'],

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -862,7 +862,7 @@ def test_dataframe_methods_on_accessor(sample_df):
     copied_df = schema_df.ww.copy()
 
     assert schema_df is not copied_df
-    assert isinstance(copied_df.ww.schema, Schema)
+    assert schema_df.ww.schema is not copied_df.ww.schema
     assert copied_df.ww.schema == schema_df.ww.schema
 
     pd.testing.assert_frame_equal(to_pandas(schema_df), to_pandas(copied_df))
@@ -875,6 +875,11 @@ def test_dataframe_methods_on_accessor(sample_df):
     assert new_df['id'].dtype == 'string'
     assert new_df.ww.schema is None
     assert schema_df.ww.schema is not None
+
+
+def test_dataframe_methods_on_accessor_new_schema_object(sample_df):
+    pass
+    # --> make changes to column descriptions and metadata and col metadata and confirm things don't propogate
 
 
 def test_dataframe_methods_on_accessor_inplace(sample_df):

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -306,6 +306,7 @@ def test_get_subset_schema_all_params(sample_column_names, sample_inferred_logic
     copy_schema = schema._get_subset_schema(sample_column_names)
 
     assert schema == copy_schema
+    assert schema is not copy_schema
 
 
 def test_set_semantic_tags(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -284,7 +284,7 @@ def test_get_subset_schema(sample_column_names, sample_inferred_logical_types):
 
 def test_get_subset_schema_all_params(sample_column_names, sample_inferred_logical_types):
     # The first element is self, so it won't be included in kwargs
-    possible_dt_params = inspect.getfullargspec(Schema.__init__)[0][1:]
+    possible_schema_params = inspect.getfullargspec(Schema.__init__)[0][1:]
 
     kwargs = {
         'column_names': sample_column_names,
@@ -300,7 +300,7 @@ def test_get_subset_schema_all_params(sample_column_names, sample_inferred_logic
     }
 
     # Confirm all possible params to Schema init are present with non-default values where possible
-    assert set(possible_dt_params) == set(kwargs.keys())
+    assert set(possible_schema_params) == set(kwargs.keys())
 
     schema = Schema(**kwargs)
     copy_schema = schema._get_subset_schema(sample_column_names)


### PR DESCRIPTION
- Creates a new schema object when we do operations like `new_df = df.ww.head()` so that any changes don't impact `df`'s schema and `new_df`'s schema. 
- Uses deepcopy where necessary (metadata is the big one) 
- adds tests that confirm we have new objects and that changes don't impact both
- Closes #582 