### PR TITLE
Serialize accessor to csv, pickle, and parquet

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -28,6 +28,7 @@ Release Notes
         * Add ``set_time_index`` to WoodworkTableAccessor (:pr:`612`)
         * Implement ``loc`` and ``iloc`` for WoodworkTableAccessor (:pr:`618`)
         * Allow updating logical types with ``set_types`` and make relevant DataFrame changes (:pr:`619`)
+        * Allow serialization of WoodworkColumnAccessor to csv, pickle, and parquet (:pr:`624`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -1,0 +1,183 @@
+import datetime
+import json
+import os
+import tarfile
+import tempfile
+
+import pandas as pd
+
+import woodwork as ww
+from woodwork.s3_utils import get_transport_params, use_smartopen
+from woodwork.type_sys.utils import (
+    _get_ltype_class,
+    _get_specified_ltype_params
+)
+from woodwork.utils import _is_s3, _is_url, import_or_none
+
+dd = import_or_none('dask.dataframe')
+ks = import_or_none('databricks.koalas')
+
+# --> not sure if we should go to 6 or 1
+SCHEMA_VERSION = '1.0.0'
+FORMATS = ['csv', 'pickle', 'parquet']
+
+
+def typing_info_to_dict(dataframe):
+    '''Gets the description for a DataTable, including typing information for each column
+    and loading information.
+    '''
+    # --> confirm schema is initialized
+    schema = dataframe.ww.schema
+    ordered_columns = dataframe.columns
+    column_typing_info = [
+        {'name': col_name,
+         'ordinal': ordered_columns.get_loc(col_name),
+         'logical_type': {
+             'parameters': _get_specified_ltype_params(col['logical_type']),
+             'type': str(_get_ltype_class(col['logical_type']))
+         },
+            'physical_type': {
+            'type': str(col['dtype'])
+         },
+            'semantic_tags': sorted(list(col['semantic_tags'])),
+            'description': col['description'],
+            'metadata': col['metadata']
+         }
+        for col_name, col in schema.columns.items()
+    ]
+
+    if dd and isinstance(dataframe, dd.DataFrame):
+        table_type = 'dask'
+    elif ks and isinstance(dataframe, ks.DataFrame):
+        table_type = 'koalas'
+    else:
+        table_type = 'pandas'
+
+    return {
+        'schema_version': SCHEMA_VERSION,
+        'name': schema.name,
+        'index': schema.index,
+        'time_index': schema.time_index,
+        'column_typing_info': column_typing_info,
+        'loading_info': {
+            'table_type': table_type
+        },
+        'table_metadata': schema.metadata
+    }
+
+
+def write_datatable(datatable, path, profile_name=None, **kwargs):
+    '''Serialize datatable and write to disk or S3 path.
+
+    Args:
+    datatable (DataTable) : Instance of :class:`.DataTable`.
+    path (str) : Location on disk to write datatable data and description.
+    profile_name (str, bool): The AWS profile specified to write to S3. Will default to None and search for AWS credentials.
+            Set to False to use an anonymous profile.
+    kwargs (keywords) : Additional keyword arguments to pass as keywords arguments to the underlying serialization method or to specify AWS profile.
+    '''
+    if _is_s3(path):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, 'data'))
+            dump_table(datatable, tmpdir, **kwargs)
+            file_path = create_archive(tmpdir)
+
+            transport_params = get_transport_params(profile_name)
+            use_smartopen(file_path, path, read=False, transport_params=transport_params)
+    elif _is_url(path):
+        raise ValueError("Writing to URLs is not supported")
+    else:
+        path = os.path.abspath(path)
+        os.makedirs(os.path.join(path, 'data'), exist_ok=True)
+        dump_table(datatable, path, **kwargs)
+
+
+def dump_table(datatable, path, **kwargs):
+    '''Writes datatable description to table_description.json at the specified path.
+    '''
+    loading_info = write_dataframe(datatable, path, **kwargs)
+
+    description = typing_info_to_dict(datatable)
+    description['loading_info'].update(loading_info)
+
+    write_schema(description, path)
+
+
+def write_schema(description, path):
+    # --> add docstring
+    try:
+        file = os.path.join(path, 'table_description.json')
+        with open(file, 'w') as file:
+            json.dump(description, file)
+    except TypeError:
+        raise TypeError('DataTable is not json serializable. Check table and column metadata for values that may not be serializable.')
+
+
+def write_dataframe(datatable, path, format='csv', **kwargs):
+    '''Write underlying datatable data to disk or S3 path.
+
+    Args:
+        datatable (DataTable) : Instance of :class:`.DataTable`.
+        path (str) : Location on disk to write datatable data.
+        format (str) : Format to use for writing datatable data. Defaults to csv.
+        kwargs (keywords) : Additional keyword arguments to pass as keywords arguments to the underlying serialization method.
+
+    Returns:
+        loading_info (dict) : Information on storage location and format of datatable data.
+    '''
+    format = format.lower()
+
+    dt_name = datatable.name or 'data'
+    df = datatable.to_dataframe()
+
+    if dd and isinstance(df, dd.DataFrame) and format == 'csv':
+        basename = "{}-*.{}".format(dt_name, format)
+    else:
+        basename = '.'.join([dt_name, format])
+    location = os.path.join('data', basename)
+    file = os.path.join(path, location)
+
+    if format == 'csv':
+        compression = kwargs['compression']
+        if ks and isinstance(df, ks.DataFrame):
+            df = df.copy()
+            columns = list(df.select_dtypes('object').columns)
+            df[columns] = df[columns].astype(str)
+            compression = str(compression)
+        df.to_csv(
+            file,
+            index=kwargs['index'],
+            sep=kwargs['sep'],
+            encoding=kwargs['encoding'],
+            compression=compression
+        )
+    elif format == 'pickle':
+        # Dask and Koalas currently do not support to_pickle
+        if not isinstance(df, pd.DataFrame):
+            msg = 'DataFrame type not compatible with pickle serialization. Please serialize to another format.'
+            raise ValueError(msg)
+        df.to_pickle(file, **kwargs)
+    elif format == 'parquet':
+        # Latlong columns in pandas and Dask DataFrames contain tuples, which raises
+        # an error in parquet format.
+        df = df.copy()
+        latlong_columns = [col_name for col_name, col in datatable.columns.items() if _get_ltype_class(col.logical_type) == ww.logical_types.LatLong]
+        df[latlong_columns] = df[latlong_columns].astype(str)
+
+        df.to_parquet(file, **kwargs)
+    else:
+        error = 'must be one of the following formats: {}'
+        raise ValueError(error.format(', '.join(FORMATS)))
+    return {'location': location, 'type': format, 'params': kwargs}
+
+
+def create_archive(tmpdir):
+    '''When seralizing to an S3 URL, writes a tar archive.
+    '''
+    file_name = "dt-{date:%Y-%m-%d_%H%M%S}.tar".format(date=datetime.datetime.now())
+    file_path = os.path.join(tmpdir, file_name)
+    tar = tarfile.open(str(file_path), 'w')
+    tar.add(str(tmpdir) + '/table_description.json', arcname='/table_description.json')
+    tar.add(str(tmpdir) + '/data', arcname='/data')
+    tar.close()
+    return file_path

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -17,8 +17,7 @@ from woodwork.utils import _is_s3, _is_url, import_or_none
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
 
