### PR TITLE
Allow updating index 

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -44,7 +44,7 @@ Schema
     Schema.add_semantic_tags
     Schema.remove_semantic_tags
     Schema.reset_semantic_tags
-    Schema.set_semantic_tags
+    Schema.set_types
 
 
 DataTable

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -10,8 +10,13 @@ WoodworkTableAccessor
     :toctree: generated/
 
     WoodworkTableAccessor
+    WoodworkTableAccessor.describe
+    WoodworkTableAccessor.describe_dict
     WoodworkTableAccessor.init
+    WoodworkTableAccessor.mutual_information_dict
+    WoodworkTableAccessor.mutual_information
     WoodworkTableAccessor.select
+    WoodworkTableAccessor.set_index
 
 WoodworkColumnAccessor
 ======================
@@ -22,6 +27,11 @@ WoodworkColumnAccessor
 
     WoodworkColumnAccessor
     WoodworkColumnAccessor.init
+    WoodworkColumnAccessor.add_semantic_tags
+    WoodworkColumnAccessor.remove_semantic_tags
+    WoodworkColumnAccessor.reset_semantic_tags
+    WoodworkColumnAccessor.set_logical_type
+    WoodworkColumnAccessor.set_semantic_tags
 
 Schema
 ======
@@ -31,6 +41,10 @@ Schema
     :toctree: generated/
 
     Schema
+    Schema.add_semantic_tags
+    Schema.remove_semantic_tags
+    Schema.reset_semantic_tags
+    Schema.set_semantic_tags
 
 
 DataTable

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -22,6 +22,7 @@ Release Notes
         * Add semantic tag update methods to table schema (:pr:`591`)
         * Add warning if additional parameters are passed along with schema (:pr:`593`)
         * Better warning when accessing column properties before init (:pr:`596`)
+        * Add ``set_index`` to WoodworkTableAccessor (:pr:`603`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -67,7 +67,7 @@ class Schema(object):
                                             column_descriptions,
                                             column_metadata)
         if index is not None:
-            _update_index(self, column_names, index)
+            self.set_index(index)
 
         if time_index is not None:
             _update_time_index(self, column_names, time_index)
@@ -281,6 +281,19 @@ class Schema(object):
                                              metadata=metadata_for_col)
         return columns
 
