### PR TITLE
Implement loc and iloc for Column Accessor

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -26,8 +26,10 @@ WoodworkColumnAccessor
     :toctree: generated/
 
     WoodworkColumnAccessor
-    WoodworkColumnAccessor.init
     WoodworkColumnAccessor.add_semantic_tags
+    WoodworkColumnAccessor.iloc
+    WoodworkColumnAccessor.init
+    WoodworkColumnAccessor.loc
     WoodworkColumnAccessor.remove_semantic_tags
     WoodworkColumnAccessor.reset_semantic_tags
     WoodworkColumnAccessor.set_logical_type

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,6 +24,7 @@ Release Notes
         * Better warning when accessing column properties before init (:pr:`596`)
         * Update column accessor to work with LatLong columns (:pr:`598`)
         * Add ``set_index`` to WoodworkTableAccessor (:pr:`603`)
+        * Implement ``loc`` and ``iloc`` for WoodworkColumnAccessor (:pr:`613)`
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,7 +24,7 @@ Release Notes
         * Better warning when accessing column properties before init (:pr:`596`)
         * Update column accessor to work with LatLong columns (:pr:`598`)
         * Add ``set_index`` to WoodworkTableAccessor (:pr:`603`)
-        * Implement ``loc`` and ``iloc`` for WoodworkColumnAccessor (:pr:`613)`
+        * Implement ``loc`` and ``iloc`` for WoodworkColumnAccessor (:pr:`613`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from woodwork.accessor_utils import init_series
 from woodwork.exceptions import TypingInfoMismatchWarning
+from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 from woodwork.logical_types import LatLong, Ordinal
 from woodwork.schema_column import (
     _add_semantic_tags,
@@ -16,7 +17,6 @@ from woodwork.schema_column import (
     _validate_metadata
 )
 from woodwork.utils import _get_column_logical_type, _is_valid_latlong_series
-from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 
 
 @pd.api.extensions.register_series_accessor('ww')
@@ -87,7 +87,6 @@ class WoodworkColumnAccessor:
         """
         return _iLocIndexerAccessor(self._series)
 
-    
     @property
     def loc(self):
         """

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -16,6 +16,7 @@ from woodwork.schema_column import (
     _validate_metadata
 )
 from woodwork.utils import _get_column_logical_type, _is_valid_latlong_series
+from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 
 
 @pd.api.extensions.register_series_accessor('ww')
@@ -66,6 +67,50 @@ class WoodworkColumnAccessor:
     def description(self, description):
         _validate_description(description)
         self._schema['description'] = description
+
+    @property
+    def iloc(self):
+        """
+        Integer-location based indexing for selection by position.
+        ``.iloc[]`` is primarily integer position based (from ``0`` to
+        ``length-1`` of the axis), but may also be used with a boolean array.
+
+        Allowed inputs are:
+            An integer, e.g. ``5``.
+            A list or array of integers, e.g. ``[4, 3, 0]``.
+            A slice object with ints, e.g. ``1:7``.
+            A boolean array.
+            A ``callable`` function with one argument (the calling Series, DataFrame
+            or Panel) and that returns valid output for indexing (one of the above).
+            This is useful in method chains, when you don't have a reference to the
+            calling object, but would like to base your selection on some value.
+        """
+        return _iLocIndexerAccessor(self._series)
+
+    
+    @property
+    def loc(self):
+        """
+        Access a group of rows and columns by label(s) or a boolean array.
+        ``.loc[]`` is primarily label based, but may also be used with a
+        boolean array.
+        Allowed inputs are:
+        - A single label, e.g. ``5`` or ``'a'``, (note that ``5`` is
+          interpreted as a *label* of the index, and **never** as an
+          integer position along the index).
+        - A list or array of labels, e.g. ``['a', 'b', 'c']``.
+        - A slice object with labels, e.g. ``'a':'f'``.
+          .. warning:: Note that contrary to usual python slices, **both** the
+              start and the stop are included
+        - A boolean array of the same length as the axis being sliced,
+          e.g. ``[True, False, True]``.
+        - An alignable boolean Series. The index of the key will be aligned before
+          masking.
+        - An alignable Index. The Index of the returned selection will be the input.
+        - A ``callable`` function with one argument (the calling Series or
+          DataFrame) and that returns valid output for indexing (one of the above)
+        """
+        return _locIndexerAccessor(self._series)
 
     @property
     def logical_type(self):

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -91,23 +91,23 @@ class WoodworkColumnAccessor:
     def loc(self):
         """
         Access a group of rows and columns by label(s) or a boolean array.
+
         ``.loc[]`` is primarily label based, but may also be used with a
         boolean array.
+
         Allowed inputs are:
-        - A single label, e.g. ``5`` or ``'a'``, (note that ``5`` is
-          interpreted as a *label* of the index, and **never** as an
-          integer position along the index).
-        - A list or array of labels, e.g. ``['a', 'b', 'c']``.
-        - A slice object with labels, e.g. ``'a':'f'``.
-          .. warning:: Note that contrary to usual python slices, **both** the
-              start and the stop are included
-        - A boolean array of the same length as the axis being sliced,
-          e.g. ``[True, False, True]``.
-        - An alignable boolean Series. The index of the key will be aligned before
-          masking.
-        - An alignable Index. The Index of the returned selection will be the input.
-        - A ``callable`` function with one argument (the calling Series or
-          DataFrame) and that returns valid output for indexing (one of the above)
+            A single label, e.g. ``5`` or ``'a'``, (note that ``5`` is
+            interpreted as a *label* of the index, and **never** as an
+            integer position along the index).
+            A list or array of labels, e.g. ``['a', 'b', 'c']``.
+            A slice object with labels, e.g. ``'a':'f'``.
+            A boolean array of the same length as the axis being sliced,
+            e.g. ``[True, False, True]``.
+            An alignable boolean Series. The index of the key will be aligned before
+            masking.
+            An alignable Index. The Index of the returned selection will be the input.
+            A ``callable`` function with one argument (the calling Series or
+            DataFrame) and that returns valid output for indexing (one of the above)
         """
         return _locIndexerAccessor(self._series)
 

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -183,7 +183,7 @@ class WoodworkColumnAccessor:
                         schema = copy.deepcopy(self._schema)
                         # We don't need to pass dtype from the schema to init
                         del schema['dtype']
-                        result.ww.init(**schema)
+                        result.ww.init(**schema, use_standard_tags=self.use_standard_tags)
                     else:
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \
                             f'{self._schema["logical_type"].pandas_dtype}, and returned dtype, {result.dtype}'

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -75,7 +75,7 @@ class WoodworkColumnAccessor:
         ``.iloc[]`` is primarily integer position based (from ``0`` to
         ``length-1`` of the axis), but may also be used with a boolean array.
 
-        If selection result is a Series, Woodwork typing information will
+        If the selection result is a Series, Woodwork typing information will
         be initialized for the returned Series.
 
         Allowed inputs are:
@@ -98,7 +98,7 @@ class WoodworkColumnAccessor:
         ``.loc[]`` is primarily label based, but may also be used with a
         boolean array.
 
-        If selection result is a Series, Woodwork typing information will
+        If the selection result is a Series, Woodwork typing information will
         be initialized for the returned Series.
 
         Allowed inputs are:

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -75,6 +75,9 @@ class WoodworkColumnAccessor:
         ``.iloc[]`` is primarily integer position based (from ``0`` to
         ``length-1`` of the axis), but may also be used with a boolean array.
 
+        If selection result is a Series, Woodwork typing information will
+        be initialized for the returned Series.
+
         Allowed inputs are:
             An integer, e.g. ``5``.
             A list or array of integers, e.g. ``[4, 3, 0]``.
@@ -90,10 +93,13 @@ class WoodworkColumnAccessor:
     @property
     def loc(self):
         """
-        Access a group of rows and columns by label(s) or a boolean array.
+        Access a group of rows by label(s) or a boolean array.
 
         ``.loc[]`` is primarily label based, but may also be used with a
         boolean array.
+
+        If selection result is a Series, Woodwork typing information will
+        be initialized for the returned Series.
 
         Allowed inputs are:
             A single label, e.g. ``5`` or ``'a'``, (note that ``5`` is

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -69,10 +69,9 @@ class _locIndexerAccessor:
         return _process_selection(selection, self.data)
 
 
-
 def _process_selection(selection, original_data):
     if isinstance(selection, pd.Series) or (ks and isinstance(selection, ks.Series)):
-        col_name = selection.name
+        # col_name = selection.name
         # if isinstance(self.ww_data, ww.DataTable) and set(selection.index.values) == set(self.ww_data.columns):
         #     # return selection as series if series of one row.
         #     return selection

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -81,15 +81,10 @@ def _process_selection(selection, original_data):
         #     logical_type = self.ww_data.logical_types.get(col_name, None)
         #     semantic_tags = self.ww_data.semantic_tags.get(col_name, None)
         # else:
-        logical_type = original_data.ww.logical_type or None
-        semantic_tags = original_data.ww.semantic_tags.copy() or None
-        # if semantic_tags is not None:
-        #     semantic_tags = semantic_tags - {'index'} - {'time_index'}
-        selection.ww.init(logical_type=logical_type,
-                          semantic_tags=semantic_tags,
-                          use_standard_tags=original_data.ww.use_standard_tags,
-                          description=original_data.ww.description,
-                          metadata=copy.deepcopy(original_data.ww.metadata))
+        schema = copy.deepcopy(original_data.ww._schema)
+        del schema['dtype']
+        selection.ww.init(**schema, use_standard_tags=original_data.ww.use_standard_tags)
+
         return selection
     # elif isinstance(selection, pd.DataFrame) or (ks and isinstance(selection, ks.DataFrame)):
     #     return _new_dt_including(self.ww_data, selection)

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -1,3 +1,4 @@
+import copy
 import pandas as pd
 
 import woodwork as ww
@@ -80,14 +81,14 @@ def _process_selection(selection, original_data):
         #     semantic_tags = self.ww_data.semantic_tags.get(col_name, None)
         # else:
         logical_type = original_data.ww.logical_type or None
-        semantic_tags = original_data.ww.semantic_tags or None
+        semantic_tags = original_data.ww.semantic_tags.copy() or None
         # if semantic_tags is not None:
         #     semantic_tags = semantic_tags - {'index'} - {'time_index'}
         selection.ww.init(logical_type=logical_type,
                           semantic_tags=semantic_tags,
                           use_standard_tags=original_data.ww.use_standard_tags,
                           description=original_data.ww.description,
-                          metadata=original_data.ww.metadata)
+                          metadata=copy.deepcopy(original_data.ww.metadata))
         return selection
     # elif isinstance(selection, pd.DataFrame) or (ks and isinstance(selection, ks.DataFrame)):
     #     return _new_dt_including(self.ww_data, selection)

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -85,7 +85,9 @@ def _process_selection(selection, original_data):
         #     semantic_tags = semantic_tags - {'index'} - {'time_index'}
         selection.ww.init(logical_type=logical_type,
                           semantic_tags=semantic_tags,
-                          use_standard_tags=original_data.ww.use_standard_tags)
+                          use_standard_tags=original_data.ww.use_standard_tags,
+                          description=original_data.ww.description,
+                          metadata=original_data.ww.metadata)
         return selection
     # elif isinstance(selection, pd.DataFrame) or (ks and isinstance(selection, ks.DataFrame)):
     #     return _new_dt_including(self.ww_data, selection)

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -1,4 +1,5 @@
 import copy
+
 import pandas as pd
 
 import woodwork as ww

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -390,6 +390,17 @@ def test_series_methods_on_accessor(sample_series):
     pd.testing.assert_series_equal(series, copied_series)
 
 
+def test_series_methods_on_accessor_without_standard_tags(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    series.ww.init(use_standard_tags=False)
+
+    copied_series = series.ww.copy()
+    assert copied_series is not series
+    assert copied_series.ww._schema == series.ww._schema
+    pd.testing.assert_series_equal(series, copied_series)
+
+
 def test_series_methods_on_accessor_returning_series_valid_schema(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series.astype('category')

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -95,36 +95,6 @@ def test_accessor_warnings_accessing_properties_before_init(sample_series):
         sample_series.ww.semantic_tags
 
 
-# def test_datacolumn_init_with_extension_array():
-#     series_categories = pd.Series([1, 2, 3], dtype='category')
-#     extension_categories = pd.Categorical([1, 2, 3])
-
-#     data_col = DataColumn(extension_categories)
-#     series = data_col.to_series()
-#     assert series.equals(series_categories)
-#     assert series.name is None
-#     assert data_col.name is None
-#     assert data_col.dtype == 'category'
-#     assert data_col.logical_type == Categorical
-
-#     series_ints = pd.Series([1, 2, None, 4], dtype='Int64')
-#     extension_ints = pd.arrays.IntegerArray(np.array([1, 2, 3, 4], dtype="int64"), mask=np.array([False, False, True, False]))
-
-#     data_col_with_name = DataColumn(extension_ints, name='extension')
-#     series = data_col_with_name.to_series()
-#     assert series.equals(series_ints)
-#     assert series.name == 'extension'
-#     assert data_col_with_name.name == 'extension'
-
-#     series_strs = pd.Series([1, 2, None, 4], dtype='string')
-
-#     data_col_different_ltype = DataColumn(extension_ints, logical_type='NaturalLanguage')
-#     series = data_col_different_ltype.to_series()
-#     assert series.equals(series_strs)
-#     assert data_col_different_ltype.logical_type == NaturalLanguage
-#     assert data_col_different_ltype.dtype == 'string'
-
-
 def test_accessor_with_alternate_semantic_tags_input(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series.copy().astype('category')

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -57,6 +57,29 @@ def test_iloc_column(sample_series):
     assert sliced.ww.semantic_tags == set()
 
 
+def test_iloc_column_does_not_propagate_changes_to_data(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    logical_type = Categorical
+    semantic_tags = ['tag1', 'tag2']
+    description = 'custom column description'
+    metadata = {'meta_key': 'custom metadata'}
+    series.ww.init(logical_type=logical_type,
+                   semantic_tags=semantic_tags,
+                   description=description,
+                   metadata=metadata,
+                   use_standard_tags=False)
+
+    sliced = series.ww.iloc[2:]
+    series.ww.add_semantic_tags('new_tag')
+    assert sliced.ww.semantic_tags == {'tag1', 'tag2'}
+    assert sliced.ww.semantic_tags is not series.ww.semantic_tags
+
+    series.ww.metadata['new_key'] = 'new_value'
+    assert sliced.ww.metadata == {'meta_key': 'custom metadata'}
+    assert sliced.ww.metadata is not series.ww.metadata
+
+
 def test_loc_column(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series.astype('category')

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -1,17 +1,8 @@
 import pandas as pd
 import pytest
 
-import woodwork as ww
-from woodwork import DataColumn, DataTable
 from woodwork.indexers import _iLocIndexerAccessor
-from woodwork.logical_types import (
-    Categorical,
-    Datetime,
-    Double,
-    EmailAddress,
-    Integer,
-    PhoneNumber
-)
+from woodwork.logical_types import Categorical
 from woodwork.tests.testing_utils import to_pandas, xfail_dask_and_koalas
 from woodwork.utils import import_or_none
 

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -32,12 +32,19 @@ def test_iloc_column(sample_series):
     series = sample_series.astype('category')
     logical_type = Categorical
     semantic_tags = ['tag1', 'tag2']
-    series.ww.init(logical_type=logical_type, semantic_tags=semantic_tags)
+    description = 'custom column description'
+    metadata = {'meta_key': 'custom metadata'}
+    series.ww.init(logical_type=logical_type,
+                   semantic_tags=semantic_tags,
+                   description=description,
+                   metadata=metadata)
 
     sliced = series.ww.iloc[2:]
     assert sliced.name == "sample_series"
     assert sliced.ww.logical_type == logical_type
     assert sliced.ww.semantic_tags == {'category', 'tag1', 'tag2'}
+    assert sliced.ww.description == description
+    assert sliced.ww.metadata == metadata
     pd.testing.assert_series_equal(to_pandas(sliced), to_pandas(series.iloc[2:]))
 
     assert series.ww.iloc[0] == 'a'

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -1,0 +1,163 @@
+import pandas as pd
+import pytest
+
+import woodwork as ww
+from woodwork import DataColumn, DataTable
+from woodwork.indexers import _iLocIndexerAccessor
+from woodwork.logical_types import (
+    Categorical,
+    Datetime,
+    Double,
+    EmailAddress,
+    Integer,
+    PhoneNumber
+)
+from woodwork.tests.testing_utils import to_pandas, xfail_dask_and_koalas
+from woodwork.utils import import_or_none
+
+dd = import_or_none('dask.dataframe')
+
+
+def test_iLocIndexer_class_error(sample_df_dask, sample_series_dask):
+    with pytest.raises(TypeError, match="iloc is not supported for Dask DataFrames"):
+        _iLocIndexerAccessor(sample_df_dask)
+
+    with pytest.raises(TypeError, match="iloc is not supported for Dask Series"):
+        _iLocIndexerAccessor(sample_series_dask)
+
+
+# def test_iLocIndexer_class(sample_df):
+#     if dd and isinstance(sample_df, dd.DataFrame):
+#         pytest.xfail('iloc is not supported with Dask inputs')
+#     dt = ww.DataTable(sample_df)
+#     ind = _iLocIndexer(dt)
+#     pd.testing.assert_frame_equal(to_pandas(ind.underlying_data), to_pandas(sample_df))
+#     pd.testing.assert_frame_equal(to_pandas(ind[1:2].to_dataframe()), to_pandas(sample_df.iloc[1:2]))
+#     assert ind[0, 0] == 0
+
+
+def test_iloc_column(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    logical_type = Categorical
+    semantic_tags = ['tag1', 'tag2']
+    series.ww.init(logical_type=logical_type, semantic_tags=semantic_tags)
+
+    sliced = series.ww.iloc[2:]
+    assert sliced.name == "sample_series"
+    assert sliced.ww.logical_type == logical_type
+    assert sliced.ww.semantic_tags == {'category', 'tag1', 'tag2'}
+    pd.testing.assert_series_equal(to_pandas(sliced), to_pandas(series.iloc[2:]))
+
+    assert series.ww.iloc[0] == 'a'
+
+    series = sample_series.astype('category')
+    series.ww.init(use_standard_tags=False)
+    sliced = series.ww.iloc[:]
+    assert sliced.name
+    assert sliced.ww.logical_type == logical_type
+    assert sliced.ww.semantic_tags == set()
+
+
+def test_loc_column(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    series = sample_series.astype('category')
+    logical_type = Categorical
+    semantic_tags = ['tag1', 'tag2']
+    series.ww.init(logical_type=logical_type, semantic_tags=semantic_tags)
+
+    sliced = series.ww.loc[2:]
+    assert sliced.name == "sample_series"
+    assert sliced.ww.logical_type == logical_type
+    assert sliced.ww.semantic_tags == {'category', 'tag1', 'tag2'}
+    pd.testing.assert_series_equal(to_pandas(sliced), to_pandas(series.loc[2:]))
+
+    assert series.ww.loc[0] == 'a'
+
+    series = sample_series.astype('category')
+    series.ww.init(use_standard_tags=False)
+    sliced = series.ww.loc[:]
+    assert sliced.name
+    assert sliced.ww.logical_type == logical_type
+    assert sliced.ww.semantic_tags == set()
+
+
+# def test_iloc_indices_column(sample_df):
+#     if dd and isinstance(sample_df, dd.DataFrame):
+#         pytest.xfail('iloc is not supported with Dask inputs')
+#     dt_indices = DataTable(sample_df, index='id', time_index='signup_date')
+#     sliced_index = dt_indices.iloc[:, 0]
+#     assert sliced_index.semantic_tags == {'numeric'}
+
+#     sliced_time_index = dt_indices.iloc[:, 5]
+#     assert sliced_time_index.semantic_tags == set()
+
+
+# def test_iloc_with_properties(sample_df):
+#     if dd and isinstance(sample_df, dd.DataFrame):
+#         pytest.xfail('iloc is not supported with Dask inputs')
+#     semantic_tags = {
+#         'full_name': 'tag1',
+#         'email': ['tag2'],
+#         'phone_number': ['tag3', 'tag2'],
+#         'signup_date': {'secondary_time_index'},
+#     }
+#     logical_types = {
+#         'full_name': Categorical,
+#         'email': EmailAddress,
+#         'phone_number': PhoneNumber,
+#         'age': Double,
+#     }
+#     dt = DataTable(sample_df, logical_types=logical_types, semantic_tags=semantic_tags)
+#     sliced = dt.iloc[1:3, 1:3]
+#     assert sliced.shape == (2, 2)
+
+#     assert sliced.semantic_tags == {'full_name': {'category', 'tag1'}, 'email': {'tag2'}}
+#     assert sliced.logical_types == {'full_name': Categorical, 'email': EmailAddress}
+#     assert sliced.index is None
+
+#     dt_no_std_tags = DataTable(sample_df, logical_types=logical_types, use_standard_tags=False)
+#     sliced = dt_no_std_tags.iloc[:, [0, 5]]
+#     assert sliced.semantic_tags == {'id': set(), 'signup_date': set()}
+#     assert sliced.logical_types == {'id': Integer, 'signup_date': Datetime}
+#     assert sliced.index is None
+
+
+# def test_iloc_dimensionality(sample_df):
+#     if dd and isinstance(sample_df, dd.DataFrame):
+#         pytest.xfail('iloc is not supported with Dask inputs')
+#     semantic_tags = {
+#         'full_name': 'tag1',
+#         'email': ['tag2'],
+#         'phone_number': ['tag3', 'tag2'],
+#         'signup_date': {'secondary_time_index'},
+#     }
+#     logical_types = {
+#         'full_name': Categorical,
+#         'email': EmailAddress,
+#         'phone_number': PhoneNumber,
+#         'age': Double,
+#     }
+#     dt = DataTable(sample_df, logical_types=logical_types, semantic_tags=semantic_tags)
+
+#     sliced_series_row = dt.iloc[1]
+#     assert isinstance(sliced_series_row, pd.Series)
+#     assert set(sliced_series_row.index) == set(sample_df.columns)
+#     assert sliced_series_row.name == 1
+
+#     sliced_series_col = dt.iloc[:, 1]
+#     assert sliced_series_col.logical_type == Categorical
+#     assert sliced_series_col.semantic_tags == {'tag1', 'category'}
+#     assert sliced_series_col.name == 'full_name'
+
+
+# def test_iloc_indices(sample_df):
+#     if dd and isinstance(sample_df, dd.DataFrame):
+#         pytest.xfail('iloc is not supported with Dask inputs')
+#     dt_with_index = DataTable(sample_df, index='id')
+#     assert dt_with_index.iloc[:, [0, 5]].index == 'id'
+#     assert dt_with_index.iloc[:, [1, 2]].index is None
+
+#     dt_with_time_index = DataTable(sample_df, time_index='signup_date')
+#     assert dt_with_time_index.iloc[:, [0, 5]].time_index == 'signup_date'
+#     assert dt_with_time_index.iloc[:, [1, 2]].index is None


### PR DESCRIPTION
- Implement loc and iloc for Column Accessor
- Closes #594 

This PR adds `.loc` and `.iloc` to the ColumnAccessor along with corresponding unit tests for these methods. Code and tests that will be needed for the table implementation of `loc` and `iloc` have been left in place but commented out.