### PR TITLE
Add schema properties to WoodworkTableAccessor

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -19,6 +19,7 @@ WoodworkTableAccessor
     WoodworkTableAccessor.mutual_information_dict
     WoodworkTableAccessor.mutual_information
     WoodworkTableAccessor.pop
+    WoodworkTableAccessor.rename
     WoodworkTableAccessor.select
     WoodworkTableAccessor.set_index
     WoodworkTableAccessor.set_types
@@ -54,6 +55,7 @@ Schema
 
     Schema
     Schema.add_semantic_tags
+    Schema.rename
     Schema.remove_semantic_tags
     Schema.reset_semantic_tags
     Schema.set_index

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -37,6 +37,7 @@ Release Notes
         * Add ``drop`` to WoodworkTableAccessor (:pr:`640`)
         * Add ``rename`` to WoodworkTableAccessor (:pr:`646`)
         * Add DaskTableAccessor (:pr:`648`)
+        * Add Schema properties to WoodworkTableAccessor (:pr:`651`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -208,6 +208,37 @@ class WoodworkTableAccessor:
         if self._schema:
             return self._schema._get_subset_schema(list(self.columns.keys()))
 
+    @property
+    def types(self):
+        """DataFrame containing the physical dtypes, logical types and semantic
+        tags for the Schema."""
+        return self._schema.types
+
+    @property
+    def logical_types(self):
+        """A dictionary containing logical types for each column"""
+        return self._schema.logical_types
+
+    @property
+    def physical_types(self):
+        """A dictionary containing physical types for each column"""
+        return self._schema.physical_types
+
+    @property
+    def semantic_tags(self):
+        """A dictionary containing semantic tags for each column"""
+        return self._schema.semantic_tags
+
+    @property
+    def index(self):
+        """The index column for the table"""
+        return self._schema.index
+
+    @property
+    def time_index(self):
+        """The time index column for the table"""
+        return self._schema.time_index
+
     def set_index(self, new_index):
         """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
         and clears the tag from any previously set index column.

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1606,3 +1606,25 @@ def test_accessor_rename_indices(sample_df):
 
     assert renamed_df.ww.index == 'renamed_index'
     assert renamed_df.ww.time_index == 'renamed_time_index'
+
+
+def test_accessor_schema_properties(sample_df):
+    xfail_koalas(sample_df)
+
+    sample_df.ww.init(index='id',
+                      time_index='signup_date')
+
+    schema_properties = ['types', 'logical_types', 'physical_types', 'semantic_tags', 'index', 'time_index']
+    for schema_property in schema_properties:
+        prop_from_accessor = getattr(sample_df.ww, schema_property)
+        prop_from_schema = getattr(sample_df.ww.schema, schema_property)
+
+        if schema_property == 'types':
+            pd.testing.assert_frame_equal(prop_from_accessor, prop_from_schema)
+        else:
+            assert prop_from_accessor == prop_from_schema
+
+        # Assumes we don't have setters for any of these attributes
+        error = "can't set attribute"
+        with pytest.raises(AttributeError, match=error):
+            setattr(sample_df.ww, schema_property, 'new_value')


### PR DESCRIPTION
- We weren't getting proper property behavior with attributes that are properties on the Schema but are getting pulled in the WoodworkTableAccessor's getattr, so by adding them as properties on the WoodworkTableAccessor, we get the benefit of not being able to set those properties directly unless we define a setter, which is important for things like `index` and `time_index`
- Closes #602 