### PR TITLE
Update set_types to also set logical types

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -19,6 +19,7 @@ WoodworkTableAccessor
     WoodworkTableAccessor.mutual_information
     WoodworkTableAccessor.select
     WoodworkTableAccessor.set_index
+    WoodworkTableAccessor.set_types
 
 WoodworkColumnAccessor
 ======================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -27,6 +27,7 @@ Release Notes
         * Implement ``loc`` and ``iloc`` for WoodworkColumnAccessor (:pr:`613`)
         * Add ``set_time_index`` to WoodworkTableAccessor (:pr:`612`)
         * Implement ``loc`` and ``iloc`` for WoodworkTableAccessor (:pr:`618`)
+        * Allow updating logical types with ``set_types`` and make relevant DataFrame changes (:pr:`619`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -155,18 +155,17 @@ class Schema(object):
         return None
 
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
-        """Update the semantic tags for any columns names in the provided types dictionary,
-        updating the Woodwork typing information for the DataFrame. Any columns whose Logical Type
-        or semantic tags are updated will have its existing semantic tags reset.
+        """Update the logical tpye and semantic tags for any columns names in the provided types dictionaries,
+        updating the Schema at those columns.
 
         Args:
-            # --> add ltypes param back in
+            logical_types (dict[str -> LogicalType], optional): A dictionary defining the new logical types for the
+                specified columns.
             semantic_tags (dict[str -> str/list/set], optional): A dictionary defining the new semantic_tags for the
                 specified columns.
             retain_index_tags (bool, optional): If True, will retain any index or time_index
-                semantic tags set on the column. If False, will replace all semantic tags. Defaults to
-                True.
-
+                semantic tags set on the column. If False, will replace all semantic tags any time a column's
+                semantic tags or logical type changes. Defaults to True.
         """
         logical_types = logical_types or {}
         _check_logical_types(self.columns.keys(), logical_types, require_all_cols=False)

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -176,7 +176,7 @@ class Schema(object):
 
         # Set logical types
         # --> we should confirm they're ltype objects and not strings - but probably below
-        for col_name, column in self.columns.items():
+        for col_name in (logical_types.keys() | semantic_tags.keys()):
             if col_name not in logical_types and col_name not in semantic_tags:
                 continue
 

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -155,7 +155,7 @@ class Schema(object):
         return None
 
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
-        """Update the logical tpye and semantic tags for any columns names in the provided types dictionaries,
+        """Update the logical type and semantic tags for any columns names in the provided types dictionaries,
         updating the Schema at those columns.
 
         Args:

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -180,19 +180,18 @@ class Schema(object):
             new_logical_type = logical_types.get(col_name)
             if new_logical_type is not None:
                 self.columns[col_name]['logical_type'] = new_logical_type
-                ltype_update_tags = _reset_semantic_tags(new_logical_type.standard_tags, self.use_standard_tags)
 
             # Get new semantic tags, removing existing tags
             new_semantic_tags = semantic_tags.get(col_name)
-            if new_semantic_tags is not None:
+            if new_semantic_tags is None:
+                new_semantic_tags = _reset_semantic_tags(new_logical_type.standard_tags, self.use_standard_tags)
+            else:
                 new_semantic_tags = _set_semantic_tags(new_semantic_tags,
                                                        self.logical_types[col_name].standard_tags,
                                                        self.use_standard_tags)
                 _validate_not_setting_index_tags(new_semantic_tags, col_name)
 
             # Update the tags for the Schema
-            if new_semantic_tags is None:
-                new_semantic_tags = ltype_update_tags
             self.columns[col_name]['semantic_tags'] = new_semantic_tags
 
             if retain_index_tags and 'index' in original_tags:

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -177,7 +177,6 @@ class Schema(object):
             original_tags = self.semantic_tags[col_name]
 
             # Update Logical Type for the Schema, getting new semantic tags
-            ltype_update_tags = original_tags
             new_logical_type = logical_types.get(col_name)
             if new_logical_type is not None:
                 self.columns[col_name]['logical_type'] = new_logical_type
@@ -516,6 +515,10 @@ def _check_semantic_tags(column_names, semantic_tags):
     if cols_not_found:
         raise LookupError('semantic_tags contains columns that do not exist: '
                           f'{sorted(list(cols_not_found))}')
+
+    for col_name, col_tags in semantic_tags.items():
+        if not isinstance(col_tags, (str, list, set)):
+            raise TypeError(f"semantic_tags for {col_name} must be a string, set or list")
 
 
 def _check_column_descriptions(column_names, column_descriptions):

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -7,7 +7,6 @@ import woodwork as ww
 from woodwork.schema_column import (
     _add_semantic_tags,
     _get_column_dict,
-    _get_column_tags,
     _remove_semantic_tags,
     _reset_semantic_tags,
     _set_semantic_tags
@@ -160,7 +159,7 @@ class Schema(object):
         updating the Woodwork typing information for the DataFrame.
 
         Args:
-            # --> add ltypes param back in 
+            # --> add ltypes param back in
             semantic_tags (dict[str -> str/list/set], optional): A dictionary defining the new semantic_tags for the
                 specified columns.
             retain_index_tags (bool, optional): If True, will retain any index or time_index
@@ -497,6 +496,12 @@ def _check_logical_types(column_names, logical_types, require_all_cols=True):
     if cols_not_found_in_ltypes and require_all_cols:
         raise LookupError(f'logical_types is missing columns that are present in '
                           f'Schema: {sorted(list(cols_not_found_in_ltypes))}')
+
+    for col_name, logical_type in logical_types.items():
+        if _get_ltype_class(logical_type) not in ww.type_system.registered_types:
+            raise TypeError("Logical Types must be of the LogicalType class "
+                            "and registered in Woodwork's type system. "
+                            f"{logical_type} does not meet that criteria.")
 
 
 def _check_semantic_tags(column_names, semantic_tags):

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -149,6 +149,7 @@ def _set_semantic_tags(semantic_tags, standard_tags, use_standard_tags):
         standard_tags (set): Set of standard tags for the column logical type
         use_standard_tags (bool): If True, retain standard tags after reset
     """
+    # --> use _get_semantic_tags here
     semantic_tags = _convert_input_to_set(semantic_tags)
 
     if use_standard_tags:

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -149,7 +149,6 @@ def _set_semantic_tags(semantic_tags, standard_tags, use_standard_tags):
         standard_tags (set): Set of standard tags for the column logical type
         use_standard_tags (bool): If True, retain standard tags after reset
     """
-    # --> use _get_semantic_tags here
     semantic_tags = _convert_input_to_set(semantic_tags)
 
     if use_standard_tags:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -218,6 +218,13 @@ class WoodworkTableAccessor:
             _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
 
+    def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
+        # --> add dosctring
+        pass
+        # --> set schema
+        # go through changed ltypes and update dtype if necessary
+        # if index has been reset, reset underlying index via _set_underlying_index
+
     def select(self, include):
         """Create a DataFrame with Woodowork typing information initialized
         that includes only columns whose Logical Type and semantic tags are

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -219,9 +219,19 @@ class WoodworkTableAccessor:
         self._set_underlying_index()
 
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
-        # --> add dosctring
+        """Update the logical tpye and semantic tags for any columns names in the provided types dictionaries,
+        updating the Woodwork typing information for the DataFrame.
+
+        Args:
+            logical_types (dict[str -> str], optional): A dictionary defining the new logical types for the
+                specified columns.
+            semantic_tags (dict[str -> str/list/set], optional): A dictionary defining the new semantic_tags for the
+                specified columns.
+            retain_index_tags (bool, optional): If True, will retain any index or time_index
+                semantic tags set on the column. If False, will replace all semantic tags any time a column's
+                semantic tags or logical type changes. Defaults to True.
+        """
         logical_types = logical_types or {}
-        # --> this is a little ackward bc we definitely dont want to infer
         logical_types = {col_name: _get_column_logical_type(None, ltype, col_name) for col_name, ltype in logical_types.items()}
 
         original_index = self._schema.index

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -235,7 +235,7 @@ class WoodworkTableAccessor:
             if updated_series is not series:
                 self._dataframe[col_name] = updated_series
 
-        # if index has been reset, reset underlying index via _set_underlying_index
+        # if index has been reset, reset underlying index of DataFrame
         if original_index is not None and self._schema.index is None:
             self._set_underlying_index()
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -796,8 +796,8 @@ def test_ordinal_with_incomplete_ranking(sample_series):
     with pytest.raises(ValueError, match=error_msg):
         schema_df.ww.init(logical_types={'sample_series': ordinal_incomplete_order})
 
+    schema_df.ww.init()
     with pytest.raises(ValueError, match=error_msg):
-        schema_df.ww.init()
         schema_df.ww.set_types(logical_types={'sample_series': ordinal_incomplete_order})
 
 
@@ -1360,7 +1360,7 @@ def test_accessor_set_index_errors(sample_df):
 def test_set_types(sample_df):
     xfail_dask_and_koalas(sample_df)
 
-    sample_df.ww.init(index='full_name')
+    sample_df.ww.init(index='full_name', time_index='signup_date')
 
     original_df = sample_df.ww.copy()
 
@@ -1371,8 +1371,11 @@ def test_set_types(sample_df):
     sample_df.ww.set_types(logical_types={'is_registered': 'Integer'})
     assert sample_df['is_registered'].dtype == 'Int64'
 
-    sample_df.ww.set_types(logical_types={'full_name': 'Categorical'}, retain_index_tags=False)
-    assert type(sample_df.index) == pd.RangeIndex
+    sample_df.ww.set_types(semantic_tags={'signup_date': ['new_tag']},
+                           logical_types={'full_name': 'Categorical'},
+                           retain_index_tags=False)
+    assert sample_df.ww.index is None
+    assert sample_df.ww.time_index is None
 
 
 def test_set_types_errors(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1357,6 +1357,12 @@ def test_set_types(sample_df):
 
     sample_df.ww.init(index='full_name')
 
+    original_df = sample_df.ww.copy()
+
+    sample_df.ww.set_types()
+    assert original_df.ww.schema == sample_df.ww.schema
+    pd.testing.assert_frame_equal(to_pandas(original_df), to_pandas(sample_df))
+
     sample_df.ww.set_types(logical_types={'is_registered': 'Integer'})
     assert sample_df['is_registered'].dtype == 'Int64'
 
@@ -1373,13 +1379,13 @@ def test_set_types_errors(sample_df):
     with pytest.raises(ValueError, match=error):
         sample_df.ww.set_types(logical_types={'id': 'invalid'})
 
-    error = f'Error converting datatype for email from type string ' \
-        f'to type float64. Please confirm the underlying data is consistent with ' \
-        f'logical type Double.'
+    error = 'Error converting datatype for email from type string ' \
+        'to type float64. Please confirm the underlying data is consistent with ' \
+        'logical type Double.'
     with pytest.raises(TypeConversionError, match=error):
         sample_df.ww.set_types(logical_types={'email': 'Double'})
 
-    error = re.escape(f"Cannot add 'index' tag directly for column email. To set a column as the index, "
+    error = re.escape("Cannot add 'index' tag directly for column email. To set a column as the index, "
                       "use DataFrame.ww.set_index() instead.")
     with pytest.raises(ValueError, match=error):
         sample_df.ww.set_types(semantic_tags={'email': 'index'})

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -352,11 +352,6 @@ def test_set_logical_types_empty(sample_column_names, sample_inferred_logical_ty
                     index='full_name',
                     semantic_tags=semantic_tags, use_standard_tags=True)
 
-    # If the tags for a column are None, nothing should change
-    schema.set_types(semantic_tags={'full_name': None}, retain_index_tags=False)
-    assert schema.logical_types['full_name'] == NaturalLanguage
-    assert schema.semantic_tags['full_name'] == {'index', 'tag1'}
-
     # An empty set should reset the tags
     schema.set_types(semantic_tags={'full_name': set()}, retain_index_tags=False)
     assert schema.logical_types['full_name'] == NaturalLanguage
@@ -385,6 +380,10 @@ def test_set_logical_types_invalid_data(sample_column_names, sample_inferred_log
                      "<class 'int'> does not meet that criteria.")
     with pytest.raises(TypeError, match=error_message):
         schema.set_types(logical_types={'age': int})
+
+    error_message = "semantic_tags for full_name must be a string, set or list"
+    with pytest.raises(TypeError, match=error_message):
+        schema.set_types(semantic_tags={'full_name': None})
 
 
 def test_set_types_combined(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -343,11 +343,18 @@ def test_set_logical_types(sample_column_names, sample_inferred_logical_types):
     assert schema.semantic_tags['signup_date'] == {'secondary_time_index'}
 
 
-# def test_set_logical_types_invalid_data(sample_df):
-#     dt = DataTable(sample_df)
-#     error_message = re.escape("logical_types contains columns that are not present in dataframe: ['birthday']")
-#     with pytest.raises(LookupError, match=error_message):
-#         dt.set_types(logical_types={'birthday': Double})
+def test_set_logical_types_invalid_data(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types)
+
+    error_message = re.escape("logical_types contains columns that are not present in Schema: ['birthday']")
+    with pytest.raises(LookupError, match=error_message):
+        schema.set_types(logical_types={'birthday': Double})
+
+    error_message = ("Logical Types must be of the LogicalType class "
+                     "and registered in Woodwork's type system. "
+                     "Double does not meet that criteria.")
+    with pytest.raises(TypeError, match=error_message):
+        schema.set_types(logical_types={'id': 'Double'})
 
     # --> test in table accessor along with correct dtype change to dataframe
     # error_message = "Invalid logical type specified for 'age'"

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -380,10 +380,11 @@ def test_set_logical_types_invalid_data(sample_column_names, sample_inferred_log
     with pytest.raises(TypeError, match=error_message):
         schema.set_types(logical_types={'id': 'Double'})
 
-    # --> test in table accessor along with correct dtype change to dataframe
-    # error_message = "Invalid logical type specified for 'age'"
-    # with pytest.raises(TypeError, match=error_message):
-    #     dt.set_types(logical_types={'age': int})
+    error_message = ("Logical Types must be of the LogicalType class "
+                     "and registered in Woodwork's type system. "
+                     "<class 'int'> does not meet that criteria.")
+    with pytest.raises(TypeError, match=error_message):
+        schema.set_types(logical_types={'age': int})
 
 
 def test_set_types_combined(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -359,7 +359,7 @@ def test_set_logical_types_of_indices(sample_column_names, sample_inferred_logic
     pass
 
 
-def test_set_types_combined(sample_df):
+def test_set_types_combined(sample_column_names, sample_inferred_logical_types):
     # test that the resetting of indices when ltype changes doesnt touch index??
     semantic_tags = {
         'id': 'tag1',
@@ -374,13 +374,33 @@ def test_set_types_combined(sample_df):
     schema.set_types(semantic_tags={'id': 'new_tag', 'age': 'new_tag', 'email': 'new_tag'},
                      logical_types={'id': Double, 'age': Double, 'email': Categorical})
 
-    # replaces existing tags and keeps index
     assert schema.semantic_tags['id'] == {'new_tag', 'index'}
-    # keeps standard tag
     assert schema.semantic_tags['age'] == {'numeric', 'new_tag'}
-    # Adds new standard tag
     assert schema.semantic_tags['email'] == {'new_tag', 'category'}
 
+    assert schema.logical_types['id'] == Double
+    assert schema.logical_types['age'] == Double
+    assert schema.logical_types['email'] == Categorical
+
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    semantic_tags=semantic_tags, use_standard_tags=False,
+                    index='id', time_index='signup_date')
+
+    schema.set_types(semantic_tags={'id': 'new_tag', 'age': 'new_tag', 'is_registered': 'new_tag'},
+                     logical_types={'id': Double, 'age': Double, 'email': Categorical}, retain_index_tags=False)
+
+    assert schema.index is None
+    assert schema.time_index == 'signup_date'
+
+    assert schema.semantic_tags['id'] == {'new_tag'}
+    assert schema.semantic_tags['age'] == {'new_tag'}
+    assert schema.semantic_tags['is_registered'] == {'new_tag'}
+    assert schema.semantic_tags['email'] == set()
+    assert schema.semantic_tags['signup_date'] == {'time_index', 'secondary_time_index'}
+
+    assert schema.logical_types['id'] == Double
+    assert schema.logical_types['age'] == Double
+    assert schema.logical_types['email'] == Categorical
 
 #     dt = DataTable(sample_df, index='id', time_index='signup_date')
 #     assert dt['signup_date'].semantic_tags == set(['time_index'])

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -362,10 +362,6 @@ def test_set_logical_types_invalid_data(sample_column_names, sample_inferred_log
     #     dt.set_types(logical_types={'age': int})
 
 
-def test_set_logical_types_of_indices(sample_column_names, sample_inferred_logical_types):
-    pass
-
-
 def test_set_types_combined(sample_column_names, sample_inferred_logical_types):
     # test that the resetting of indices when ltype changes doesnt touch index??
     semantic_tags = {
@@ -408,38 +404,6 @@ def test_set_types_combined(sample_column_names, sample_inferred_logical_types):
     assert schema.logical_types['id'] == Double
     assert schema.logical_types['age'] == Double
     assert schema.logical_types['email'] == Categorical
-
-#     dt = DataTable(sample_df, index='id', time_index='signup_date')
-#     assert dt['signup_date'].semantic_tags == set(['time_index'])
-#     assert dt['signup_date'].logical_type == Datetime
-#     assert dt['age'].semantic_tags == set(['numeric'])
-#     assert dt['age'].logical_type == Integer
-#     assert dt['is_registered'].semantic_tags == set()
-#     assert dt['is_registered'].logical_type == Boolean
-#     assert dt['email'].logical_type == NaturalLanguage
-#     assert dt['phone_number'].logical_type == NaturalLanguage
-
-#     semantic_tags = {
-#         'signup_date': ['test1'],
-#         'age': [],
-#         'is_registered': 'test2'
-#     }
-
-#     logical_types = {
-#         'email': 'EmailAddress',
-#         'phone_number': PhoneNumber,
-#         'age': 'Double'
-#     }
-
-#     dt = dt.set_types(logical_types=logical_types, semantic_tags=semantic_tags)
-#     assert dt['signup_date'].semantic_tags == set(['test1', 'time_index'])
-#     assert dt['signup_date'].logical_type == Datetime
-#     assert dt['age'].semantic_tags == set(['numeric'])
-#     assert dt['age'].logical_type == Double
-#     assert dt['is_registered'].semantic_tags == set(['test2'])
-#     assert dt['is_registered'].logical_type == Boolean
-#     assert dt['email'].logical_type == EmailAddress
-#     assert dt['phone_number'].logical_type == PhoneNumber
 
 
 def test_set_semantic_tags(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -90,6 +90,27 @@ def test_check_logical_types_errors(sample_column_names):
     with pytest.raises(LookupError, match=error_message):
         _check_logical_types(sample_column_names, bad_logical_types_keys)
 
+    bad_logical_types_keys = {
+        'email': 1,
+
+    }
+    error_message = ("Logical Types must be of the LogicalType class "
+                     "and registered in Woodwork's type system. "
+                     "1 does not meet that criteria.")
+
+    with pytest.raises(TypeError, match=error_message):
+        _check_logical_types(sample_column_names, bad_logical_types_keys, require_all_cols=False)
+
+    bad_logical_types_keys = {
+        'email': 'NaturalLanguage',
+    }
+    error_message = ("Logical Types must be of the LogicalType class "
+                     "and registered in Woodwork's type system. "
+                     "NaturalLanguage does not meet that criteria.")
+
+    with pytest.raises(TypeError, match=error_message):
+        _check_logical_types(sample_column_names, bad_logical_types_keys, require_all_cols=False)
+
 
 def test_check_semantic_tags_errors(sample_column_names):
     error_message = 'semantic_tags must be a dictionary'

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -124,6 +124,10 @@ def test_check_semantic_tags_errors(sample_column_names):
     with pytest.raises(LookupError, match=error_message):
         _check_semantic_tags(sample_column_names, bad_semantic_tags_keys)
 
+    error_message = "semantic_tags for id must be a string, set or list"
+    with pytest.raises(TypeError, match=error_message):
+        _check_semantic_tags(sample_column_names, {'id': 1})
+
 
 def test_check_table_metadata_errors():
     error_message = 'Table metadata must be a dictionary.'

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -90,10 +90,7 @@ def test_check_logical_types_errors(sample_column_names):
     with pytest.raises(LookupError, match=error_message):
         _check_logical_types(sample_column_names, bad_logical_types_keys)
 
-    bad_logical_types_keys = {
-        'email': 1,
-
-    }
+    bad_logical_types_keys = {'email': 1}
     error_message = ("Logical Types must be of the LogicalType class "
                      "and registered in Woodwork's type system. "
                      "1 does not meet that criteria.")

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -35,6 +35,7 @@ from woodwork.utils import (
     _is_valid_latlong_series,
     _is_valid_latlong_value,
     _new_dt_including,
+    _parse_logical_type,
     _reformat_to_latlong,
     _to_latlong_float,
     camel_to_snake,
@@ -489,23 +490,27 @@ def test_get_valid_mi_types():
 
 
 def test_get_column_logical_type(sample_series):
-    assert _get_column_logical_type(sample_series, 'Datetime', 'col_name') == Datetime
-    assert _get_column_logical_type(sample_series, Datetime, 'col_name') == Datetime
-
-    ymd_format = Datetime(datetime_format='%Y-%m-%d')
-    assert _get_column_logical_type(sample_series, ymd_format, 'col_name') == ymd_format
-
     assert _get_column_logical_type(sample_series, None, 'col_name') == Categorical
 
+    assert _get_column_logical_type(sample_series, Datetime, 'col_name') == Datetime
 
-def test_get_column_logical_type_errors(sample_series):
+
+def test_parse_logical_type():
+    assert _parse_logical_type('Datetime', 'col_name') == Datetime
+    assert _parse_logical_type(Datetime, 'col_name') == Datetime
+
+    ymd_format = Datetime(datetime_format='%Y-%m-%d')
+    assert _parse_logical_type(ymd_format, 'col_name') == ymd_format
+
+
+def test_parse_logical_type_errors():
     error = 'Must use an Ordinal instance with order values defined'
     with pytest.raises(TypeError, match=error):
-        _get_column_logical_type(sample_series, 'Ordinal', 'col_name')
+        _parse_logical_type('Ordinal', 'col_name')
 
     with pytest.raises(TypeError, match=error):
-        _get_column_logical_type(sample_series, Ordinal, 'col_name')
+        _parse_logical_type(Ordinal, 'col_name')
 
     error = "Invalid logical type specified for 'col_name'"
     with pytest.raises(TypeError, match=error):
-        _get_column_logical_type(sample_series, int, 'col_name')
+        _parse_logical_type(int, 'col_name')

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -320,14 +320,19 @@ def get_valid_mi_types():
 
 def _get_column_logical_type(series, logical_type, name):
     if logical_type:
-        if isinstance(logical_type, str):
-            logical_type = ww.type_system.str_to_logical_type(logical_type)
-        ltype_class = ww.type_sys.utils._get_ltype_class(logical_type)
-        if ltype_class == ww.logical_types.Ordinal and not isinstance(logical_type, ww.logical_types.Ordinal):
-            raise TypeError("Must use an Ordinal instance with order values defined")
-        if ltype_class in ww.type_system.registered_types:
-            return logical_type
-        else:
-            raise TypeError(f"Invalid logical type specified for '{name}'")
+        return _parse_logical_type(logical_type, name)
     else:
         return ww.type_system.infer_logical_type(series)
+
+
+def _parse_logical_type(logical_type, name):
+    # --> pull out parsing logic to own tests
+    if isinstance(logical_type, str):
+        logical_type = ww.type_system.str_to_logical_type(logical_type)
+    ltype_class = ww.type_sys.utils._get_ltype_class(logical_type)
+    if ltype_class == ww.logical_types.Ordinal and not isinstance(logical_type, ww.logical_types.Ordinal):
+        raise TypeError("Must use an Ordinal instance with order values defined")
+    if ltype_class in ww.type_system.registered_types:
+        return logical_type
+    else:
+        raise TypeError(f"Invalid logical type specified for '{name}'")

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -326,7 +326,6 @@ def _get_column_logical_type(series, logical_type, name):
 
 
 def _parse_logical_type(logical_type, name):
-    # --> pull out parsing logic to own tests
     if isinstance(logical_type, str):
         logical_type = ww.type_system.str_to_logical_type(logical_type)
     ltype_class = ww.type_sys.utils._get_ltype_class(logical_type)


### PR DESCRIPTION
- Updates `df.ww.set_types` so that it can also take in a logical types parameter
- Updates underlying dtype of DataFrame is logical type is changed
- Also removes underlying index if index has been removed from the Schema 
- Closes #587  