-# --> not sure if we should go to 6 or 1
-SCHEMA_VERSION = '1.0.0'
+SCHEMA_VERSION = '6.0.0'
 FORMATS = ['csv', 'pickle', 'parquet']
 
 
@@ -26,7 +25,6 @@ def typing_info_to_dict(dataframe):
     '''Gets the description for a Woodwork table, including typing information for each column
     and loading information.
     '''
-    # --> confirm schema is initialized
     ordered_columns = dataframe.columns
     column_typing_info = [
         {'name': col_name,

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -137,7 +137,7 @@ def write_dataframe(dataframe, path, format='csv', **kwargs):
     if format == 'csv':
         compression = kwargs['compression']
         if ks and isinstance(dataframe, ks.DataFrame):
-            dataframe = dataframe.copy()
+            dataframe = dataframe.ww.copy()
             columns = list(dataframe.select_dtypes('object').columns)
             dataframe[columns] = dataframe[columns].astype(str)
             compression = str(compression)
@@ -157,7 +157,7 @@ def write_dataframe(dataframe, path, format='csv', **kwargs):
     elif format == 'parquet':
         # Latlong columns in pandas and Dask DataFrames contain tuples, which raises
         # an error in parquet format.
-        dataframe = dataframe.copy()
+        dataframe = dataframe.ww.copy()
         latlong_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col['logical_type']) == ww.logical_types.LatLong]
         dataframe[latlong_columns] = dataframe[latlong_columns].astype(str)
 

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -97,10 +97,10 @@ def dump_table(dataframe, path, **kwargs):
     typing_info = typing_info_to_dict(dataframe)
     typing_info['loading_info'].update(loading_info)
 
-    write_schema(typing_info, path)
+    write_typing_info(typing_info, path)
 
 
-def write_schema(typing_info, path):
+def write_typing_info(typing_info, path):
     '''Writes Woodwork typing information to the specified path at woodwork_typing_info.json
     '''
     try:

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -33,12 +33,12 @@ def typing_info_to_dict(dataframe):
              'parameters': _get_specified_ltype_params(col['logical_type']),
              'type': str(_get_ltype_class(col['logical_type']))
          },
