### PR TITLE
Allow updating time index

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -46,6 +46,8 @@ Schema
     Schema.add_semantic_tags
     Schema.remove_semantic_tags
     Schema.reset_semantic_tags
+    Schema.set_index
+    Schema.set_time_index
     Schema.set_types
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ Release Notes
         * Update column accessor to work with LatLong columns (:pr:`598`)
         * Add ``set_index`` to WoodworkTableAccessor (:pr:`603`)
         * Implement ``loc`` and ``iloc`` for WoodworkColumnAccessor (:pr:`613`)
+        * Add ``set_time_index`` to WoodworkTableAccessor (:pr:`603`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,7 +25,7 @@ Release Notes
         * Update column accessor to work with LatLong columns (:pr:`598`)
         * Add ``set_index`` to WoodworkTableAccessor (:pr:`603`)
         * Implement ``loc`` and ``iloc`` for WoodworkColumnAccessor (:pr:`613`)
-        * Add ``set_time_index`` to WoodworkTableAccessor (:pr:`603`)
+        * Add ``set_time_index`` to WoodworkTableAccessor (:pr:`612`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -164,19 +164,6 @@ class WoodworkTableAccessor:
             _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
 
-    def set_time_index(self, new_time_index):
-        '''Sets the time index column of the DataFrame. Adds the 'time index' semantic tag to the column
-        and clears the tag from any previously set time index column.
-        Clears the DataFrame's time index by passing in None.
-
-        Args:
-            new_time_index (str): The name of the column to set as the time index
-        '''
-        self._schema.set_time_index(new_time_index)
-
-        if self._schema.time_index is not None:
-            _check_time_index(self._dataframe, self._schema.time_index)
-
     def select(self, include):
         """Create a DataFrame with Woodowork typing information initialized
         that includes only columns whose Logical Type and semantic tags are

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -153,15 +153,29 @@ class WoodworkTableAccessor:
         and clears the tag from any previously set index column.
         Setting a column as the index column will also cause any previously set standard
         tags for the column to be removed.
+        Clears the DataFrame's index by passing in None.
 
         Args:
-            index (str): The name of the column to set as the index
+            new_index (str): The name of the column to set as the index
         """
         self._schema.set_index(new_index)
 
         if self._schema.index is not None:
             _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
+
+    def set_time_index(self, new_time_index):
+        '''Sets the time index column of the DataFrame. Adds the 'time index' semantic tag to the column
+        and clears the tag from any previously set time index column.
+        Clears the DataFrame's time index by passing in None.
+
+        Args:
+            new_time_index (str): The name of the column to set as the time index
+        '''
+        self._schema.set_time_index(new_time_index)
+
+        if self._schema.time_index is not None:
+            _check_time_index(self._dataframe, self._schema.time_index)
 
     def select(self, include):
         """Create a DataFrame with Woodowork typing information initialized

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -317,7 +317,7 @@ def test_accessor_with_numeric_time_index(time_index_df):
     with pytest.raises(TypeError, match=error_msg):
         time_index_df.ww.init(time_index='letters', logical_types={'strs': 'Integer'})
 
-    # Change time index to normal datetime time index
+    # Set numeric time index after init
     schema_df = time_index_df.copy()
     schema_df.ww.init(logical_types={'ints': 'Double'})
     assert schema_df.ww.time_index is None

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1350,32 +1350,3 @@ def test_accessor_set_index_errors(sample_df):
     error = "Index column must be unique"
     with pytest.raises(LookupError, match=error):
         sample_df.ww.set_index('age')
-
-
-def test_accessor_set_time_index(sample_df):
-    xfail_dask_and_koalas(sample_df)
-
-    sample_df.ww.init()
-
-    sample_df.ww.set_time_index('signup_date')
-    assert sample_df.ww.time_index == 'signup_date'
-
-    sample_df.ww.set_time_index('age')
-    assert sample_df.ww.time_index == 'age'
-
-    sample_df.ww.set_time_index(None)
-    assert sample_df.ww.time_index is None
-
-
-def test_accessor_set_time_index_errors(sample_df):
-    xfail_dask_and_koalas(sample_df)
-
-    sample_df.ww.init()
-
-    error = 'Specified time index column `testing` not found in Schema'
-    with pytest.raises(LookupError, match=error):
-        sample_df.ww.set_time_index('testing')
-
-    error = "Time index column must be a Datetime or numeric column."
-    with pytest.raises(TypeError, match=error):
-        sample_df.ww.set_time_index('email')

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -585,7 +585,6 @@ def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
 def test_set_time_index(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types)
     assert schema.time_index is None
-    assert schema.semantic_tags['id'] == {'numeric'}
     assert schema.semantic_tags['age'] == {'numeric'}
     assert schema.semantic_tags['signup_date'] == set()
 

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -582,12 +582,65 @@ def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
         schema.set_index('testing')
 
 
+def test_set_time_index(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types)
+    assert schema.time_index is None
+    assert schema.semantic_tags['id'] == {'numeric'}
+    assert schema.semantic_tags['age'] == {'numeric'}
+    assert schema.semantic_tags['signup_date'] == set()
+
+    schema.set_time_index('signup_date')
+    assert schema.time_index == 'signup_date'
+    assert schema.semantic_tags['signup_date'] == {'time_index'}
+
+    schema.set_time_index('age')
+    assert schema.time_index == 'age'
+    assert schema.semantic_tags['age'] == {'numeric', 'time_index'}
+    assert schema.semantic_tags['signup_date'] == set()
+
+    schema.set_time_index(None)
+    assert schema.index is None
+    assert schema.semantic_tags['age'] == {'numeric'}
+    assert schema.semantic_tags['signup_date'] == set()
+
+
+def test_set_numeric_datetime_time_index(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, {**sample_inferred_logical_types, 'age': Datetime})
+
+    assert schema.logical_types['age'] == Datetime
+    assert schema.semantic_tags['age'] == set()
+
+    schema.set_time_index('age')
+    assert schema.time_index == 'age'
+    assert schema.semantic_tags['age'] == {'time_index'}
+
+    schema.set_time_index(None)
+    assert schema.time_index is None
+    assert schema.semantic_tags['age'] == set()
+
+
+def test_set_time_index_errors(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types)
+
+    error = re.escape("Specified time index column `testing` not found in Schema")
+    with pytest.raises(LookupError, match=error):
+        schema.set_time_index('testing')
+
+    error = re.escape("Time index column must be a Datetime or numeric column.")
+    with pytest.raises(TypeError, match=error):
+        schema.set_time_index('email')
+
+
 def test_set_index_twice(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types)
     schema.set_index(None)
     assert schema.index is None
 
-    schema = Schema(sample_column_names, sample_inferred_logical_types, index='id')
+    schema.set_time_index(None)
+    assert schema.time_index is None
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id', time_index='signup_date')
     original_schema = schema._get_subset_schema(list(schema.columns.keys()))
 
     schema.set_index('id')
@@ -595,15 +648,7 @@ def test_set_index_twice(sample_column_names, sample_inferred_logical_types):
     assert schema.semantic_tags['id'] == {'index'}
     assert schema == original_schema
 
-    # --> add time index
-#     dt_time_index_twice = dt.set_time_index('signup_date')
-#     assert 'time_index' in dt_time_index_twice['signup_date'].semantic_tags
-#     assert dt_time_index_twice.time_index == 'signup_date'
-#     assert dt_time_index_twice == dt
-#     pd.testing.assert_frame_equal(to_pandas(original_df), to_pandas(dt_time_index_twice.df))
-
-
-#     dt.time_index = 'signup_date'
-#     assert 'time_index' in dt['signup_date'].semantic_tags
-#     assert dt.time_index == 'signup_date'
-#     pd.testing.assert_frame_equal(to_pandas(original_df), to_pandas(dt.df))
+    schema.set_time_index('signup_date')
+    assert schema.time_index == 'signup_date'
+    assert schema.semantic_tags['signup_date'] == {'time_index'}
+    assert schema == original_schema

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -187,22 +187,6 @@ def test_schema_with_numeric_time_index(sample_column_names, sample_inferred_log
     assert date_col['logical_type'] == Double
     assert date_col['semantic_tags'] == {'time_index', 'numeric'}
 
-    # --> add back when schema updates are implemented
-    # # Change time index to normal datetime time index
-    # schema = schema.set_time_index('times')
-    # date_col = schema['ints']
-    # assert schema.time_index == 'times'
-    # assert date_col.logical_type == Double
-    # assert date_col.semantic_tags == {'numeric'}
-
-    # Set numeric time index after init
-    # schema = Schema(time_index_df, logical_types={'ints': 'Double'})
-    # schema = schema.set_time_index('ints')
-    # date_col = schema['ints']
-    # assert schema.time_index == 'ints'
-    # assert date_col.logical_type == Double
-    # assert date_col.semantic_tags == {'time_index', 'numeric'}
-
 
 def test_schema_init_with_logical_type_classes(sample_column_names, sample_inferred_logical_types):
     logical_types = {


### PR DESCRIPTION
- Adds `set_time_index method that allows for creating, changing, or removing a time index column. Performs relevant checks for whether the column is a valid time index column.
- Closes #586 