+    def set_index(self, new_index):
+        '''Sets the index. Handles creating a new index, updating the index, or removing the index.
+
+        Args:
+            new_index (str): Name of the new index column. Must be present in the Schema.
+        '''
+        old_index = self.index
+        if old_index is not None:
+            self.remove_semantic_tags({old_index: 'index'})
+        if new_index is not None:
+            _check_index(self.columns.keys(), new_index)
+            self._set_index_tags(new_index)
+
     def _set_index_tags(self, index):
         '''
         Updates the semantic tags of the index by removing any standard tags
@@ -485,17 +498,6 @@ def _check_column_metadata(column_names, column_metadata):
     if cols_not_found:
         raise LookupError('column_metadata contains columns that do not exist: '
                           f'{sorted(list(cols_not_found))}')
-
-
-def _update_index(schema, column_names, index, old_index=None):
-    """Add the `index` tag to the specified index column and remove the tag from the
-    old_index column, if specified. Also checks that the specified index column
-    can be used as an index."""
-    _check_index(column_names, index)
-    # --> when schema updates are implemented need a way of removing the old index
-    # if old_index is not None:
-    #     schema._update_columns({old_index: schema.columns[old_index].remove_semantic_tags('index')})
-    schema._set_index_tags(index)
 
 
 def _update_time_index(schema, column_names, time_index, old_time_index=None):

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -282,7 +282,7 @@ class Schema(object):
         return columns
 
     def set_index(self, new_index):
-        '''Sets the index. Handles creating a new index, updating the index, or removing the index.
+        '''Sets the index. Handles setting a new index, updating the index, or removing the index.
 
         Args:
             new_index (str): Name of the new index column. Must be present in the Schema.

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -159,7 +159,6 @@ class WoodworkTableAccessor:
         """
         self._schema.set_index(new_index)
 
-        # --> by putting this after it follows separation paradigm but means the error message we get will come from schema
         if new_index is not None:
             _check_index(self._dataframe, new_index)
         self._set_underlying_index()

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -148,6 +148,22 @@ class WoodworkTableAccessor:
         if self._schema:
             return self._schema._get_subset_schema(list(self.columns.keys()))
 
+    def set_index(self, new_index):
+        """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
+        and clears the tag from any previously set index column.
+        Setting a column as the index column will also cause any previously set standard
+        tags for the column to be removed.
+
+        Args:
+            index (str): The name of the column to set as the index
+        """
+        self._schema.set_index(new_index)
+
+        # --> by putting this after it follows separation paradigm but means the error message we get will come from schema
+        if new_index is not None:
+            _check_index(self._dataframe, new_index)
+        self._set_underlying_index()
+
     def select(self, include):
         """Create a DataFrame with Woodowork typing information initialized
         that includes only columns whose Logical Type and semantic tags are

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -159,8 +159,8 @@ class WoodworkTableAccessor:
         """
         self._schema.set_index(new_index)
 
-        if new_index is not None:
-            _check_index(self._dataframe, new_index)
+        if self._schema.index is not None:
+            _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
 
     def select(self, include):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1348,6 +1348,20 @@ def test_accessor_set_index(sample_df):
     # --> add setter test
 
 
+def test_accessor_set_index_errors(sample_df):
+    xfail_dask_and_koalas(sample_df)
+
+    sample_df.ww.init()
+
+    error = 'Specified index column `testing` not found in Schema.'
+    with pytest.raises(LookupError, match=error):
+        sample_df.ww.set_index('testing')
+
+    error = "Index column must be unique"
+    with pytest.raises(LookupError, match=error):
+        sample_df.ww.set_index('age')
+
+
 # def test_set_index(sample_df):
 #     # Test setting index with set_index()
 #     dt = DataTable(sample_df)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -701,6 +701,7 @@ def test_underlying_index(sample_df):
         pytest.xfail('Setting underlying index is not supported with Koalas input')
 
     specified_index = pd.Index
+    unspecified_index = pd.RangeIndex
 
     schema_df = sample_df.copy()
     schema_df.ww.init(index='full_name')
@@ -708,24 +709,21 @@ def test_underlying_index(sample_df):
     assert (schema_df.index == ['Mr. John Doe', 'Doe, Mrs. Jane', 'James Brown', 'Ms. Paige Turner']).all()
     assert type(schema_df.index) == specified_index
 
-    # --> add back when schema updates are implemented
-    # schema = Schema(sample_df.copy())
-    # schema = schema.set_index('full_name')
-    # assert (schema._dataframe.index == schema.to_dataframe()['full_name']).all()
-    # assert schema._dataframe.index.name is None
-    # assert type(schema._dataframe.index) == specified_index
-    # assert type(schema.to_dataframe().index) == specified_index
+    schema_df.ww.set_index('full_name')
+    assert (schema_df.index == schema_df['full_name']).all()
+    assert schema_df.index.name is None
+    assert type(schema_df.index) == specified_index
 
+    # --> add back in with setter
     # schema.index = 'id'
     # assert (schema._dataframe.index == [0, 1, 2, 3]).all()
     # assert schema._dataframe.index.name is None
     # assert type(schema._dataframe.index) == specified_index
     # assert type(schema.to_dataframe().index) == specified_index
 
-    # # test removing index removes the dataframe's index
-    # schema.index = None
-    # assert type(schema._dataframe.index) == unspecified_index
-    # assert type(schema.to_dataframe().index) == unspecified_index
+    # test removing index removes the dataframe's index
+    schema_df.ww.set_index(None)
+    assert type(schema_df.index) == unspecified_index
 
     schema_df = sample_df.copy()
     schema_df.ww.init(index='made_index', make_index=True)
@@ -733,7 +731,7 @@ def test_underlying_index(sample_df):
     assert schema_df.index.name is None
     assert type(schema_df.index) == specified_index
 
-    # --> add back when schema updates are implemented
+    # --> add back when df.ww.drop is implemented
     # schema_dropped = schema.drop('made_index')
     # assert 'made_index' not in schema_dropped.columns
     # assert 'made_index' not in schema_dropped._dataframe.columns
@@ -1328,3 +1326,64 @@ def test_select_repetitive(sample_df):
     df_repeat_ltypes = schema_df.ww.select(['PhoneNumber', PhoneNumber, 'phone_number'])
     assert len(df_repeat_ltypes.columns) == 1
     assert set(df_repeat_ltypes.columns) == {'phone_number'}
+
+
+def test_accessor_set_index(sample_df):
+    xfail_dask_and_koalas(sample_df)
+
+    sample_df.ww.init()
+
+    sample_df.ww.set_index('id')
+    assert sample_df.ww.index == 'id'
+    assert (sample_df.index == [0, 1, 2, 3]).all()
+
+    sample_df.ww.set_index('full_name')
+    assert sample_df.ww.index == 'full_name'
+    assert (sample_df.index == sample_df['full_name']).all()
+
+    sample_df.ww.set_index(None)
+    assert sample_df.ww.index is None
+    assert (sample_df.index == [0, 1, 2, 3]).all()
+
+    # --> add setter test
+
+
+# def test_set_index(sample_df):
+#     # Test setting index with set_index()
+#     dt = DataTable(sample_df)
+#     new_dt = dt.set_index('id')
+#     assert new_dt is not dt
+#     assert new_dt.index == 'id'
+#     assert dt.index is None
+#     assert new_dt.columns['id'].semantic_tags == {'index'}
+#     non_index_cols = [col for col in new_dt.columns.values() if col.name != 'id']
+#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
+#     # Test changing index with set_index()
+#     new_dt2 = new_dt.set_index('full_name')
+#     assert new_dt.index == 'id'
+#     assert new_dt2.columns['full_name'].semantic_tags == {'index'}
+#     non_index_cols = [col for col in new_dt2.columns.values() if col.name != 'full_name']
+#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
+
+#     # Test setting index using setter
+#     dt = DataTable(sample_df)
+#     dt.index = 'id'
+#     assert dt.index == 'id'
+#     assert 'index' in dt.columns['id'].semantic_tags
+#     non_index_cols = [col for col in dt.columns.values() if col.name != 'id']
+#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
+#     # Test changing index with setter
+#     dt.index = 'full_name'
+#     assert 'index' in dt.columns['full_name'].semantic_tags
+#     non_index_cols = [col for col in dt.columns.values() if col.name != 'full_name']
+#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
+
+#     # Test changing index also changes underlying DataFrame - pandas only
+#     if isinstance(sample_df, pd.DataFrame):
+#         dt = DataTable(sample_df)
+#         dt.index = 'id'
+#         assert (dt.to_dataframe().index == [0, 1, 2, 3]).all()
+#         assert (dt._dataframe.index == [0, 1, 2, 3]).all()
+#         dt.index = 'full_name'
+#         assert (dt.to_dataframe().index == dt.to_dataframe()['full_name']).all()
+#         assert (dt._dataframe.index == dt.to_dataframe()['full_name']).all()

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -705,21 +705,18 @@ def test_underlying_index(sample_df):
 
     schema_df = sample_df.copy()
     schema_df.ww.init(index='full_name')
+    assert 'full_name' in schema_df.columns
     assert schema_df.index.name is None
-    assert (schema_df.index == ['Mr. John Doe', 'Doe, Mrs. Jane', 'James Brown', 'Ms. Paige Turner']).all()
+    assert (schema_df.index == schema_df['full_name']).all()
     assert type(schema_df.index) == specified_index
 
+    schema_df = sample_df.copy()
+    schema_df.ww.init(index='id')
     schema_df.ww.set_index('full_name')
+    assert 'full_name' in schema_df.columns
     assert (schema_df.index == schema_df['full_name']).all()
     assert schema_df.index.name is None
     assert type(schema_df.index) == specified_index
-
-    # --> add back in with setter
-    # schema.index = 'id'
-    # assert (schema._dataframe.index == [0, 1, 2, 3]).all()
-    # assert schema._dataframe.index.name is None
-    # assert type(schema._dataframe.index) == specified_index
-    # assert type(schema.to_dataframe().index) == specified_index
 
     # test removing index removes the dataframe's index
     schema_df.ww.set_index(None)
@@ -727,6 +724,7 @@ def test_underlying_index(sample_df):
 
     schema_df = sample_df.copy()
     schema_df.ww.init(index='made_index', make_index=True)
+    assert 'made_index' in schema_df
     assert (schema_df.index == [0, 1, 2, 3]).all()
     assert schema_df.index.name is None
     assert type(schema_df.index) == specified_index
@@ -1335,7 +1333,7 @@ def test_accessor_set_index(sample_df):
 
     sample_df.ww.set_index('id')
     assert sample_df.ww.index == 'id'
-    assert (sample_df.index == [0, 1, 2, 3]).all()
+    assert (sample_df.index == sample_df['id']).all()
 
     sample_df.ww.set_index('full_name')
     assert sample_df.ww.index == 'full_name'
@@ -1343,9 +1341,7 @@ def test_accessor_set_index(sample_df):
 
     sample_df.ww.set_index(None)
     assert sample_df.ww.index is None
-    assert (sample_df.index == [0, 1, 2, 3]).all()
-
-    # --> add setter test
+    assert (sample_df.index == range(4)).all()
 
 
 def test_accessor_set_index_errors(sample_df):
@@ -1360,44 +1356,3 @@ def test_accessor_set_index_errors(sample_df):
     error = "Index column must be unique"
     with pytest.raises(LookupError, match=error):
         sample_df.ww.set_index('age')
-
-
-# def test_set_index(sample_df):
-#     # Test setting index with set_index()
-#     dt = DataTable(sample_df)
-#     new_dt = dt.set_index('id')
-#     assert new_dt is not dt
-#     assert new_dt.index == 'id'
-#     assert dt.index is None
-#     assert new_dt.columns['id'].semantic_tags == {'index'}
-#     non_index_cols = [col for col in new_dt.columns.values() if col.name != 'id']
-#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
-#     # Test changing index with set_index()
-#     new_dt2 = new_dt.set_index('full_name')
-#     assert new_dt.index == 'id'
-#     assert new_dt2.columns['full_name'].semantic_tags == {'index'}
-#     non_index_cols = [col for col in new_dt2.columns.values() if col.name != 'full_name']
-#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
-
-#     # Test setting index using setter
-#     dt = DataTable(sample_df)
-#     dt.index = 'id'
-#     assert dt.index == 'id'
-#     assert 'index' in dt.columns['id'].semantic_tags
-#     non_index_cols = [col for col in dt.columns.values() if col.name != 'id']
-#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
-#     # Test changing index with setter
-#     dt.index = 'full_name'
-#     assert 'index' in dt.columns['full_name'].semantic_tags
-#     non_index_cols = [col for col in dt.columns.values() if col.name != 'full_name']
-#     assert all(['index' not in col.semantic_tags for col in non_index_cols])
-
-#     # Test changing index also changes underlying DataFrame - pandas only
-#     if isinstance(sample_df, pd.DataFrame):
-#         dt = DataTable(sample_df)
-#         dt.index = 'id'
-#         assert (dt.to_dataframe().index == [0, 1, 2, 3]).all()
-#         assert (dt._dataframe.index == [0, 1, 2, 3]).all()
-#         dt.index = 'full_name'
-#         assert (dt.to_dataframe().index == dt.to_dataframe()['full_name']).all()
-#         assert (dt._dataframe.index == dt.to_dataframe()['full_name']).all()

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -577,9 +577,6 @@ def test_set_index(sample_column_names, sample_inferred_logical_types):
 def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types)
 
-    schema.set_index(None)
-    assert schema.index is None
-
     error = re.escape("Specified index column `testing` not found in Schema.")
     with pytest.raises(LookupError, match=error):
         schema.set_index('testing')
@@ -590,16 +587,13 @@ def test_set_index_twice(sample_column_names, sample_inferred_logical_types):
 
     original_schema = schema._get_subset_schema(list(schema.columns.keys()))
 
+    schema.set_index(None)
+    assert schema.index is None
+
     schema.set_index('id')
     assert schema.index == 'id'
     assert schema.semantic_tags['id'] == {'index'}
     assert schema == original_schema
-
-    # --> add test when using setter
-#     dt.index = 'id'
-#     assert 'index' in dt['id'].semantic_tags
-#     assert dt.index == 'id'
-#     pd.testing.assert_frame_equal(to_pandas(original_df), to_pandas(dt.df))
 
     # --> add time index
 #     dt_time_index_twice = dt.set_time_index('signup_date')

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -551,3 +551,35 @@ def test_removes_time_index_via_tags(sample_column_names, sample_inferred_logica
     schema.reset_semantic_tags('signup_date')
     assert schema.semantic_tags['signup_date'] == set()
     assert schema.time_index is None
+
+
+def test_set_index(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types)
+    assert schema.index is None
+    assert schema.semantic_tags['id'] == {'numeric'}
+    assert schema.semantic_tags['age'] == {'numeric'}
+
+    schema.set_index('id')
+    assert schema.index == 'id'
+    assert schema.semantic_tags['id'] == {'index'}
+
+    schema.set_index('age')
+    assert schema.index == 'age'
+    assert schema.semantic_tags['age'] == {'index'}
+    assert schema.semantic_tags['id'] == {'numeric'}
+
+    schema.set_index(None)
+    assert schema.index is None
+    assert schema.semantic_tags['age'] == {'numeric'}
+    assert schema.semantic_tags['id'] == {'numeric'}
+
+
+def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types)
+
+    schema.set_index(None)
+    assert schema.index is None
+
+    error = re.escape("Specified index column `testing` not found in Schema.")
+    with pytest.raises(LookupError, match=error):
+        schema.set_index('testing')

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -583,12 +583,12 @@ def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
 
 
 def test_set_index_twice(sample_column_names, sample_inferred_logical_types):
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
-
-    original_schema = schema._get_subset_schema(list(schema.columns.keys()))
-
+    schema = Schema(sample_column_names, sample_inferred_logical_types)
     schema.set_index(None)
     assert schema.index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    original_schema = schema._get_subset_schema(list(schema.columns.keys()))
 
     schema.set_index('id')
     assert schema.index == 'id'

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -583,3 +583,33 @@ def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
     error = re.escape("Specified index column `testing` not found in Schema.")
     with pytest.raises(LookupError, match=error):
         schema.set_index('testing')
+
+
+def test_set_index_twice(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+
+    original_schema = schema._get_subset_schema(list(schema.columns.keys()))
+
+    schema.set_index('id')
+    assert schema.index == 'id'
+    assert schema.semantic_tags['id'] == {'index'}
+    assert schema == original_schema
+
+    # --> add test when using setter
+#     dt.index = 'id'
+#     assert 'index' in dt['id'].semantic_tags
+#     assert dt.index == 'id'
+#     pd.testing.assert_frame_equal(to_pandas(original_df), to_pandas(dt.df))
+
+    # --> add time index
+#     dt_time_index_twice = dt.set_time_index('signup_date')
+#     assert 'time_index' in dt_time_index_twice['signup_date'].semantic_tags
+#     assert dt_time_index_twice.time_index == 'signup_date'
+#     assert dt_time_index_twice == dt
+#     pd.testing.assert_frame_equal(to_pandas(original_df), to_pandas(dt_time_index_twice.df))
+
+
+#     dt.time_index = 'signup_date'
+#     assert 'time_index' in dt['signup_date'].semantic_tags
+#     assert dt.time_index == 'signup_date'
+#     pd.testing.assert_frame_equal(to_pandas(original_df), to_pandas(dt.df))


### PR DESCRIPTION
- Adds `set_index` that allows for creating, updating, or removing an index column. Performs relevant checks for whether the column is a valid index column.
- Closes #586 