-            'physical_type': {
-            'type': str(col['dtype'])
+         'physical_type': {
+             'type': str(col['dtype'])
          },
-            'semantic_tags': sorted(list(col['semantic_tags'])),
-            'description': col['description'],
-            'metadata': col['metadata']
+         'semantic_tags': sorted(list(col['semantic_tags'])),
+         'description': col['description'],
+         'metadata': col['metadata']
          }
         for col_name, col in dataframe.ww.columns.items()
     ]
@@ -90,7 +90,7 @@ def write_woodwork_table(dataframe, path, profile_name=None, **kwargs):
 
 
 def dump_table(dataframe, path, **kwargs):
-    '''Writes Woodwork table the specified path, including both the data and the typing information.
+    '''Writes Woodwork table at the specified path, including both the data and the typing information.
     '''
     loading_info = write_dataframe(dataframe, path, **kwargs)
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -275,6 +275,8 @@ class WoodworkTableAccessor:
         Returns:
             description (dict) : Description of the typing information.
         '''
+        if self._schema is None:
+            _raise_init_error()
         return serialize.typing_info_to_dict(self._dataframe)
 
     def to_csv(self, path, sep=',', encoding='utf-8', engine='python', compression=None, profile_name=None):
@@ -290,6 +292,8 @@ class WoodworkTableAccessor:
                 compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
                 profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
         '''
+        if self._schema is None:
+            _raise_init_error()
         serialize.write_woodwork_table(self._dataframe, path, format='csv', index=False,
                                        sep=sep, encoding=encoding, engine=engine,
                                        compression=compression, profile_name=profile_name)
@@ -304,6 +308,8 @@ class WoodworkTableAccessor:
                 compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
                 profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
         '''
+        if self._schema is None:
+            _raise_init_error()
         serialize.write_woodwork_table(self._dataframe, path, format='pickle',
                                        compression=compression, profile_name=profile_name)
 
@@ -321,6 +327,9 @@ class WoodworkTableAccessor:
                 compression (str) : Name of the compression to use. Possible values are: {'snappy', 'gzip', 'brotli', None}.
                 profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
         '''
+        if self._schema is None:
+            _raise_init_error()
+
         import_error_message = (
             "The pyarrow library is required to serialize to parquet.\n"
             "Install via pip:\n"

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -270,15 +270,15 @@ class WoodworkTableAccessor:
 
     def to_dictionary(self):
         '''
-        Get a DataTable's description
+        Get a dictionary representation of the Woodwork typing information.
 
         Returns:
-            description (dict) : Description of :class:`.Schema`.
+            description (dict) : Description of the typing information.
         '''
         return serialize.typing_info_to_dict(self._dataframe)
 
     def to_csv(self, path, sep=',', encoding='utf-8', engine='python', compression=None, profile_name=None):
-        '''Write DataTable to disk in the CSV format, location specified by `path`.
+        '''Write Woodwork table to disk in the CSV format, location specified by `path`.
             Path could be a local path or a S3 path.
             If writing to S3 a tar archive of files will be written.
 
@@ -295,7 +295,7 @@ class WoodworkTableAccessor:
                                        compression=compression, profile_name=profile_name)
 
     def to_pickle(self, path, compression=None, profile_name=None):
-        '''Write DataTable to disk in the pickle format, location specified by `path`.
+        '''Write Woodwork table to disk in the pickle format, location specified by `path`.
             Path could be a local path or a S3 path.
             If writing to S3 a tar archive of files will be written.
 
@@ -308,7 +308,7 @@ class WoodworkTableAccessor:
                                        compression=compression, profile_name=profile_name)
 
     def to_parquet(self, path, compression=None, profile_name=None):
-        '''Write DataTable to disk in the parquet format, location specified by `path`.
+        '''Write Woodwork table to disk in the parquet format, location specified by `path`.
             Path could be a local path or a S3 path.
             If writing to S3 a tar archive of files will be written.
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -2,6 +2,7 @@ import warnings
 
 import pandas as pd
 
+import woodwork.serialize_accessor as serialize
 from woodwork.accessor_utils import _update_column_dtype
 from woodwork.exceptions import (
     ParametersIgnoredWarning,
@@ -10,7 +11,6 @@ from woodwork.exceptions import (
 from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 from woodwork.logical_types import Datetime
 from woodwork.schema import Schema
-import woodwork.serialize_accessor as serialize
 from woodwork.statistics_utils import (
     _get_describe_dict,
     _get_mutual_information_dict
@@ -23,7 +23,8 @@ from woodwork.type_sys.utils import (
 from woodwork.utils import (
     _get_column_logical_type,
     _parse_logical_type,
-    import_or_none
+    import_or_none,
+    import_or_raise
 )
 
 dd = import_or_none('dask.dataframe')
@@ -275,6 +276,62 @@ class WoodworkTableAccessor:
             description (dict) : Description of :class:`.Schema`.
         '''
         return serialize.typing_info_to_dict(self._dataframe)
