### PR TITLE
Column accessor update for LatLong columns

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -21,6 +21,7 @@ Release Notes
         * Add ``set_logical_type`` method to WoodworkColumnAccessor (:pr:`590`)
         * Add semantic tag update methods to table schema (:pr:`591`)
         * Better warning when accessing column properties before init (:pr:`596`)
+        * Update column accessor to work with LatLong columns (:pr:`598`)
     * Fixes
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from woodwork.accessor_utils import init_series
 from woodwork.exceptions import TypingInfoMismatchWarning
-from woodwork.logical_types import Ordinal
+from woodwork.logical_types import LatLong, Ordinal
 from woodwork.schema_column import (
     _add_semantic_tags,
     _get_column_dict,
@@ -15,7 +15,7 @@ from woodwork.schema_column import (
     _validate_description,
     _validate_metadata
 )
-from woodwork.utils import _get_column_logical_type
+from woodwork.utils import _get_column_logical_type, _is_valid_latlong_series
 
 
 @pd.api.extensions.register_series_accessor('ww')
@@ -164,6 +164,11 @@ class WoodworkColumnAccessor:
 
         if isinstance(logical_type, Ordinal):
             logical_type._validate_data(self._series)
+        elif logical_type == LatLong:
+            if not _is_valid_latlong_series(self._series):
+                raise ValueError("Cannot initialize Woodwork. Series does not contain properly formatted "
+                                 "LatLong data. Try reformatting before initializing or use the "
+                                 "woodwork.init_series function to initialize.")
 
     def add_semantic_tags(self, semantic_tags):
         """Add the specified semantic tags to the set of tags.

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from woodwork.accessor_utils import init_series
 from woodwork.exceptions import (
     DuplicateTagsWarning,
     TypeConversionError,
@@ -15,6 +16,7 @@ from woodwork.logical_types import (
     Datetime,
     Double,
     Integer,
+    LatLong,
     NaturalLanguage,
     Ordinal,
     SubRegionCode,
@@ -541,20 +543,37 @@ def test_ordinal_with_nan_values():
     assert nan_series.ww.logical_type.order == ['a', 'b']
 
 
-# def test_latlong_formatting(latlongs):
-#     expected_series = pd.Series([(1, 2), (3, 4)])
-#     if ks and isinstance(latlongs[0], ks.Series):
-#         expected_series = ks.Series([[1, 2], [3, 4]])
-#     elif dd and isinstance(latlongs[0], dd.Series):
-#         expected_series = dd.from_pandas(expected_series, npartitions=2)
+def test_latlong_init_with_valid_series(latlongs):
+    xfail_dask_and_koalas(latlongs[0])
+    series = latlongs[0]
+    series.ww.init(logical_type="LatLong")
+    assert series.ww.logical_type == LatLong
 
-#     expected_dc = DataColumn(expected_series, logical_type='LatLong', name='test_series')
 
-#     for series in latlongs:
-#         dc = DataColumn(series, logical_type='LatLong', name='test_series')
-#         pd.testing.assert_series_equal(to_pandas(dc.to_series()), to_pandas(expected_series))
+def test_latlong_init_error_with_invalid_series(latlongs):
+    xfail_dask_and_koalas(latlongs[0])
+    series = latlongs[1]
+    error_message = "Cannot initialize Woodwork. Series does not contain properly formatted " \
+        "LatLong data. Try reformatting before initializing or use the " \
+        "woodwork.init_series function to initialize."
+    with pytest.raises(ValueError, match=error_message):
+        series.ww.init(logical_type="LatLong")
 
-#         assert dc == expected_dc
+
+def test_latlong_formatting_with_init_series(latlongs):
+    xfail_dask_and_koalas(latlongs[0])
+    expected_series = pd.Series([(1.0, 2.0), (3.0, 4.0)])
+    # if ks and isinstance(latlongs[0], ks.Series):
+    #     expected_series = ks.Series([[1, 2], [3, 4]])
+    # elif dd and isinstance(latlongs[0], dd.Series):
+    #     expected_series = dd.from_pandas(expected_series, npartitions=2)
+
+    expected_series.ww.init(logical_type=LatLong)
+    for series in latlongs:
+        new_series = init_series(series, logical_type=LatLong)
+        assert new_series.ww.logical_type == LatLong
+        pd.testing.assert_series_equal(new_series, expected_series)
+        assert expected_series.ww._schema == new_series.ww._schema
 
 
 def test_accessor_equality(sample_series, sample_datetime_series):

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -459,6 +459,7 @@ def latlong_df(request):
 @pytest.fixture
 def pandas_latlongs():
     return [
+        pd.Series([(1.0, 2.0), (3.0, 4.0)]),
         pd.Series([('1', '2'), ('3', '4')]),
         pd.Series([['1', '2'], ['3', '4']]),
         pd.Series([(1, 2), (3, 4)]),

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -32,6 +32,8 @@ from woodwork.utils import (
     _is_null_latlong,
     _is_s3,
     _is_url,
+    _is_valid_latlong_series,
+    _is_valid_latlong_value,
     _new_dt_including,
     _reformat_to_latlong,
     _to_latlong_float,
@@ -434,6 +436,39 @@ def test_is_null_latlong():
     assert not _is_null_latlong('none')
     assert not _is_null_latlong(0)
     assert not _is_null_latlong(False)
+
+
+def test_is_valid_latlong_value():
+    values = [
+        (1.0, 2.0),
+        (np.nan, np.nan),
+        [1.0, 2.0],
+        np.nan,
+        ('a', 2.0),
+        (1.0, 2.0, 3.0),
+        None
+    ]
+
+    expected_values = [
+        True,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False
+    ]
+
+    for index, value in enumerate(values):
+        assert _is_valid_latlong_value(value) is expected_values[index]
+
+
+def test_is_valid_latlong_series():
+    valid_series = pd.Series([(1.0, 2.0), (3.0, 4.0)])
+    invalid_series = pd.Series([(1.0, 2.0), (3.0, '4.0')])
+
+    assert _is_valid_latlong_series(valid_series) is True
+    assert _is_valid_latlong_series(invalid_series) is False
 
 
 def test_get_valid_mi_types():

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -441,9 +441,9 @@ def test_is_null_latlong():
 def test_is_valid_latlong_value():
     values = [
         (1.0, 2.0),
-        (np.nan, np.nan),
-        [1.0, 2.0],
         np.nan,
+        [1.0, 2.0],
+        (np.nan, np.nan),
         ('a', 2.0),
         (1.0, 2.0, 3.0),
         None

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -274,10 +274,14 @@ def _is_valid_latlong_series(series):
 
 def _is_valid_latlong_value(val):
     '''Returns True if the value provided is a properly formatted LatLong value, otherwise
-    returns False'''
+    returns False.'''
     if isinstance(val, tuple) and len(val) == 2:
         if isinstance(val[0], float) and isinstance(val[1], float):
+            if pd.isnull(val[0]) and pd.isnull(val[1]):
+                return False
             return True
+    elif isinstance(val, float) and pd.isnull(val):
+        return True
     return False
 
 

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -264,6 +264,23 @@ def _to_latlong_float(val):
         raise ValueError(f'Latitude and Longitude values must be in decimal degrees. The latitude or longitude represented by {val} cannot be converted to a float.')
 
 
+def _is_valid_latlong_series(series):
+    '''Returns True if all elements in the series contain properly formatted LatLong values,
+    otherwise returns False'''
+    if series.apply(_is_valid_latlong_value).all():
+        return True
+    return False
+
+
+def _is_valid_latlong_value(val):
+    '''Returns True if the value provided is a properly formatted LatLong value, otherwise
+    returns False'''
+    if isinstance(val, tuple) and len(val) == 2:
+        if isinstance(val[0], float) and isinstance(val[1], float):
+            return True
+    return False
+
+
 def _is_null_latlong(val):
     if isinstance(val, str):
         return val == 'None' or val == 'nan' or val == 'NaN'

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -276,8 +276,9 @@ def _is_valid_latlong_value(val):
     '''Returns True if the value provided is a properly formatted LatLong value, otherwise
     returns False.'''
     if isinstance(val, tuple) and len(val) == 2:
-        if isinstance(val[0], float) and isinstance(val[1], float):
-            if pd.isnull(val[0]) and pd.isnull(val[1]):
+        latitude, longitude = val
+        if isinstance(latitude, float) and isinstance(longitude, float):
+            if pd.isnull(latitude) and pd.isnull(longitude):
                 return False
             return True
     elif isinstance(val, float) and pd.isnull(val):


### PR DESCRIPTION
- Column accessor update for LatLong columns
- Closes #568

Allows for direct initialization of LatLong columns via `series.ww.init` if the data is properly formatted, otherwise raises an error. LatLong columns that require reformatting can be initialized via `ww.init_series`.