### PR TITLE
Better error when accessing column accessor properties before init

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Release Notes
         * Add ``describe`` and ``describe_dict`` to WoodworkTableAccessor (:pr:`579`)
         * Add ``init_series`` util function for initializing a series with dtype change (:pr:`581`)
         * Add semantic tag update methods to table schema (:pr:`591`)
+        * Better warning when accessing column properties before init (:pr:`596`)
     * Fixes
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -110,6 +110,8 @@ class WoodworkColumnAccessor:
             raise AttributeError(f"Woodwork has no attribute '{attr}'")
 
     def __repr__(self):
+        if self._schema is None:
+            _raise_init_warning()
         msg = u"<Series: {} ".format(self._series.name)
         msg += u"(Physical Type = {}) ".format(self._series.dtype)
         msg += u"(Logical Type = {}) ".format(self.logical_type)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -57,6 +57,8 @@ class WoodworkColumnAccessor:
     @property
     def description(self):
         """The description of the series"""
+        if self._schema is None:
+            _raise_init_warning()
         return self._schema['description']
 
     @description.setter
@@ -67,11 +69,15 @@ class WoodworkColumnAccessor:
     @property
     def logical_type(self):
         """The logical type of the series"""
+        if self._schema is None:
+            _raise_init_warning()
         return self._schema['logical_type']
 
     @property
     def metadata(self):
         """The metadata of the series"""
+        if self._schema is None:
+            _raise_init_warning()
         return self._schema['metadata']
 
     @metadata.setter
@@ -82,6 +88,8 @@ class WoodworkColumnAccessor:
     @property
     def semantic_tags(self):
         """The semantic tags assigned to the series"""
+        if self._schema is None:
+            _raise_init_warning()
         return self._schema['semantic_tags']
 
     def __eq__(self, other):
@@ -95,7 +103,7 @@ class WoodworkColumnAccessor:
             If the method is present on Series, uses that method.
         '''
         if self._schema is None:
-            raise AttributeError("Woodwork not initialized for this Series. Initialize by calling Series.ww.init")
+            _raise_init_warning()
         if hasattr(self._series, attr):
             return self._make_series_call(attr)
         else:
@@ -195,3 +203,7 @@ class WoodworkColumnAccessor:
         self._schema['semantic_tags'] = _set_semantic_tags(semantic_tags,
                                                            self.logical_type.standard_tags,
                                                            self.use_standard_tags)
+
+
+def _raise_init_warning():
+    raise AttributeError("Woodwork not initialized for this Series. Initialize by calling Series.ww.init")

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -58,7 +58,7 @@ class WoodworkColumnAccessor:
     def description(self):
         """The description of the series"""
         if self._schema is None:
-            _raise_init_warning()
+            _raise_init_error()
         return self._schema['description']
 
     @description.setter
@@ -70,14 +70,14 @@ class WoodworkColumnAccessor:
     def logical_type(self):
         """The logical type of the series"""
         if self._schema is None:
-            _raise_init_warning()
+            _raise_init_error()
         return self._schema['logical_type']
 
     @property
     def metadata(self):
         """The metadata of the series"""
         if self._schema is None:
-            _raise_init_warning()
+            _raise_init_error()
         return self._schema['metadata']
 
     @metadata.setter
@@ -89,7 +89,7 @@ class WoodworkColumnAccessor:
     def semantic_tags(self):
         """The semantic tags assigned to the series"""
         if self._schema is None:
-            _raise_init_warning()
+            _raise_init_error()
         return self._schema['semantic_tags']
 
     def __eq__(self, other):
@@ -103,7 +103,7 @@ class WoodworkColumnAccessor:
             If the method is present on Series, uses that method.
         '''
         if self._schema is None:
-            _raise_init_warning()
+            _raise_init_error()
         if hasattr(self._series, attr):
             return self._make_series_call(attr)
         else:
@@ -111,7 +111,7 @@ class WoodworkColumnAccessor:
 
     def __repr__(self):
         if self._schema is None:
-            _raise_init_warning()
+            _raise_init_error()
         msg = u"<Series: {} ".format(self._series.name)
         msg += u"(Physical Type = {}) ".format(self._series.dtype)
         msg += u"(Logical Type = {}) ".format(self.logical_type)
@@ -207,5 +207,5 @@ class WoodworkColumnAccessor:
                                                            self.use_standard_tags)
 
 
-def _raise_init_warning():
+def _raise_init_error():
     raise AttributeError("Woodwork not initialized for this Series. Initialize by calling Series.ww.init")

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -74,6 +74,9 @@ def test_accessor_warnings_accessing_properties_before_init(sample_series):
     error_message = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
 
     with pytest.raises(AttributeError, match=error_message):
+        sample_series.ww.__repr__()
+
+    with pytest.raises(AttributeError, match=error_message):
         sample_series.ww.description
 
     with pytest.raises(AttributeError, match=error_message):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -69,6 +69,23 @@ def test_accessor_init_with_semantic_tags(sample_series):
     assert series.ww.semantic_tags == set(semantic_tags)
 
 
+def test_accessor_warnings_accessing_properties_before_init(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    error_message = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_series.ww.description
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_series.ww.logical_type
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_series.ww.metadata
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_series.ww.semantic_tags
+
+
 # def test_datacolumn_init_with_extension_array():
 #     series_categories = pd.Series([1, 2, 3], dtype='category')
 #     extension_categories = pd.Categorical([1, 2, 3])


### PR DESCRIPTION
- Pull Request Description (replace this text with your description)
- Closes #572 

Adds a better warning message when trying to access properties on Column Accessor before initialization.