+
+    def to_csv(self, path, sep=',', encoding='utf-8', engine='python', compression=None, profile_name=None):
+        '''Write DataTable to disk in the CSV format, location specified by `path`.
+            Path could be a local path or a S3 path.
+            If writing to S3 a tar archive of files will be written.
+
+            Args:
+                path (str) : Location on disk to write to (will be created as a directory)
+                sep (str) : String of length 1. Field delimiter for the output file.
+                encoding (str) : A string representing the encoding to use in the output file, defaults to 'utf-8'.
+                engine (str) : Name of the engine to use. Possible values are: {'c', 'python'}.
+                compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
+                profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
+        '''
+        serialize.write_woodwork_table(self._dataframe, path, format='csv', index=False,
+                                       sep=sep, encoding=encoding, engine=engine,
+                                       compression=compression, profile_name=profile_name)
+
+    def to_pickle(self, path, compression=None, profile_name=None):
+        '''Write DataTable to disk in the pickle format, location specified by `path`.
+            Path could be a local path or a S3 path.
+            If writing to S3 a tar archive of files will be written.
+
+            Args:
+                path (str) : Location on disk to write to (will be created as a directory)
+                compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
+                profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
+        '''
+        serialize.write_woodwork_table(self._dataframe, path, format='pickle',
+                                       compression=compression, profile_name=profile_name)
+
+    def to_parquet(self, path, compression=None, profile_name=None):
+        '''Write DataTable to disk in the parquet format, location specified by `path`.
+            Path could be a local path or a S3 path.
+            If writing to S3 a tar archive of files will be written.
+
+            Note:
+                As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used
+                for serialization to parquet.
+
+            Args:
+                path (str): location on disk to write to (will be created as a directory)
+                compression (str) : Name of the compression to use. Possible values are: {'snappy', 'gzip', 'brotli', None}.
+                profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
+        '''
+        import_error_message = (
+            "The pyarrow library is required to serialize to parquet.\n"
+            "Install via pip:\n"
+            "    pip install pyarrow\n"
+            "Install via conda:\n"
+            "   conda install pyarrow -c conda-forge"
+        )
+        import_or_raise('pyarrow', import_error_message)
+        serialize.write_woodwork_table(self._dataframe, path, format='parquet',
+                                       engine='pyarrow', compression=compression,
+                                       profile_name=profile_name)
 
     def _sort_columns(self, already_sorted):
         if dd and isinstance(self._dataframe, dd.DataFrame) or (ks and isinstance(self._dataframe, ks.DataFrame)):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -10,6 +10,7 @@ from woodwork.exceptions import (
 from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 from woodwork.logical_types import Datetime
 from woodwork.schema import Schema
+import woodwork.serialize_accessor as serialize
 from woodwork.statistics_utils import (
     _get_describe_dict,
     _get_mutual_information_dict
@@ -265,6 +266,15 @@ class WoodworkTableAccessor:
         """
         cols_to_include = self._schema._filter_cols(include)
         return self._get_subset_df_with_schema(cols_to_include)
+
+    def to_dictionary(self):
+        '''
+        Get a DataTable's description
+
+        Returns:
+            description (dict) : Description of :class:`.Schema`.
+        '''
+        return serialize.typing_info_to_dict(self._dataframe)
 
     def _sort_columns(self, already_sorted):
         if dd and isinstance(self._dataframe, dd.DataFrame) or (ks and isinstance(self._dataframe, ks.DataFrame)):

--- a/woodwork/tests/datatable/test_accessor_serialization.py
+++ b/woodwork/tests/datatable/test_accessor_serialization.py
@@ -1,0 +1,463 @@
+import json
+import os
+
+import boto3
+import pandas as pd
+import pytest
+
+import woodwork.deserialize as deserialize
+import woodwork.serialize as serialize
+from woodwork import DataTable
+from woodwork.exceptions import OutdatedSchemaWarning, UpgradeSchemaWarning
+from woodwork.logical_types import Ordinal
+from woodwork.tests.testing_utils import to_pandas, xfail_dask_and_koalas
+from woodwork.utils import import_or_none
+
+dd = import_or_none('dask.dataframe')
+ks = import_or_none('databricks.koalas')
+
+BUCKET_NAME = "test-bucket"
+WRITE_KEY_NAME = "test-key"
+TEST_S3_URL = "s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)
+TEST_FILE = "test_serialization_woodwork_table_schema_1.0.0.tar"
+S3_URL = "s3://woodwork-static/" + TEST_FILE
+URL = "https://woodwork-static.s3.amazonaws.com/" + TEST_FILE
+TEST_KEY = "test_access_key_es"
+
+
+def xfail_tmp_disappears(dataframe):
+    # TODO: tmp file disappears after deserialize step, cannot check equality with Dask
+    if not isinstance(dataframe, pd.DataFrame):
+        pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask')
+
+
+def test_to_dictionary(sample_df):
+    xfail_dask_and_koalas(sample_df)
+    # if dd and isinstance(sample_df, dd.DataFrame):
+    #     table_type = 'dask'
+    # elif ks and isinstance(sample_df, ks.DataFrame):
+    #     table_type = 'koalas'
+    # else:
+    table_type = 'pandas'
+
+    # if ks and isinstance(sample_df, ks.DataFrame):
+    #     int_val = 'int64'
+    #     cat_val = 'object'
+    #     string_val = 'object'
+    #     bool_val = 'bool'
+    # else:
+    int_val = 'Int64'
+    cat_val = 'category'
+    string_val = 'string'
+    bool_val = 'boolean'
+    expected = {'schema_version': '1.0.0',
+                'name': 'test_data',
+                'index': 'id',
+                'time_index': None,
+                'column_typing_info': [{'name': 'id',
+                                        'ordinal': 0,
+                                        'logical_type': {'parameters': {}, 'type': 'Integer'},
+                                        'physical_type': {'type': int_val},
+                                        'semantic_tags': ['index', 'tag1'],
+                                        'description': None,
+                                        'metadata':{'is_sorted': True}},
+                                       {'name': 'full_name',
+                                        'ordinal': 1,
+                                        'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
+                                        'physical_type': {'type': string_val},
+                                        'semantic_tags': [],
+                                        'description': None,
+                                        'metadata':{}},
+                                       {'name': 'email',
+                                        'ordinal': 2,
+                                        'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
+                                        'physical_type': {'type': string_val},
+                                        'semantic_tags': [],
+                                        'description': None,
+                                        'metadata':{}},
+                                       {'name': 'phone_number',
+                                        'ordinal': 3,
+                                        'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
+                                        'physical_type': {'type': string_val},
+                                        'semantic_tags': [],
+                                        'description': None,
+                                        'metadata': {}},
+                                       {'name': 'age',
+                                        'ordinal': 4,
+                                        'logical_type': {'parameters': {'order': [25, 33, 57]}, 'type': 'Ordinal'},
+                                        'physical_type': {'type': cat_val},
+                                        'semantic_tags': ['category'],
+                                        'description': 'age of the user',
+                                        'metadata':{'interesting_values': [33, 57]}},
+                                       {'name': 'signup_date',
+                                        'ordinal': 5,
+                                        'logical_type': {'parameters': {},
+                                                         'type': 'Datetime'},
+                                        'physical_type': {'type': 'datetime64[ns]'},
+                                        'semantic_tags': [],
+                                        'description': 'original signup date',
+                                        'metadata':{}},
+                                       {'name': 'is_registered',
+                                        'ordinal': 6,
+                                        'logical_type': {'parameters': {}, 'type': 'Boolean'},
+                                        'physical_type': {'type': bool_val},
+                                        'semantic_tags': [],
+                                        'description': None,
+                                        'metadata':{}}],
+                'loading_info': {'table_type': table_type},
+                'table_metadata': {'date_created': '11/16/20'}
+                }
+
+    sample_df.ww.init(
+        name='test_data',
+        index='id',
+        semantic_tags={'id': 'tag1'},
+        logical_types={'age': Ordinal(order=[25, 33, 57])},
+        table_metadata={'date_created': '11/16/20'},
+        column_descriptions={'signup_date': 'original signup date',
+                             'age': 'age of the user'},
+        column_metadata={'id': {'is_sorted': True},
+                         'age': {'interesting_values': [33, 57]}}
+    )
+
+    description = sample_df.ww.to_dictionary()
+
+    assert description == expected
+
+
+# def test_unserializable_table(sample_df, tmpdir):
+#     dt = DataTable(sample_df, table_metadata={'not_serializable': sample_df['is_registered'].dtype})
+
+#     error = "DataTable is not json serializable. Check table and column metadata for values that may not be serializable."
+#     with pytest.raises(TypeError, match=error):
+#         dt.to_csv(str(tmpdir), encoding='utf-8', engine='python')
+
+
+# def test_serialize_wrong_format(sample_df, tmpdir):
+#     dt = DataTable(sample_df)
+
+#     error = 'must be one of the following formats: csv, pickle, parquet'
+#     with pytest.raises(ValueError, match=error):
+#         serialize.write_datatable(dt, str(tmpdir), format='test')
+
+
+# def test_to_csv(sample_df, tmpdir):
+#     dt = DataTable(sample_df,
+#                    name='test_data',
+#                    index='id',
+#                    semantic_tags={'id': 'tag1'},
+#                    logical_types={'age': Ordinal(order=[25, 33, 57])},
+#                    column_descriptions={'signup_date': 'original signup date',
+#                                         'age': 'age of the user'},
+#                    column_metadata={'id': {'is_sorted': True},
+#                                     'age': {'interesting_values': [33, 57]}})
+
+#     dt.to_csv(str(tmpdir), encoding='utf-8', engine='python')
+#     _dt = deserialize.read_datatable(str(tmpdir))
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=_dt.index, sort_index=True),
+#                                   to_pandas(_dt.to_dataframe(), index=_dt.index, sort_index=True))
+#     assert dt == _dt
+
+
+# def test_to_csv_with_latlong(latlong_df, tmpdir):
+#     dt = DataTable(latlong_df, index='tuple_ints', logical_types={col: 'LatLong' for col in latlong_df.columns})
+#     dt.to_csv(str(tmpdir))
+#     _dt = deserialize.read_datatable(str(tmpdir))
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index, sort_index=True),
+#                                   to_pandas(_dt.to_dataframe(), index=_dt.index, sort_index=True))
+#     assert dt == _dt
+
+
+# def test_to_pickle(sample_df, tmpdir):
+#     dt = DataTable(sample_df)
+#     if not isinstance(sample_df, pd.DataFrame):
+#         msg = 'DataFrame type not compatible with pickle serialization. Please serialize to another format.'
+#         with pytest.raises(ValueError, match=msg):
+#             dt.to_pickle(str(tmpdir))
+#     else:
+#         dt.to_pickle(str(tmpdir))
+#         _dt = deserialize.read_datatable(str(tmpdir))
+
+#         pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index),
+#                                       to_pandas(_dt.to_dataframe(), index=_dt.index))
+#         assert dt == _dt
+
+
+# def test_to_pickle_with_latlong(latlong_df, tmpdir):
+#     dt = DataTable(latlong_df, logical_types={col: 'LatLong' for col in latlong_df.columns})
+#     if not isinstance(latlong_df, pd.DataFrame):
+#         msg = 'DataFrame type not compatible with pickle serialization. Please serialize to another format.'
+#         with pytest.raises(ValueError, match=msg):
+#             dt.to_pickle(str(tmpdir))
+#     else:
+#         dt.to_pickle(str(tmpdir))
+#         _dt = deserialize.read_datatable(str(tmpdir))
+
+#         pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index, sort_index=True),
+#                                       to_pandas(_dt.to_dataframe(), index=_dt.index, sort_index=True))
+#         assert dt == _dt
+
+
+# def test_to_parquet(sample_df, tmpdir):
+#     dt = DataTable(sample_df, index='id')
+#     dt.to_parquet(str(tmpdir))
+#     _dt = deserialize.read_datatable(str(tmpdir))
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index, sort_index=True),
+#                                   to_pandas(_dt.to_dataframe(), index=_dt.index, sort_index=True))
+#     assert dt == _dt
+
+
+# def test_to_parquet_with_latlong(latlong_df, tmpdir):
+#     dt = DataTable(latlong_df, logical_types={col: 'LatLong' for col in latlong_df.columns})
+#     dt.to_parquet(str(tmpdir))
+#     _dt = deserialize.read_datatable(str(tmpdir))
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index, sort_index=True),
+#                                   to_pandas(_dt.to_dataframe(), index=_dt.index, sort_index=True))
+#     assert dt == _dt
+
+
+# @pytest.fixture
+# def s3_client():
+#     # TODO: Fix Moto tests needing to explicitly set permissions for objects
+#     _environ = os.environ.copy()
+#     from moto import mock_s3
+#     with mock_s3():
+#         s3 = boto3.resource('s3')
+#         yield s3
+#     os.environ.clear()
+#     os.environ.update(_environ)
+
+
+# @pytest.fixture
+# def s3_bucket(s3_client):
+#     s3_client.create_bucket(Bucket=BUCKET_NAME, ACL='public-read-write')
+#     s3_bucket = s3_client.Bucket(BUCKET_NAME)
+#     yield s3_bucket
+
+
+# def make_public(s3_client, s3_bucket):
+#     obj = list(s3_bucket.objects.all())[0].key
+#     s3_client.ObjectAcl(BUCKET_NAME, obj).put(ACL='public-read-write')
+
+
+# def test_to_csv_S3(sample_df, s3_client, s3_bucket):
+#     xfail_tmp_disappears(sample_df)
+
+#     dt = DataTable(sample_df,
+#                    name='test_data',
+#                    index='id',
+#                    semantic_tags={'id': 'tag1'},
+#                    logical_types={'age': Ordinal(order=[25, 33, 57])})
+#     dt.to_csv(TEST_S3_URL, encoding='utf-8', engine='python')
+#     make_public(s3_client, s3_bucket)
+
+#     _dt = deserialize.read_datatable(TEST_S3_URL)
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def test_serialize_s3_pickle(sample_df_pandas, s3_client, s3_bucket):
+#     pandas_dt = DataTable(sample_df_pandas)
+#     pandas_dt.to_pickle(TEST_S3_URL)
+#     make_public(s3_client, s3_bucket)
+#     _dt = deserialize.read_datatable(TEST_S3_URL)
+
+#     pd.testing.assert_frame_equal(to_pandas(pandas_dt.to_dataframe(), index=pandas_dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert pandas_dt == _dt
+
+
+# def test_serialize_s3_parquet(sample_df, s3_client, s3_bucket):
+#     xfail_tmp_disappears(sample_df)
+
+#     dt = DataTable(sample_df)
+#     dt.to_parquet(TEST_S3_URL)
+#     make_public(s3_client, s3_bucket)
+#     _dt = deserialize.read_datatable(TEST_S3_URL)
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def test_to_csv_S3_anon(sample_df, s3_client, s3_bucket):
+#     xfail_tmp_disappears(sample_df)
+
+#     dt = DataTable(sample_df,
+#                    name='test_data',
+#                    index='id',
+#                    time_index='signup_date',
+#                    semantic_tags={'id': 'tag1'},
+#                    logical_types={'age': Ordinal(order=[25, 33, 57])})
+#     dt.to_csv(TEST_S3_URL, encoding='utf-8', engine='python', profile_name=False)
+#     make_public(s3_client, s3_bucket)
+
+#     _dt = deserialize.read_datatable(TEST_S3_URL, profile_name=False)
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def test_serialize_s3_pickle_anon(sample_df_pandas, s3_client, s3_bucket):
+#     pandas_dt = DataTable(sample_df_pandas)
+#     pandas_dt.to_pickle(TEST_S3_URL, profile_name=False)
+#     make_public(s3_client, s3_bucket)
+#     _dt = deserialize.read_datatable(TEST_S3_URL, profile_name=False)
+
+#     pd.testing.assert_frame_equal(to_pandas(pandas_dt.to_dataframe(), index=pandas_dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert pandas_dt == _dt
+
+
+# def test_serialize_s3_parquet_anon(sample_df, s3_client, s3_bucket):
+#     xfail_tmp_disappears(sample_df)
+
+#     dt = DataTable(sample_df)
+#     dt.to_parquet(TEST_S3_URL, profile_name=False)
+#     make_public(s3_client, s3_bucket)
+#     _dt = deserialize.read_datatable(TEST_S3_URL, profile_name=False)
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def create_test_credentials(test_path):
+#     with open(test_path, "w+") as f:
+#         f.write("[test]\n")
+#         f.write("aws_access_key_id=AKIAIOSFODNN7EXAMPLE\n")
+#         f.write("aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n")
+
+
+# def create_test_config(test_path_config):
+#     with open(test_path_config, "w+") as f:
+#         f.write("[profile test]\n")
+#         f.write("region=us-east-2\n")
+#         f.write("output=text\n")
+
+
+# @pytest.fixture
+# def setup_test_profile(monkeypatch, tmpdir):
+#     cache = str(tmpdir.join('.cache').mkdir())
+#     test_path = os.path.join(cache, 'test_credentials')
+#     test_path_config = os.path.join(cache, 'test_config')
+#     monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", test_path)
+#     monkeypatch.setenv("AWS_CONFIG_FILE", test_path_config)
+#     monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+#     monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+#     monkeypatch.setenv("AWS_PROFILE", "test")
+
+#     try:
+#         os.remove(test_path)
+#     except OSError:
+#         pass
+#     try:
+#         os.remove(test_path_config)
+#     except OSError:
+#         pass
+
+#     create_test_credentials(test_path)
+#     create_test_config(test_path_config)
+#     yield
+#     os.remove(test_path)
+#     os.remove(test_path_config)
+
+
+# def test_s3_test_profile(sample_df, s3_client, s3_bucket, setup_test_profile):
+#     xfail_tmp_disappears(sample_df)
+#     dt = DataTable(sample_df)
+#     dt.to_csv(TEST_S3_URL, encoding='utf-8', engine='python', profile_name='test')
+#     make_public(s3_client, s3_bucket)
+#     _dt = deserialize.read_datatable(TEST_S3_URL, profile_name='test')
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def test_serialize_url_csv(sample_df):
+#     dt = DataTable(sample_df)
+#     error_text = "Writing to URLs is not supported"
+#     with pytest.raises(ValueError, match=error_text):
+#         dt.to_csv(URL, encoding='utf-8', engine='python')
+
+
+# def test_serialize_subdirs_not_removed(sample_df, tmpdir):
+#     dt = DataTable(sample_df)
+#     write_path = tmpdir.mkdir("test")
+#     test_dir = write_path.mkdir("test_dir")
+#     with open(str(write_path.join('table_description.json')), 'w') as f:
+#         json.dump('__SAMPLE_TEXT__', f)
+#     compression = None
+#     serialize.write_datatable(dt, path=str(write_path), index='1', sep='\t', encoding='utf-8', compression=compression)
+#     assert os.path.exists(str(test_dir))
+#     with open(str(write_path.join('table_description.json')), 'r') as f:
+#         assert '__SAMPLE_TEXT__' not in json.load(f)
+
+
+# def test_deserialize_url_csv(sample_df_pandas):
+#     dt = DataTable(sample_df_pandas, index='id')
+#     _dt = deserialize.read_datatable(URL)
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def test_deserialize_url_csv_anon(sample_df_pandas):
+#     dt = DataTable(sample_df_pandas, index='id')
+#     _dt = deserialize.read_datatable(URL, profile_name=False)
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def test_deserialize_s3_csv(sample_df_pandas):
+#     dt = DataTable(sample_df_pandas, index='id')
+#     _dt = deserialize.read_datatable(S3_URL)
+
+#     pd.testing.assert_frame_equal(to_pandas(dt.to_dataframe(), index=dt.index), to_pandas(_dt.to_dataframe(), index=_dt.index))
+#     assert dt == _dt
+
+
+# def test_check_later_schema_version():
+#     def test_version(major, minor, patch, raises=True):
+#         version_to_check = '.'.join([str(v) for v in [major, minor, patch]])
+#         if raises:
+#             warning_text = ('The schema version of the saved woodwork.DataTable '
+#                             '%s is greater than the latest supported %s. '
+#                             'You may need to upgrade woodwork. Attempting to load woodwork.DataTable ...'
+#                             % (version_to_check, serialize.SCHEMA_VERSION))
+#             with pytest.warns(UpgradeSchemaWarning, match=warning_text):
+#                 deserialize._check_schema_version(version_to_check)
+#         else:
+#             with pytest.warns(None) as record:
+#                 deserialize._check_schema_version(version_to_check)
+#             assert len(record) == 0
+
+#     major, minor, patch = [int(s) for s in serialize.SCHEMA_VERSION.split('.')]
+
+#     test_version(major + 1, minor, patch)
+#     test_version(major, minor + 1, patch)
+#     test_version(major, minor, patch + 1)
+#     test_version(major, minor - 1, patch + 1, raises=False)
+
+
+# def test_earlier_schema_version():
+#     def test_version(major, minor, patch, raises=True):
+#         version_to_check = '.'.join([str(v) for v in [major, minor, patch]])
+#         if raises:
+#             warning_text = ('The schema version of the saved woodwork.DataTable '
+#                             '%s is no longer supported by this version '
+#                             'of woodwork. Attempting to load woodwork.DataTable ...'
+#                             % (version_to_check))
+#             with pytest.warns(OutdatedSchemaWarning, match=warning_text):
+#                 deserialize._check_schema_version(version_to_check)
+#         else:
+#             with pytest.warns(None) as record:
+#                 deserialize._check_schema_version(version_to_check)
+#             assert len(record) == 0
+
+#     major, minor, patch = [int(s) for s in serialize.SCHEMA_VERSION.split('.')]
+
+#     test_version(major - 1, minor, patch)
+#     test_version(major, minor - 1, patch, raises=False)
+#     test_version(major, minor, patch - 1, raises=False)


### PR DESCRIPTION
- creates `serialize_accessor.py` file for serializing a DataFrame and its Woodwork Schema and `test_accessor_serialization.py` 
- Closes #560 

Note: Most of the serialization tests require the ability to deserialize as well, so those tests will have to wait until deserialization is implemented