### PR TITLE
Implements iloc and loc for WoodworkTableAccessor

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -12,7 +12,9 @@ WoodworkTableAccessor
     WoodworkTableAccessor
     WoodworkTableAccessor.describe
     WoodworkTableAccessor.describe_dict
+    WoodworkTableAccessor.iloc
     WoodworkTableAccessor.init
+    WoodworkTableAccessor.loc
     WoodworkTableAccessor.mutual_information_dict
     WoodworkTableAccessor.mutual_information
     WoodworkTableAccessor.select

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,6 +26,7 @@ Release Notes
         * Add ``set_index`` to WoodworkTableAccessor (:pr:`603`)
         * Implement ``loc`` and ``iloc`` for WoodworkColumnAccessor (:pr:`613`)
         * Add ``set_time_index`` to WoodworkTableAccessor (:pr:`612`)
+        * Implement ``loc`` and ``iloc`` for WoodworkTableAccessor (:pr:`618`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -88,6 +88,8 @@ class WoodworkColumnAccessor:
             This is useful in method chains, when you don't have a reference to the
             calling object, but would like to base your selection on some value.
         """
+        if self._schema is None:
+            _raise_init_error()
         return _iLocIndexerAccessor(self._series)
 
     @property
@@ -115,6 +117,8 @@ class WoodworkColumnAccessor:
             A ``callable`` function with one argument (the calling Series or
             DataFrame) and that returns valid output for indexing (one of the above)
         """
+        if self._schema is None:
+            _raise_init_error()
         return _locIndexerAccessor(self._series)
 
     @property

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -73,13 +73,12 @@ class _locIndexerAccessor:
 
 def _process_selection(selection, original_data):
     if isinstance(selection, pd.Series) or (ks and isinstance(selection, ks.Series)):
-        # if isinstance(self.ww_data, ww.DataTable) and set(selection.index.values) == set(self.ww_data.columns):
-        #     # Selecting a single row from a DataFrame, returned as Series
-        #     return selection
-        col_name = selection.name
+        if isinstance(original_data, pd.DataFrame) and set(selection.index.values) == set(original_data.columns):
+            # Selecting a single row from a DataFrame, returned as Series without Woodwork initialized
+            return selection
         if isinstance(original_data, pd.DataFrame):
             # Selecting a single column from a DataFrame
-            schema = original_data.ww.schema.columns[col_name]
+            schema = original_data.ww.schema.columns[selection.name]
             schema['semantic_tags'] = schema['semantic_tags'] - {'index'} - {'time_index'}
         else:
             # Selecting a new Series from an existing Series
@@ -88,9 +87,12 @@ def _process_selection(selection, original_data):
         selection.ww.init(**schema, use_standard_tags=original_data.ww.use_standard_tags)
 
         return selection
-    # elif isinstance(selection, pd.DataFrame) or (ks and isinstance(selection, ks.DataFrame)):
-    #     # Selecting a new DataFrame from an existing DataFrame
-    #     return _new_dt_including(self.ww_data, selection)
+    elif isinstance(selection, pd.DataFrame) or (ks and isinstance(selection, ks.DataFrame)):
+        # Selecting a new DataFrame from an existing DataFrame
+        schema = original_data.ww.schema
+        new_schema = schema._get_subset_schema(list(selection.columns))
+        selection.ww.init(schema=new_schema)
+        return selection
     else:
-        # Selecting a singular value
+        # Selecting a single value
         return selection

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -73,21 +73,24 @@ class _locIndexerAccessor:
 
 def _process_selection(selection, original_data):
     if isinstance(selection, pd.Series) or (ks and isinstance(selection, ks.Series)):
-        # col_name = selection.name
         # if isinstance(self.ww_data, ww.DataTable) and set(selection.index.values) == set(self.ww_data.columns):
-        #     # return selection as series if series of one row.
+        #     # Selecting a single row from a DataFrame, returned as Series
         #     return selection
-        # if isinstance(self.ww_data, ww.DataTable):
-        #     logical_type = self.ww_data.logical_types.get(col_name, None)
-        #     semantic_tags = self.ww_data.semantic_tags.get(col_name, None)
-        # else:
-        schema = copy.deepcopy(original_data.ww._schema)
+        col_name = selection.name
+        if isinstance(original_data, pd.DataFrame):
+            # Selecting a single column from a DataFrame
+            schema = original_data.ww.schema.columns[col_name]
+            schema['semantic_tags'] = schema['semantic_tags'] - {'index'} - {'time_index'}
+        else:
+            # Selecting a new Series from an existing Series
+            schema = copy.deepcopy(original_data.ww._schema)
         del schema['dtype']
         selection.ww.init(**schema, use_standard_tags=original_data.ww.use_standard_tags)
 
         return selection
     # elif isinstance(selection, pd.DataFrame) or (ks and isinstance(selection, ks.DataFrame)):
+    #     # Selecting a new DataFrame from an existing DataFrame
     #     return _new_dt_including(self.ww_data, selection)
     else:
-        # singular value
+        # Selecting a singular value
         return selection

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -76,7 +76,7 @@ def _process_selection(selection, original_data):
         if isinstance(original_data, pd.DataFrame) and set(selection.index.values) == set(original_data.columns):
             # Selecting a single row from a DataFrame, returned as Series without Woodwork initialized
             schema = None
-        elif isinstance(original_data, pd.DataFrame) and set(selection.index.values) != set(original_data.columns):
+        elif isinstance(original_data, pd.DataFrame):
             # Selecting a single column from a DataFrame
             schema = original_data.ww.schema.columns[selection.name]
             schema['semantic_tags'] = schema['semantic_tags'] - {'index'} - {'time_index'}

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -7,6 +7,7 @@ from woodwork.exceptions import (
     ParametersIgnoredWarning,
     TypingInfoMismatchWarning
 )
+from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 from woodwork.logical_types import Datetime
 from woodwork.schema import Schema
 from woodwork.statistics_utils import (
@@ -140,6 +141,55 @@ class WoodworkTableAccessor:
 
     def __repr__(self):
         return repr(self._schema)
+
+    @property
+    def iloc(self):
+        """
+        Integer-location based indexing for selection by position.
+        ``.iloc[]`` is primarily integer position based (from ``0`` to
+        ``length-1`` of the axis), but may also be used with a boolean array.
+
+        If the selection result is a Series, Woodwork typing information will
+        be initialized for the returned Series.
+
+        Allowed inputs are:
+            An integer, e.g. ``5``.
+            A list or array of integers, e.g. ``[4, 3, 0]``.
+            A slice object with ints, e.g. ``1:7``.
+            A boolean array.
+            A ``callable`` function with one argument (the calling Series, DataFrame
+            or Panel) and that returns valid output for indexing (one of the above).
+            This is useful in method chains, when you don't have a reference to the
+            calling object, but would like to base your selection on some value.
+        """
+        return _iLocIndexerAccessor(self._dataframe)
+
+    @property
+    def loc(self):
+        """
+        Access a group of rows by label(s) or a boolean array.
+
+        ``.loc[]`` is primarily label based, but may also be used with a
+        boolean array.
+
+        If the selection result is a Series, Woodwork typing information will
+        be initialized for the returned Series.
+
+        Allowed inputs are:
+            A single label, e.g. ``5`` or ``'a'``, (note that ``5`` is
+            interpreted as a *label* of the index, and **never** as an
+            integer position along the index).
+            A list or array of labels, e.g. ``['a', 'b', 'c']``.
+            A slice object with labels, e.g. ``'a':'f'``.
+            A boolean array of the same length as the axis being sliced,
+            e.g. ``[True, False, True]``.
+            An alignable boolean Series. The index of the key will be aligned before
+            masking.
+            An alignable Index. The Index of the returned selection will be the input.
+            A ``callable`` function with one argument (the calling Series or
+            DataFrame) and that returns valid output for indexing (one of the above)
+        """
+        return _locIndexerAccessor(self._dataframe)
 
     @property
     def schema(self):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -131,7 +131,7 @@ class WoodworkTableAccessor:
             If the method is present on DataFrame, uses that method.
         '''
         if self._schema is None:
-            raise AttributeError("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
+            _raise_init_error()
         if hasattr(self._schema, attr):
             return self._make_schema_call(attr)
         if hasattr(self._dataframe, attr):
@@ -162,6 +162,8 @@ class WoodworkTableAccessor:
             This is useful in method chains, when you don't have a reference to the
             calling object, but would like to base your selection on some value.
         """
+        if self._schema is None:
+            _raise_init_error()
         return _iLocIndexerAccessor(self._dataframe)
 
     @property
@@ -189,6 +191,8 @@ class WoodworkTableAccessor:
             A ``callable`` function with one argument (the calling Series or
             DataFrame) and that returns valid output for indexing (one of the above)
         """
+        if self._schema is None:
+            _raise_init_error()
         return _locIndexerAccessor(self._dataframe)
 
     @property
@@ -524,3 +528,7 @@ def _get_invalid_schema_message(dataframe, schema):
             return 'Index mismatch between DataFrame and typing information'
         elif not dataframe[schema.index].is_unique:
             return 'Index column is not unique'
+
+
+def _raise_init_error():
+    raise AttributeError("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -149,8 +149,8 @@ class WoodworkTableAccessor:
         ``.iloc[]`` is primarily integer position based (from ``0`` to
         ``length-1`` of the axis), but may also be used with a boolean array.
 
-        If the selection result is a Series, Woodwork typing information will
-        be initialized for the returned Series.
+        If the selection result is a DataFrame or Series, Woodwork typing
+        information will be initialized for the returned object when possible.
 
         Allowed inputs are:
             An integer, e.g. ``5``.
@@ -172,8 +172,8 @@ class WoodworkTableAccessor:
         ``.loc[]`` is primarily label based, but may also be used with a
         boolean array.
 
-        If the selection result is a Series, Woodwork typing information will
-        be initialized for the returned Series.
+        If the selection result is a DataFrame or Series, Woodwork typing
+        information will be initialized for the returned object when possible.
 
         Allowed inputs are:
             A single label, e.g. ``5`` or ``'a'``, (note that ``5`` is

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -44,6 +44,28 @@ def test_locIndexer_class(sample_df):
     assert ind[0, 'id'] == 0
 
 
+def test_error_before_table_init(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    error_message = "Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init"
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_df.ww.iloc[:, :]
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_df.ww.loc[:, :]
+
+
+def test_error_before_column_init(sample_series):
+    xfail_dask_and_koalas(sample_series)
+    error_message = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_series.ww.iloc[:]
+
+    with pytest.raises(AttributeError, match=error_message):
+        sample_series.ww.loc[:]
+
+
 def test_iloc_column(sample_series):
     xfail_dask_and_koalas(sample_series)
     series = sample_series.astype('category')

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from woodwork.indexers import _iLocIndexerAccessor
+from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 from woodwork.logical_types import Categorical
 from woodwork.tests.testing_utils import to_pandas, xfail_dask_and_koalas
 from woodwork.utils import import_or_none
@@ -17,14 +17,22 @@ def test_iLocIndexer_class_error(sample_df_dask, sample_series_dask):
         _iLocIndexerAccessor(sample_series_dask)
 
 
-# def test_iLocIndexer_class(sample_df):
-#     if dd and isinstance(sample_df, dd.DataFrame):
-#         pytest.xfail('iloc is not supported with Dask inputs')
-#     dt = ww.DataTable(sample_df)
-#     ind = _iLocIndexer(dt)
-#     pd.testing.assert_frame_equal(to_pandas(ind.underlying_data), to_pandas(sample_df))
-#     pd.testing.assert_frame_equal(to_pandas(ind[1:2].to_dataframe()), to_pandas(sample_df.iloc[1:2]))
-#     assert ind[0, 0] == 0
+def test_iLocIndexer_class(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    # if dd and isinstance(sample_df, dd.DataFrame):
+    #     pytest.xfail('iloc is not supported with Dask inputs')
+    ind = _iLocIndexerAccessor(sample_df)
+    pd.testing.assert_frame_equal(to_pandas(ind.data), to_pandas(sample_df))
+    pd.testing.assert_frame_equal(to_pandas(ind[1:2]), to_pandas(sample_df.iloc[1:2]))
+    assert ind[0, 0] == 0
+
+
+def test_locIndexer_class(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    ind = _locIndexerAccessor(sample_df)
+    pd.testing.assert_frame_equal(to_pandas(ind.data), to_pandas(sample_df))
+    pd.testing.assert_frame_equal(to_pandas(ind[1:2]), to_pandas(sample_df.loc[1:2]))
+    assert ind[0, 'id'] == 0
 
 
 def test_iloc_column(sample_series):
@@ -103,15 +111,28 @@ def test_loc_column(sample_series):
     assert sliced.ww.semantic_tags == set()
 
 
-# def test_iloc_indices_column(sample_df):
-#     if dd and isinstance(sample_df, dd.DataFrame):
-#         pytest.xfail('iloc is not supported with Dask inputs')
-#     dt_indices = DataTable(sample_df, index='id', time_index='signup_date')
-#     sliced_index = dt_indices.iloc[:, 0]
-#     assert sliced_index.semantic_tags == {'numeric'}
+def test_iloc_indices_column(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    # if dd and isinstance(sample_df, dd.DataFrame):
+    #     pytest.xfail('iloc is not supported with Dask inputs')
+    sample_df.ww.init(index='id', time_index='signup_date')
+    sliced_index = sample_df.ww.iloc[:, 0]
+    assert sliced_index.ww.semantic_tags == {'numeric'}
 
-#     sliced_time_index = dt_indices.iloc[:, 5]
-#     assert sliced_time_index.semantic_tags == set()
+    sliced_time_index = sample_df.ww.iloc[:, 5]
+    assert sliced_time_index.ww.semantic_tags == set()
+
+
+def test_loc_indices_column(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    # if dd and isinstance(sample_df, dd.DataFrame):
+    #     pytest.xfail('iloc is not supported with Dask inputs')
+    sample_df.ww.init(index='id', time_index='signup_date')
+    sliced_index = sample_df.ww.loc[:, 'id']
+    assert sliced_index.ww.semantic_tags == {'numeric'}
+
+    sliced_time_index = sample_df.ww.loc[:, 'signup_date']
+    assert sliced_time_index.ww.semantic_tags == set()
 
 
 # def test_iloc_with_properties(sample_df):


### PR DESCRIPTION
Closes #539

Implements `iloc` and `loc` for WoodworkTableAccessor, returning initialized dataframes or series when possible.