### PR TITLE
Add pop to WoodworkTableAccessor

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -17,6 +17,7 @@ WoodworkTableAccessor
     WoodworkTableAccessor.loc
     WoodworkTableAccessor.mutual_information_dict
     WoodworkTableAccessor.mutual_information
+    WoodworkTableAccessor.pop
     WoodworkTableAccessor.select
     WoodworkTableAccessor.set_index
     WoodworkTableAccessor.set_types

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -32,6 +32,7 @@ Release Notes
         * Add DaskColumnAccessor (:pr:`625`)
         * Allow deserialization from csv, pickle, and parquet to Woodwork table (:pr:`626`)
         * Add ``value_counts`` to WoodworkTableAccessor (:pr:`632`)
+        * Add ``pop`` to WoodworkTableAccessor (:pr:`636`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -433,6 +433,30 @@ class WoodworkTableAccessor:
 
         return new_df
 
+    def pop(self, column_name):
+        """Return a Series with Woodwork typing information and remove it from the DataFrame.
+
+        Args:
+            column (str): Name of the column to pop.
+
+        Returns:
+            (pd.Series, ks.Series): Popped series with Woodwork initialized
+        """
+        if column_name not in self._dataframe.columns:
+            raise LookupError(f'Column with name {column_name} not found in DataFrame')
+
+        series = self._dataframe.pop(column_name)
+
+        # Initialize Woodwork typing info for series
+        col_schema = self._schema.columns[column_name]
+        del col_schema['dtype']
+        series.ww.init(**col_schema, use_standard_tags=self.use_standard_tags)
+
+        # Update schema to not include popped column
+        del self._schema.columns[column_name]
+
+        return series
+
     def mutual_information_dict(self, num_bins=10, nrows=None):
         """
         Calculates mutual information between all pairs of columns in the DataFrame that

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -440,7 +440,7 @@ class WoodworkTableAccessor:
             column (str): Name of the column to pop.
 
         Returns:
-            (pd.Series, ks.Series): Popped series with Woodwork initialized
+            (pd.Series): Popped series with Woodwork initialized
         """
         if column_name not in self._dataframe.columns:
             raise LookupError(f'Column with name {column_name} not found in DataFrame')

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1397,11 +1397,7 @@ def test_pop(sample_df):
     xfail_dask_and_koalas(sample_df)
 
     schema_df = sample_df.copy()
-    schema_df.ww.init(
-        name='table',
-        logical_types={'age': Integer},
-        semantic_tags={'age': 'custom_tag'},
-        use_standard_tags=True)
+    schema_df.ww.init(semantic_tags={'age': 'custom_tag'})
     original_schema = schema_df.ww.schema
 
     popped_series = schema_df.ww.pop('age')
@@ -1429,7 +1425,6 @@ def test_pop(sample_df):
     popped_series = schema_df.ww.pop('age')
 
     assert popped_series.ww.semantic_tags == {'custom_tag'}
-    assert schema_df.ww.semantic_tags['id'] == set()
 
 
 def test_pop_index(sample_df):


### PR DESCRIPTION
- Removes column from dataframe and returns the series with woodwork typing information initialized
- Closes #614 