### PR TITLE
Update release branch naming instructions

### DIFF
--- a/.github/workflows/release_notes_updated.yml
+++ b/.github/workflows/release_notes_updated.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           from re import compile
           main = '^main$'
-          release = '^release_\d+\_\d+\_\d+$'
+          release = '^release_v\d+\_\d+\_\d+$'
           dep_update = '^dep-update-[a-f0-9]{7}$'
           regex = main, release, dep_update
           patterns = list(map(compile, regex))

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
     * Testing Changes
         * Update branch reference in tests to run on main (:pr:`641`)
         * Make release notes updated check separate from unit tests (:pr:`642`)
+        * Update release branch naming instructions (:pr:`644`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`

--- a/release.md
+++ b/release.md
@@ -20,7 +20,7 @@ If you'd like to create a development release, which won't be deployed to pypi a
 
 #### Create release branch
 
-1. Branch off of Woodwork `main` and name the branch the release version number (e.g. release_0_13_3)
+1. Branch off of Woodwork `main`. For the branch name, please use "release_vX.Y.Z" as the naming scheme (e.g. "release_v0.13.3"). Doing so will bypass our release notes checkin test which requires all other PRs to add a release note entry.
 
 #### Bump version number
 


### PR DESCRIPTION
- Wanted to match the way Featuretools does their release process to get parity