### PR TITLE
Bump Koalas min version and fix release notes

### DIFF
--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -72,7 +72,7 @@
     "| smart_open        | 1.8.4       | Required to read/write to URLs and S3  |\n",
     "| pyarrow           | 2.0.0       | Required to serialize to parquet       |\n",
     "| dask[distributed] | 2.30.0      | Required to use with Dask DataFrames   |\n",
-    "| koalas            | 1.3.0       | Required to use with Koalas DataFrames |\n",
+    "| koalas            | 1.4.0       | Required to use with Koalas DataFrames |\n",
     "| pyspark           | 3.0.0       | Required to use with Koalas DataFrames |\n",
     "\n",
     "\n",

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -43,7 +43,7 @@ Release Notes
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`tamargrey`, :user:`thehomebrewnerd`
+    :user:`johnbridstrup`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 **v0.0.10 February 25, 2021**
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -38,6 +38,7 @@ Release Notes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes
         * Move mutual information logic to statistics utils file (:pr:`584`)
+        * Bump min Koalas version to 1.4.0 (:pr:``)
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -38,7 +38,7 @@ Release Notes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes
         * Move mutual information logic to statistics utils file (:pr:`584`)
-        * Bump min Koalas version to 1.4.0 (:pr:``)
+        * Bump min Koalas version to 1.4.0 (:pr:`638`)
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,7 +2,7 @@
 
 Release Notes
 -------------
-.. **Future Release**
+**Future Release**
     * Enhancements
         * Implement Schema and Accessor API (:pr:`497`)
         * Add Schema class that holds typing info (:pr:`499`)
@@ -41,7 +41,8 @@ Release Notes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`tamargrey`, :user:`thehomebrewnerd`
 
 **v0.0.10 February 25, 2021**
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -56,7 +56,7 @@ Release Notes
         * Refactor test_datatable.py (:pr:`574`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`jeff-hernandez`, :user:`johnbridstrup`, :user:`tamargrey`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`jeff-hernandez`, :user:`johnbridstrup`, :user:`tamargrey`
 
 **v0.0.9 February 5, 2021**
     * Enhancements

--- a/koalas-requirements.txt
+++ b/koalas-requirements.txt
@@ -1,3 +1,3 @@
 pyspark>=3.0.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
-koalas>=1.3.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
+koalas>=1.4.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
 numpy<1.20.0 # remove when koalas supports 1.20.0


### PR DESCRIPTION
- Closes #637 

Bump Koalas min version to 1.4.0 and uncomment Future Release section of release notes.