### PR TITLE
Add rename to WoodworkTableAccessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,7 +35,7 @@ Release Notes
         * Add KoalasColumnAccessor (:pr:`634`)
         * Add ``pop`` to WoodworkTableAccessor (:pr:`636`)
         * Add ``drop`` to WoodworkTableAccessor (:pr:`640`)
-        * Add ``rename`` to WoodworkTableAccessor (:pr:`640`)
+        * Add ``rename`` to WoodworkTableAccessor (:pr:`646`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,6 +35,7 @@ Release Notes
         * Add KoalasColumnAccessor (:pr:`634`)
         * Add ``pop`` to WoodworkTableAccessor (:pr:`636`)
         * Add ``drop`` to WoodworkTableAccessor (:pr:`640`)
+        * Add ``rename`` to WoodworkTableAccessor (:pr:`640`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -42,3 +42,7 @@ class TypeConversionError(Exception):
 
 class ParametersIgnoredWarning(UserWarning):
     pass
+
+
+class ColumnNotPresentError(KeyError):
+    pass

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -336,9 +336,6 @@ class Schema(object):
 
         Returns:
             woodwork.Schema: Schema with the specified columns renamed.
-
-        Note:
-            Index and time index columns cannot be renamed.
         """
         if not isinstance(columns, dict):
             raise TypeError('columns must be a dictionary')
@@ -348,8 +345,6 @@ class Schema(object):
                 raise ColumnNotPresentError(f"Column to rename must be present. {old_name} cannot be found.")
             if new_name in self.columns and new_name not in columns.keys():
                 raise ValueError(f"The column {new_name} is already present. Please choose another name to rename {old_name} to or also rename {old_name}.")
-            if old_name == self.index or old_name == self.time_index:
-                raise KeyError(f"Cannot rename index or time index columns such as {old_name}.")
 
         if len(columns) != len(set(columns.values())):
             raise ValueError('New columns names must be unique from one another.')

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -4,6 +4,7 @@ import copy
 import pandas as pd
 
 import woodwork as ww
+from woodwork.exceptions import ColumnNotPresentError
 from woodwork.schema_column import (
     _add_semantic_tags,
     _get_column_dict,
@@ -344,7 +345,7 @@ class Schema(object):
 
         for old_name, new_name in columns.items():
             if old_name not in self.columns:
-                raise KeyError(f"Column to rename must be present. {old_name} cannot be found.")
+                raise ColumnNotPresentError(f"Column to rename must be present. {old_name} cannot be found.")
             if new_name in self.columns and new_name not in columns.keys():
                 raise ValueError(f"The column {new_name} is already present. Please choose another name to rename {old_name} to or also rename {old_name}.")
             if old_name == self.index or old_name == self.time_index:

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -331,8 +331,7 @@ class Schema(object):
         """Renames columns in a Schema
 
         Args:
-            columns (dict[str -> str]): A dictionary mapping columns whose names
-                we'd like to change to the name to which we'd like to change them.
+            columns (dict[str -> str]): A dictionary mapping current column names to new column names.
 
         Returns:
             woodwork.Schema: Schema with the specified columns renamed.

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -461,7 +461,7 @@ class WoodworkTableAccessor:
         """Drop specified columns from a DataFrame.
 
         Args:
-            columns (str or list[str]): Column name or names to drop. Must be present in the DataTable.
+            columns (str or list[str]): Column name or names to drop. Must be present in the DataFrame.
 
         Returns:
             (pd.DataFrame): DataFrame with the specified columns removed, maintaining Woodwork typing information.

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -718,7 +718,7 @@ def _get_invalid_schema_message(dataframe, schema):
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {schema_dtype}'
     if schema.index is not None:
-        if not all(dataframe.index == dataframe[schema.index]):  # --> not rel for dask bc no underlying and isunique nto going to happen
+        if not all(dataframe.index == dataframe[schema.index]):
             return 'Index mismatch between DataFrame and typing information'
         elif not dataframe[schema.index].is_unique:
             return 'Index column is not unique'

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -492,9 +492,6 @@ class WoodworkTableAccessor:
 
         Returns:
             DataFrame: DataFrame with the specified columns renamed, maintaining Woodwork typing information.
-
-        Note:
-            Index and time index columns cannot be renamed.
         """
         new_schema = self._schema.rename(columns)
         new_df = self._dataframe.rename(columns=columns)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -488,17 +488,16 @@ class WoodworkTableAccessor:
         """Renames columns in a DataFrame, maintaining Woodwork typing information.
 
         Args:
-            columns (dict[str -> str]): A dictionary mapping columns whose names
-                we'd like to change to the name to which we'd like to change them.
+            columns (dict[str -> str]): A dictionary mapping current column names to new column names.
 
         Returns:
-            pd.DataFrame: DataFrame with the specified columns renamed, maintaining Woodwork typing information.
+            DataFrame: DataFrame with the specified columns renamed, maintaining Woodwork typing information.
 
         Note:
             Index and time index columns cannot be renamed.
         """
         new_schema = self._schema.rename(columns)
-        new_df = self._dataframe.rename(columns, axis=1)
+        new_df = self._dataframe.rename(columns=columns)
 
         new_df.ww.init(schema=new_schema)
         return new_df
@@ -722,7 +721,7 @@ def _get_invalid_schema_message(dataframe, schema):
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {schema_dtype}'
     if schema.index is not None:
-        if not all(dataframe.index == dataframe[schema.index]):
+        if not all(dataframe.index == dataframe[schema.index]):  # --> not rel for dask bc no underlying and isunique nto going to happen
             return 'Index mismatch between DataFrame and typing information'
         elif not dataframe[schema.index].is_unique:
             return 'Index column is not unique'

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -484,6 +484,25 @@ class WoodworkTableAccessor:
 
         return new_df
 
+    def rename(self, columns):
+        """Renames columns in a DataFrame, maintaining Woodwork typing information.
+
+        Args:
+            columns (dict[str -> str]): A dictionary mapping columns whose names
+                we'd like to change to the name to which we'd like to change them.
+
+        Returns:
+            pd.DataFrame: DataFrame with the specified columns renamed, maintaining Woodwork typing information.
+
+        Note:
+            Index and time index columns cannot be renamed.
+        """
+        new_schema = self._schema.rename(columns)
+        new_df = self._dataframe.rename(columns, axis=1)
+
+        new_df.ww.init(schema=new_schema)
+        return new_df
+
     def mutual_information_dict(self, num_bins=10, nrows=None):
         """
         Calculates mutual information between all pairs of columns in the DataFrame that

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1553,3 +1553,22 @@ def test_accessor_rename(sample_df):
 
     assert original_df.columns.get_loc('age') == new_df.columns.get_loc('full_name')
     assert original_df.columns.get_loc('full_name') == new_df.columns.get_loc('age')
+
+
+def test_accessor_rename_indices(sample_df):
+    xfail_dask_and_koalas(sample_df)
+
+    sample_df.ww.init(
+        index='id',
+        time_index='signup_date')
+
+    renamed_df = sample_df.ww.rename({'id': 'renamed_index', 'signup_date': 'renamed_time_index'})
+    assert 'id' not in renamed_df.columns
+    assert 'signup_date' not in renamed_df.columns
+    assert 'renamed_index' in renamed_df.columns
+    assert 'renamed_time_index' in renamed_df.columns
+
+    assert all(renamed_df.index == renamed_df['renamed_index'])
+
+    assert renamed_df.ww.index == 'renamed_index'
+    assert renamed_df.ww.time_index == 'renamed_time_index'

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -825,7 +825,7 @@ def test_schema_rename(sample_column_names, sample_inferred_logical_types):
 
     renamed_schema = schema.rename({'age': 'birthday'})
 
-    # Confirm underlying data of original datatable hasn't changed
+    # Confirm original schema hasn't changed
     assert schema == original_schema
 
     assert 'age' not in renamed_schema.columns

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from woodwork import type_system
+from woodwork.exceptions import ColumnNotPresentError
 from woodwork.logical_types import (
     Boolean,
     Categorical,
@@ -800,7 +801,7 @@ def test_schema_rename_errors(sample_column_names, sample_inferred_logical_types
         schema.rename({'age': 'test', 'full_name': 'test'})
 
     error = 'Column to rename must be present. not_present cannot be found.'
-    with pytest.raises(KeyError, match=error):
+    with pytest.raises(ColumnNotPresentError, match=error):
         schema.rename({'not_present': 'test'})
 
     error = 'Cannot rename index or time index columns such as id.'

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -804,10 +804,6 @@ def test_schema_rename_errors(sample_column_names, sample_inferred_logical_types
     with pytest.raises(ColumnNotPresentError, match=error):
         schema.rename({'not_present': 'test'})
 
-    error = 'Cannot rename index or time index columns such as id.'
-    with pytest.raises(KeyError, match=error):
-        schema.rename({'id': 'test', 'age': 'test2'})
-
     error = 'The column email is already present. Please choose another name to rename age to or also rename age.'
     with pytest.raises(ValueError, match=error):
         schema.rename({'age': 'email'})
@@ -845,3 +841,18 @@ def test_schema_rename(sample_column_names, sample_inferred_logical_types):
     swapped_schema = schema.rename({'age': 'full_name', 'full_name': 'age'})
     swapped_back_schema = swapped_schema.rename({'age': 'full_name', 'full_name': 'age'})
     assert swapped_back_schema == schema
+
+
+def test_schema_rename_indices(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    index='id',
+                    time_index='signup_date')
+
+    renamed_schema = schema.rename({'id': 'renamed_index', 'signup_date': 'renamed_time_index'})
+    assert 'id' not in renamed_schema.columns
+    assert 'signup_date' not in renamed_schema.columns
+    assert 'renamed_index' in renamed_schema.columns
+    assert 'renamed_time_index' in renamed_schema.columns
+
+    assert renamed_schema.index == 'renamed_index'
+    assert renamed_schema.time_index == 'renamed_time_index'


### PR DESCRIPTION
- Adds `Schema.rename` that handles input validation and updating the schema and `WoodworkTableAccessor.rename` that updates the schema and the dataframe
- Closes #616 