### PR TITLE
Update docstrings and API Reference

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -10,6 +10,7 @@ WoodworkTableAccessor
     :toctree: generated/
 
     WoodworkTableAccessor
+    WoodworkTableAccessor.add_semantic_tags
     WoodworkTableAccessor.describe
     WoodworkTableAccessor.describe_dict
     WoodworkTableAccessor.drop
@@ -22,11 +23,14 @@ WoodworkTableAccessor
     WoodworkTableAccessor.mutual_information_dict
     WoodworkTableAccessor.physical_types
     WoodworkTableAccessor.pop
+    WoodworkTableAccessor.remove_semantic_tags
     WoodworkTableAccessor.rename
+    WoodworkTableAccessor.reset_semantic_tags
     WoodworkTableAccessor.schema
     WoodworkTableAccessor.select
     WoodworkTableAccessor.semantic_tags
     WoodworkTableAccessor.set_index
+    WoodworkTableAccessor.set_time_index
     WoodworkTableAccessor.set_types
     WoodworkTableAccessor.time_index
     WoodworkTableAccessor.to_csv

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -14,19 +14,26 @@ WoodworkTableAccessor
     WoodworkTableAccessor.describe_dict
     WoodworkTableAccessor.drop
     WoodworkTableAccessor.iloc
+    WoodworkTableAccessor.index
     WoodworkTableAccessor.init
     WoodworkTableAccessor.loc
-    WoodworkTableAccessor.mutual_information_dict
+    WoodworkTableAccessor.logical_types
     WoodworkTableAccessor.mutual_information
+    WoodworkTableAccessor.mutual_information_dict
+    WoodworkTableAccessor.physical_types
     WoodworkTableAccessor.pop
     WoodworkTableAccessor.rename
+    WoodworkTableAccessor.schema
     WoodworkTableAccessor.select
+    WoodworkTableAccessor.semantic_tags
     WoodworkTableAccessor.set_index
     WoodworkTableAccessor.set_types
+    WoodworkTableAccessor.time_index
     WoodworkTableAccessor.to_csv
     WoodworkTableAccessor.to_dictionary
     WoodworkTableAccessor.to_parquet
     WoodworkTableAccessor.to_pickle
+    WoodworkTableAccessor.types
     WoodworkTableAccessor.value_counts
 
 WoodworkColumnAccessor
@@ -38,11 +45,15 @@ WoodworkColumnAccessor
 
     WoodworkColumnAccessor
     WoodworkColumnAccessor.add_semantic_tags
+    WoodworkColumnAccessor.description
     WoodworkColumnAccessor.iloc
     WoodworkColumnAccessor.init
     WoodworkColumnAccessor.loc
+    WoodworkColumnAccessor.logical_type
+    WoodworkColumnAccessor.metadata
     WoodworkColumnAccessor.remove_semantic_tags
     WoodworkColumnAccessor.reset_semantic_tags
+    WoodworkColumnAccessor.semantic_tags
     WoodworkColumnAccessor.set_logical_type
     WoodworkColumnAccessor.set_semantic_tags
 
@@ -55,12 +66,18 @@ Schema
 
     Schema
     Schema.add_semantic_tags
+    Schema.index
+    Schema.logical_types
+    Schema.physical_types
     Schema.rename
     Schema.remove_semantic_tags
     Schema.reset_semantic_tags
+    Schema.semantic_tags
     Schema.set_index
     Schema.set_time_index
     Schema.set_types
+    Schema.time_index
+    Schema.types
 
 Serialization
 =============
@@ -200,6 +217,7 @@ General Utils
 
     get_valid_mi_types
     read_csv
+    read_csv_to_accessor
 
 .. currentmodule:: woodwork.accessor_utils
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -45,6 +45,7 @@ Release Notes
         * Move mutual information logic to statistics utils file (:pr:`584`)
         * Bump min Koalas version to 1.4.0 (:pr:`638`)
     * Documentation Changes
+        * Update docstrings and API Reference page (:pr:`660`)
     * Testing Changes
         * Update branch reference in tests to run on main (:pr:`641`)
         * Make release notes updated check separate from unit tests (:pr:`642`)

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -19,6 +19,8 @@ def init_series(series, logical_type=None, semantic_tags=None,
     of the returned series will be converted to match the dtype associated with the LogicalType.
 
     Args:
+        series (pd.Series, dd.Series, or ks.Series): The original series from which to create
+            the Woodwork initialized series.
         logical_type (LogicalType or str, optional): The logical type that should be assigned
             to the series. If no value is provided, the LogicalType for the series will
             be inferred.
@@ -112,8 +114,8 @@ def _is_dataframe(data):
 
 
 def _get_valid_dtype(series, logical_type):
-    '''Return the dtype that is considered valid for a series
-    with the given logical_type'''
+    """Return the dtype that is considered valid for a series
+    with the given logical_type"""
     backup_dtype = logical_type.backup_dtype
     if ks and isinstance(series, ks.Series) and backup_dtype:
         if backup_dtype == 'str':

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -161,10 +161,8 @@ class WoodworkColumnAccessor:
         return True
 
     def __getattr__(self, attr):
-        '''
-            If the method is present on the Accessor, uses that method.
-            If the method is present on Series, uses that method.
-        '''
+        # If the method is present on the Accessor, uses that method.
+        # If the method is present on Series, uses that method.
         if self._schema is None:
             _raise_init_error()
         if hasattr(self._series, attr):
@@ -182,12 +180,9 @@ class WoodworkColumnAccessor:
         return msg
 
     def _make_series_call(self, attr):
-        '''
-        Forwards the requested attribute onto the series object.
-        Intercepts return value, attempting to initialize Woodwork with the current schema
-        when a new Series is returned.
-        Confirms schema is still valid for the original Series.
-        '''
+        """Forwards the requested attribute onto the series object. Intercepts return value,
+        attempting to initialize Woodwork with the current schema when a new Series is returned.
+        Confirms schema is still valid for the original Series."""
         series_attr = getattr(self._series, attr)
 
         if callable(series_attr):
@@ -266,13 +261,16 @@ class WoodworkColumnAccessor:
         """Reset the semantic tags to the default values. The default values
         will be either an empty set or a set of the standard tags based on the
         column logical type, controlled by the use_standard_tags property.
+
+        Args:
+            None
         """
         self._schema['semantic_tags'] = _reset_semantic_tags(self.logical_type.standard_tags,
                                                              self.use_standard_tags)
 
     def set_logical_type(self, logical_type):
         """Update the logical type for the series, clearing any previously set semantic tags,
-        and returning a new Series.
+        and returning a new series with Woodwork initialied.
 
         Args:
             logical_type (LogicalType, str): The new logical type to set for the series.

--- a/woodwork/demo/retail.py
+++ b/woodwork/demo/retail.py
@@ -77,12 +77,12 @@ def load_retail_to_accessor(id='demo_retail_data', nrows=None, init_woodwork=Tru
         nrows (int, optional): The number of rows to return in the dataset. If None, will
             return all possible rows. Defaults to None.
         init_woodwork (bool): If True, will return a pandas DataFrame with Woodwork
-        typing information initialized. If False, will return a DataFrame without
-        Woodwork initialized. Defaults to False.
+            typing information initialized. If False, will return a DataFrame without
+            Woodwork initialized. Defaults to False.
 
     Returns:
-         pd.DataFrame: A DataFrame containing the demo data with Woodwork typing initialized.
-            If `init_woodwork` is False, will return an uninitialized DataFrame.
+        pd.DataFrame: A DataFrame containing the demo data with Woodwork typing initialized.
+        If `init_woodwork` is False, will return an uninitialized DataFrame.
     """
     csv_s3_gz = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv.gz?version=" + ww.__version__
     csv_s3 = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv?version=" + ww.__version__

--- a/woodwork/deserialize_accessor.py
+++ b/woodwork/deserialize_accessor.py
@@ -16,14 +16,14 @@ from woodwork.utils import _is_s3, _is_url, import_or_raise
 
 
 def read_table_typing_information(path):
-    '''Read Woodwork typing information from disk, S3 path, or URL.
+    """Read Woodwork typing information from disk, S3 path, or URL.
 
         Args:
             path (str): Location on disk, S3 path, or URL to read `woodwork_typing_info.json`.
 
         Returns:
             dict: Woodwork typing information dictionary
-    '''
+    """
     path = os.path.abspath(path)
     assert os.path.exists(path), '"{}" does not exist'.format(path)
     file = os.path.join(path, 'woodwork_typing_info.json')
@@ -34,7 +34,7 @@ def read_table_typing_information(path):
 
 
 def _typing_information_to_woodwork_table(table_typing_info, **kwargs):
-    '''Deserialize Woodwork table from table description.
+    """Deserialize Woodwork table from table description.
 
     Args:
         table_typing_info (dict) : Woodwork typing information. Likely generated using :meth:`.serialize.typing_info_to_dict`
@@ -42,7 +42,7 @@ def _typing_information_to_woodwork_table(table_typing_info, **kwargs):
 
     Returns:
         DataFrame: DataFrame with Woodwork typing information initialized.
-    '''
+    """
     _check_schema_version(table_typing_info['schema_version'])
 
     path = table_typing_info['path']
@@ -127,7 +127,7 @@ def _typing_information_to_woodwork_table(table_typing_info, **kwargs):
 
 
 def read_woodwork_table(path, profile_name=None, **kwargs):
-    '''Read Woodwork table from disk, S3 path, or URL.
+    """Read Woodwork table from disk, S3 path, or URL.
 
         Args:
             path (str): Directory on disk, S3 path, or URL to read `woodwork_typing_info.json`.
@@ -137,7 +137,7 @@ def read_woodwork_table(path, profile_name=None, **kwargs):
 
         Returns:
             DataFrame: DataFrame with Woodwork typing information initialized.
-    '''
+    """
     if _is_url(path) or _is_s3(path):
         with tempfile.TemporaryDirectory() as tmpdir:
             file_name = Path(path).name
@@ -159,9 +159,8 @@ def read_woodwork_table(path, profile_name=None, **kwargs):
 
 
 def _check_schema_version(saved_version_str):
-    '''Warns users if the schema used to save their data is greater than the latest
-    supported schema or if it is an outdated schema that is no longer supported.
-    '''
+    """Warns users if the schema used to save their data is greater than the latest
+    supported schema or if it is an outdated schema that is no longer supported."""
     saved = saved_version_str.split('.')
     current = SCHEMA_VERSION.split('.')
 

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -90,14 +90,12 @@ class Schema(object):
         return True
 
     def __repr__(self):
-        '''A string representation of a Schema containing typing information.
-        '''
+        """A string representation of a Schema containing typing information."""
         return repr(self._get_typing_info())
 
     def _repr_html_(self):
-        '''An HTML representation of a Schema for IPython.display in Jupyter Notebooks
-        containing typing information and a preview of the data.
-        '''
+        """An HTML representation of a Schema for IPython.display in Jupyter Notebooks
+        containing typing information and a preview of the data."""
         return self._get_typing_info().to_html()
 
     @property
@@ -107,8 +105,7 @@ class Schema(object):
         return self._get_typing_info()
 
     def _get_typing_info(self):
-        '''Creates a DataFrame that contains the typing information for a Schema.
-        '''
+        """Creates a DataFrame that contains the typing information for a Schema."""
         typing_info = {}
         for col_name, col_dict in self.columns.items():
 
@@ -281,8 +278,7 @@ class Schema(object):
                         column_descriptions,
                         column_metadata):
         """Create a dictionary with column names as keys and new column dictionaries holding
-        each column's typing information as values.
-        """
+        each column's typing information as values."""
         columns = {}
         for name in column_names:
             semantic_tags_for_col = _convert_input_to_set((semantic_tags or {}).get(name),
@@ -300,12 +296,12 @@ class Schema(object):
         return columns
 
     def set_index(self, new_index):
-        '''Sets the index. Handles setting a new index, updating the index, or removing the index.
+        """Sets the index. Handles setting a new index, updating the index, or removing the index.
 
         Args:
             new_index (str): Name of the new index column. Must be present in the Schema.
                 If None, will remove the index.
-        '''
+        """
         old_index = self.index
         if old_index is not None:
             self.remove_semantic_tags({old_index: 'index'})
@@ -314,13 +310,13 @@ class Schema(object):
             self._set_index_tags(new_index)
 
     def set_time_index(self, new_time_index):
-        '''Set the time index. Adds the 'time_index' semantic tag to the column and
+        """Set the time index. Adds the 'time_index' semantic tag to the column and
         clears the tag from any previously set index column
 
         Args:
             new_time_index (str): The name of the column to set as the time index.
                 If None, will remove the time_index.
-        '''
+        """
         old_time_index = self.time_index
         if old_time_index is not None:
             self.remove_semantic_tags({old_time_index: 'time_index'})
@@ -360,10 +356,8 @@ class Schema(object):
         return new_schema
 
     def _set_index_tags(self, index):
-        '''
-        Updates the semantic tags of the index by removing any standard tags
-        before adding the 'index' tag.
-        '''
+        """Updates the semantic tags of the index by removing any standard tags
+        before adding the 'index' tag."""
         column_dict = self.columns[index]
 
         standard_tags = column_dict['logical_type'].standard_tags
@@ -433,14 +427,13 @@ class Schema(object):
         return list(cols_to_include)
 
     def _get_subset_schema(self, subset_cols):
-        '''
-        Creates a new Schema with specified columns, retaining typing information.
+        """Creates a new Schema with specified columns, retaining typing information.
 
         Args:
             subset_cols (list[str]): subset of columns from which to create the new Schema
         Returns:
             Schema: New Schema with attributes from original Schema
-        '''
+        """
         new_logical_types = {}
         new_semantic_tags = {}
         new_column_descriptions = {}

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -106,7 +106,7 @@ def _add_semantic_tags(new_tags, current_tags, name):
 
 
 def _remove_semantic_tags(tags_to_remove, current_tags, name, standard_tags, use_standard_tags):
-    """Removes specified semantic tags from from the current set of tags'
+    """Removes specified semantic tags from from the current set of tags
 
     Args:
         tags_to_remove (str/list/set): The tags to remove

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -22,9 +22,16 @@ FORMATS = ['csv', 'pickle', 'parquet']
 
 
 def typing_info_to_dict(dataframe):
-    '''Gets the description for a Woodwork table, including typing information for each column
+    """Creates the description for a Woodwork table, including typing information for each column
     and loading information.
-    '''
+    
+    Args:
+        dataframe (pd.DataFrame, dd.Dataframe, ks.DataFrame): DataFrame with Woodwork typing
+            information initialized.
+
+    Returns:
+        dict: Dictionary containing Woodwork typing information
+    """
     ordered_columns = dataframe.columns
     column_typing_info = [
         {'name': col_name,
@@ -64,7 +71,7 @@ def typing_info_to_dict(dataframe):
 
 
 def write_woodwork_table(dataframe, path, profile_name=None, **kwargs):
-    '''Serialize Woodwork table and write to disk or S3 path.
+    """Serialize Woodwork table and write to disk or S3 path.
 
     Args:
         dataframe (pd.DataFrame, dd.DataFrame, ks.DataFrame): DataFrame with Woodwork typing information initialized.
@@ -72,7 +79,7 @@ def write_woodwork_table(dataframe, path, profile_name=None, **kwargs):
         profile_name (str, bool): The AWS profile specified to write to S3. Will default to None and search for AWS credentials.
                 Set to False to use an anonymous profile.
         kwargs (keywords) : Additional keyword arguments to pass as keywords arguments to the underlying serialization method or to specify AWS profile.
-    '''
+    """
     if _is_s3(path):
         with tempfile.TemporaryDirectory() as tmpdir:
             os.makedirs(os.path.join(tmpdir, 'data'))
@@ -90,8 +97,7 @@ def write_woodwork_table(dataframe, path, profile_name=None, **kwargs):
 
 
 def _dump_table(dataframe, path, **kwargs):
-    '''Writes Woodwork table at the specified path, including both the data and the typing information.
-    '''
+    """Writes Woodwork table at the specified path, including both the data and the typing information."""
     loading_info = write_dataframe(dataframe, path, **kwargs)
 
     typing_info = typing_info_to_dict(dataframe)
@@ -101,8 +107,11 @@ def _dump_table(dataframe, path, **kwargs):
 
 
 def write_typing_info(typing_info, path):
-    '''Writes Woodwork typing information to the specified path at woodwork_typing_info.json
-    '''
+    """Writes Woodwork typing information to the specified path at woodwork_typing_info.json
+    
+    Args:
+        typing_info (dict): Dictionary containing Woodwork typing information.
+    """
     try:
         file = os.path.join(path, 'woodwork_typing_info.json')
         with open(file, 'w') as file:
@@ -112,7 +121,7 @@ def write_typing_info(typing_info, path):
 
 
 def write_dataframe(dataframe, path, format='csv', **kwargs):
-    '''Write underlying DataFrame data to disk or S3 path.
+    """Write underlying DataFrame data to disk or S3 path.
 
     Args:
         dataframe (pd.DataFrame, dd.DataFrame, ks.DataFrame): DataFrame with Woodwork typing information initialized.
@@ -121,8 +130,8 @@ def write_dataframe(dataframe, path, format='csv', **kwargs):
         kwargs (keywords) : Additional keyword arguments to pass as keywords arguments to the underlying serialization method.
 
     Returns:
-        loading_info (dict) : Information on storage location and format of data.
-    '''
+        dict: Information on storage location and format of data.
+    """
     format = format.lower()
 
     ww_name = dataframe.ww.name or 'data'
@@ -169,8 +178,7 @@ def write_dataframe(dataframe, path, format='csv', **kwargs):
 
 
 def _create_archive(tmpdir):
-    '''When seralizing to an S3 URL, writes a tar archive.
-    '''
+    """When seralizing to an S3 URL, writes a tar archive."""
     file_name = "ww-{date:%Y-%m-%d_%H%M%S}.tar".format(date=datetime.datetime.now())
     file_path = os.path.join(tmpdir, file_name)
     tar = tarfile.open(str(file_path), 'w')

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -24,7 +24,7 @@ FORMATS = ['csv', 'pickle', 'parquet']
 def typing_info_to_dict(dataframe):
     """Creates the description for a Woodwork table, including typing information for each column
     and loading information.
-    
+
     Args:
         dataframe (pd.DataFrame, dd.Dataframe, ks.DataFrame): DataFrame with Woodwork typing
             information initialized.
@@ -108,7 +108,7 @@ def _dump_table(dataframe, path, **kwargs):
 
 def write_typing_info(typing_info, path):
     """Writes Woodwork typing information to the specified path at woodwork_typing_info.json
-    
+
     Args:
         typing_info (dict): Dictionary containing Woodwork typing information.
     """

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -111,8 +111,7 @@ def _get_mode(series):
 
 
 def _replace_nans_for_mutual_info(schema, data):
-    """
-    Replace NaN values in the dataframe so that mutual information can be calculated
+    """Replace NaN values in the dataframe so that mutual information can be calculated
 
     Args:
         schema (woodwork.Schema): Woodwork typing info for the data
@@ -122,7 +121,6 @@ def _replace_nans_for_mutual_info(schema, data):
         pd.DataFrame: data with nans replaced with either mean or mode
 
     """
-    # replace or remove null values
     for column_name in data.columns[data.isnull().any()]:
         column = schema.columns[column_name]
         series = data[column_name]
@@ -144,7 +142,7 @@ def _make_categorical_for_mutual_info(schema, data, num_bins):
 
     Args:
         schema (woodwork.Schema): Woodwork typing info for the data
-        data (pd.DataFrame): dataframe to use for caculating mutual information
+        data (pd.DataFrame): dataframe to use for calculating mutual information
         num_bins (int): Determines number of bins to use for converting
             numeric features into categorical.
 
@@ -169,8 +167,7 @@ def _make_categorical_for_mutual_info(schema, data, num_bins):
 
 
 def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None):
-    """
-    Calculates mutual information between all pairs of columns in the DataFrame that
+    """Calculates mutual information between all pairs of columns in the DataFrame that
     support mutual information. Logical Types that support mutual information are as
     follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
     SubRegionCode, and ZIPCode
@@ -181,7 +178,7 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None):
         num_bins (int): Determines number of bins to use for converting
             numeric features into categorical.
         nrows (int): The number of rows to sample for when determining mutual info.
-        If specified, samples the desired number of rows from the data.
+            If specified, samples the desired number of rows from the data.
             Defaults to using all rows.
 
     Returns:
@@ -252,7 +249,7 @@ def _get_value_counts(dataframe, ascending=False, top_n=10, dropna=False):
 
     Returns:
         list(dict): a list of dictionaries for each categorical column with keys `count`
-            and `value`.
+        and `value`.
     """
     val_counts = {}
     valid_cols = [col for col, column in dataframe.ww.columns.items() if _is_col_categorical(column)]

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -243,10 +243,10 @@ class WoodworkTableAccessor:
     def set_index(self, new_index):
         """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
         and clears the tag from any previously set index column.
-        
+
         Setting a column as the index column will also cause any previously set standard
         tags for the column to be removed.
-        
+
         Clears the DataFrame's index by passing in None.
 
         Args:
@@ -257,6 +257,16 @@ class WoodworkTableAccessor:
         if self._schema.index is not None:
             _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
+
+    def set_time_index(self, new_time_index):
+        """Set the time index. Adds the 'time_index' semantic tag to the column and
+        clears the tag from any previously set index column
+
+        Args:
+            new_time_index (str): The name of the column to set as the time index.
+                If None, will remove the time_index.
+        """
+        self._schema.set_time_index(new_time_index)
 
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
         """Update the logical type and semantic tags for any columns names in the provided types dictionaries,
@@ -302,6 +312,42 @@ class WoodworkTableAccessor:
         """
         cols_to_include = self._schema._filter_cols(include)
         return self._get_subset_df_with_schema(cols_to_include)
+
+    def add_semantic_tags(self, semantic_tags):
+        """Adds specified semantic tags to columns, updating the Woodwork typing information.
+        Will retain any previously set values.
+
+        Args:
+            semantic_tags (dict[str -> str/list/set]): A dictionary mapping the columns
+                in the DataFrame to the tags that should be added to the column's semantic tags
+        """
+        self._schema.add_semantic_tags(semantic_tags)
+
+    def remove_semantic_tags(self, semantic_tags):
+        """Remove the semantic tags for any column names in the provided semantic_tags
+        dictionary, updating the Woodwork typing information. Including `index` or `time_index`
+        tags will set the Woodwork index or time index to None for the DataFrame.
+
+        Args:
+            semantic_tags (dict[str -> str/list/set]): A dictionary mapping the columns
+                in the DataFrame to the tags that should be removed from the column's semantic tags
+        """
+        self._schema.remove_semantic_tags(semantic_tags)
+
+    def reset_semantic_tags(self, columns=None, retain_index_tags=False):
+        """Reset the semantic tags for the specified columns to the default values.
+        The default values will be either an empty set or a set of the standard tags
+        based on the column logical type, controlled by the use_standard_tags property on the table.
+        Column names can be provided as a single string, a list of strings or a set of strings.
+        If columns is not specified, tags will be reset for all columns.
+
+        Args:
+            columns (str/list/set, optional): The columns for which the semantic tags should be reset.
+            retain_index_tags (bool, optional): If True, will retain any index or time_index
+                semantic tags set on the column. If False, will clear all semantic tags. Defaults to
+                False.
+        """
+        self._schema.reset_semantic_tags(columns=columns, retain_index_tags=retain_index_tags)
 
     def to_dictionary(self):
         """Get a dictionary representation of the Woodwork typing information.

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -49,7 +49,7 @@ class WoodworkTableAccessor:
              already_sorted=False,
              schema=None,
              **kwargs):
-        '''Initializes Woodwork typing information for a DataFrame.
+        """Initializes Woodwork typing information for a DataFrame.
 
         Args:
             index (str, optional): Name of the index column.
@@ -84,7 +84,7 @@ class WoodworkTableAccessor:
                 Any other arguments provided will be ignored. Note that any changes made to the schema object after
                 initialization will propagate to the DataFrame. Similarly, to avoid unintended typing information changes,
                 the same schema object should not be shared between DataFrames.
-        '''
+        """
         _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
         if schema is not None:
             self._schema = schema
@@ -135,11 +135,9 @@ class WoodworkTableAccessor:
                 self._sort_columns(already_sorted)
 
     def __getattr__(self, attr):
-        '''
-            If the method is present on the Accessor, uses that method.
-            If the method is present on Schema, uses that method.
-            If the method is present on DataFrame, uses that method.
-        '''
+        # If the method is present on the Accessor, uses that method.
+        # If the method is present on Schema, uses that method.
+        # If the method is present on DataFrame, uses that method.
         if self._schema is None:
             _raise_init_error()
         if hasattr(self._schema, attr):
@@ -207,8 +205,7 @@ class WoodworkTableAccessor:
 
     @property
     def schema(self):
-        ''' A copy of the Woodwork typing information for the DataFrame.
-        '''
+        """A copy of the Woodwork typing information for the DataFrame."""
         if self._schema:
             return self._schema._get_subset_schema(list(self.columns.keys()))
 
@@ -246,8 +243,10 @@ class WoodworkTableAccessor:
     def set_index(self, new_index):
         """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
         and clears the tag from any previously set index column.
+        
         Setting a column as the index column will also cause any previously set standard
         tags for the column to be removed.
+        
         Clears the DataFrame's index by passing in None.
 
         Args:
@@ -286,9 +285,10 @@ class WoodworkTableAccessor:
                 self._dataframe[col_name] = updated_series
 
     def select(self, include):
-        """Create a DataFrame with Woodowork typing information initialized
+        """Create a DataFrame with Woodwork typing information initialized
         that includes only columns whose Logical Type and semantic tags are
         specified in the list of types and tags to include.
+
         If no matching columns are found, an empty DataFrame will be returned.
 
         Args:
@@ -304,18 +304,17 @@ class WoodworkTableAccessor:
         return self._get_subset_df_with_schema(cols_to_include)
 
     def to_dictionary(self):
-        '''
-        Get a dictionary representation of the Woodwork typing information.
+        """Get a dictionary representation of the Woodwork typing information.
 
         Returns:
-            description (dict) : Description of the typing information.
-        '''
+            dict: Description of the typing information.
+        """
         if self._schema is None:
             _raise_init_error()
         return serialize.typing_info_to_dict(self._dataframe)
 
     def to_csv(self, path, sep=',', encoding='utf-8', engine='python', compression=None, profile_name=None):
-        '''Write Woodwork table to disk in the CSV format, location specified by `path`.
+        """Write Woodwork table to disk in the CSV format, location specified by `path`.
             Path could be a local path or a S3 path.
             If writing to S3 a tar archive of files will be written.
 
@@ -326,7 +325,7 @@ class WoodworkTableAccessor:
                 engine (str) : Name of the engine to use. Possible values are: {'c', 'python'}.
                 compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
                 profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
-        '''
+        """
         if self._schema is None:
             _raise_init_error()
         serialize.write_woodwork_table(self._dataframe, path, format='csv', index=False,
@@ -334,7 +333,7 @@ class WoodworkTableAccessor:
                                        compression=compression, profile_name=profile_name)
 
     def to_pickle(self, path, compression=None, profile_name=None):
-        '''Write Woodwork table to disk in the pickle format, location specified by `path`.
+        """Write Woodwork table to disk in the pickle format, location specified by `path`.
             Path could be a local path or a S3 path.
             If writing to S3 a tar archive of files will be written.
 
@@ -342,15 +341,17 @@ class WoodworkTableAccessor:
                 path (str) : Location on disk to write to (will be created as a directory)
                 compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
                 profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
-        '''
+        """
         if self._schema is None:
             _raise_init_error()
         serialize.write_woodwork_table(self._dataframe, path, format='pickle',
                                        compression=compression, profile_name=profile_name)
 
     def to_parquet(self, path, compression=None, profile_name=None):
-        '''Write Woodwork table to disk in the parquet format, location specified by `path`.
+        """Write Woodwork table to disk in the parquet format, location specified by `path`.
+
             Path could be a local path or a S3 path.
+
             If writing to S3 a tar archive of files will be written.
 
             Note:
@@ -361,7 +362,7 @@ class WoodworkTableAccessor:
                 path (str): location on disk to write to (will be created as a directory)
                 compression (str) : Name of the compression to use. Possible values are: {'snappy', 'gzip', 'brotli', None}.
                 profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
-        '''
+        """
         if self._schema is None:
             _raise_init_error()
 
@@ -387,11 +388,11 @@ class WoodworkTableAccessor:
             self._dataframe.sort_values(sort_cols, inplace=True)
 
     def _set_underlying_index(self):
-        '''Sets the index of the underlying DataFrame.
+        """Sets the index of the underlying DataFrame.
         If there is an index specified for the Schema, will be set to that index.
         If no index is specified and the DataFrame's index isn't a RangeIndex, will reset the DataFrame's index,
         meaning that the index will be a pd.RangeIndex starting from zero.
-        '''
+        """
         if isinstance(self._dataframe, pd.DataFrame):
             if self._schema.index is not None:
                 self._dataframe.set_index(self._schema.index, drop=False, inplace=True)
@@ -402,10 +403,8 @@ class WoodworkTableAccessor:
                 self._dataframe.reset_index(drop=True, inplace=True)
 
     def _make_schema_call(self, attr):
-        '''
-        Forwards the requested attribute onto the schema object.
-        Results are that of the Woodwork.Schema class.
-        '''
+        """Forwards the requested attribute onto the schema object.
+        Results are that of the Woodwork.Schema class."""
         schema_attr = getattr(self._schema, attr)
 
         if callable(schema_attr):
@@ -415,12 +414,9 @@ class WoodworkTableAccessor:
         return schema_attr
 
     def _make_dataframe_call(self, attr):
-        '''
-        Forwards the requested attribute onto the dataframe object.
-        Intercepts return value, attempting to initialize Woodwork with the current schema
-        when a new DataFrame is returned.
-        Confirms schema is still valid for the original DataFrame.
-        '''
+        """Forwards the requested attribute onto the dataframe object. Intercepts return value,
+        attempting to initialize Woodwork with the current schema when a new DataFrame is returned.
+        Confirms schema is still valid for the original DataFrame."""
         dataframe_attr = getattr(self._dataframe, attr)
 
         if callable(dataframe_attr):
@@ -453,10 +449,8 @@ class WoodworkTableAccessor:
         return dataframe_attr
 
     def _get_subset_df_with_schema(self, cols_to_include):
-        '''
-        Creates a new DataFrame from a list of column names with Woodwork initialized,
-        retaining all typing information and maintaining the DataFrame's column order.
-        '''
+        """Creates a new DataFrame from a list of column names with Woodwork initialized,
+        retaining all typing information and maintaining the DataFrame's column order."""
         assert all([col_name in self._schema.columns for col_name in cols_to_include])
         cols_to_include = [col_name for col_name in self._dataframe.columns if col_name in cols_to_include]
 
@@ -556,8 +550,7 @@ class WoodworkTableAccessor:
         return _get_mutual_information_dict(self._dataframe, num_bins=num_bins, nrows=nrows)
 
     def mutual_information(self, num_bins=10, nrows=None):
-        """
-        Calculates mutual information between all pairs of columns in the DataFrame that
+        """Calculates mutual information between all pairs of columns in the DataFrame that
         support mutual information. Logical Types that support mutual information are as
         follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
         SubRegionCode, and ZIPCode
@@ -583,10 +576,10 @@ class WoodworkTableAccessor:
 
         Args:
             include (list[str or LogicalType], optional): filter for what columns to include in the
-            statistics returned. Can be a list of column names, semantic tags, logical types, or a list
-            combining any of the three. It follows the most broad specification. Favors logical types
-            then semantic tag then column name. If no matching columns are found, an empty DataFrame
-            will be returned.
+                statistics returned. Can be a list of column names, semantic tags, logical types, or a list
+                combining any of the three. It follows the most broad specification. Favors logical types
+                then semantic tag then column name. If no matching columns are found, an empty DataFrame
+                will be returned.
 
         Returns:
             dict[str -> dict]: A dictionary with a key for each column in the data or for each column
@@ -600,10 +593,10 @@ class WoodworkTableAccessor:
 
         Args:
             include (list[str or LogicalType], optional): filter for what columns to include in the
-            statistics returned. Can be a list of column names, semantic tags, logical types, or a list
-            combining any of the three. It follows the most broad specification. Favors logical types
-            then semantic tag then column name. If no matching columns are found, an empty DataFrame
-            will be returned.
+                statistics returned. Can be a list of column names, semantic tags, logical types, or a list
+                combining any of the three. It follows the most broad specification. Favors logical types
+                then semantic tag then column name. If no matching columns are found, an empty DataFrame
+                will be returned.
 
         Returns:
             pd.DataFrame: A Dataframe containing statistics for the data or the subset of the original
@@ -647,8 +640,8 @@ class WoodworkTableAccessor:
                 to False.
 
         Returns:
-           list(dict): a list of dictionaries for each categorical column with keys `count`
-                and `value`.
+            list(dict): a list of dictionaries for each categorical column with keys `count`
+            and `value`.
         """
         return _get_value_counts(self._dataframe, ascending, top_n, dropna)
 

--- a/woodwork/tests/testing_utils/column_utils.py
+++ b/woodwork/tests/testing_utils/column_utils.py
@@ -4,8 +4,8 @@ ks = import_or_none('databricks.koalas')
 
 
 def convert_series(series, logical_type):
-    '''Converts a series to match the pandas_dtype of the provided logical type
-    for pandas/Dask, or converts to the backup_dtype for Koalas if one is defined'''
+    """Converts a series to match the pandas_dtype of the provided logical type
+    for pandas/Dask, or converts to the backup_dtype for Koalas if one is defined"""
     if ks and isinstance(series, ks.Series) and logical_type.backup_dtype:
         return series.astype(logical_type.backup_dtype)
     else:

--- a/woodwork/tests/testing_utils/datatable_utils.py
+++ b/woodwork/tests/testing_utils/datatable_utils.py
@@ -38,12 +38,11 @@ def mi_between_cols(col1, col2, df):
 
 
 def to_pandas(df, index=None, sort_index=False):
-    '''
-    Testing util to convert dataframes to pandas. If a pandas dataframe is passed in, just returns the dataframe.
+    """Testing util to convert dataframes to pandas. If a pandas dataframe is passed in, just returns the dataframe.
 
     Returns:
         Pandas DataFrame
-    '''
+    """
     if isinstance(df, (pd.DataFrame, pd.Series)):
         return df
 

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -36,11 +36,8 @@ def col_is_datetime(col, datetime_format=None):
 
 
 def _is_numeric_series(series, logical_type):
-    '''
-    Determines whether a series supplied to the DataTable will be considered numeric
-    for the purposes of determining if it can be a time_index.
-
-    '''
+    """Determines whether a series supplied to the DataTable will be considered numeric
+    for the purposes of determining if it can be a time_index."""
     if ks and isinstance(series, ks.Series):
         series = series.to_pandas()
 
@@ -125,8 +122,7 @@ def _get_ltype_class(ltype):
 
 
 def _get_specified_ltype_params(ltype):
-    '''
-    Gets a dictionary of a LogicalType's parameters.
+    """Gets a dictionary of a LogicalType's parameters.
 
     Note: If the logical type has not been instantiated, no parameters have
     been specified for the LogicalType, so no parameters will be returned
@@ -137,7 +133,7 @@ def _get_specified_ltype_params(ltype):
 
     Returns:
         dict: The LogicalType's specified parameters.
-    '''
+    """
     if ltype in ww.type_system.registered_types:
         # Do not reveal parameters for an uninstantiated LogicalType
         return {}

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -10,13 +10,12 @@ import woodwork as ww
 
 
 def import_or_none(library):
-    '''
-    Attemps to import the requested library.
+    """Attempts to import the requested library.
 
     Args:
         library (str): the name of the library
     Returns: the library if it is installed, else None
-    '''
+    """
     try:
         return importlib.import_module(library)
     except ImportError:
@@ -141,8 +140,7 @@ def read_csv_to_accessor(filepath=None,
 
 
 def _new_dt_including(datatable, new_data):
-    '''
-    Creates a new DataTable with specified data and columns
+    """Creates a new DataTable with specified data and columns
 
     Args:
         datatable (DataTable): DataTable with desired information
@@ -150,7 +148,7 @@ def _new_dt_including(datatable, new_data):
         new_data (DataFrame): subset of original DataTable
     Returns:
         DataTable: New DataTable with attributes from original DataTable but data from new DataTable
-    '''
+    """
     cols = new_data.columns
 
     new_logical_types = {}
@@ -185,14 +183,13 @@ def _new_dt_including(datatable, new_data):
 
 
 def import_or_raise(library, error_msg):
-    '''
-    Attempts to import the requested library.  If the import fails, raises an
+    """Attempts to import the requested library.  If the import fails, raises an
     ImportError with the supplied error message.
 
     Args:
         library (str): the name of the library
         error_msg (str): error message to return if the import fails
-    '''
+    """
     try:
         return importlib.import_module(library)
     except ImportError:
@@ -200,24 +197,17 @@ def import_or_raise(library, error_msg):
 
 
 def _is_s3(string):
-    '''
-    Checks if the given string is a s3 path.
-    Returns a boolean.
-    '''
+    """Checks if the given string is a s3 path. Returns a boolean."""
     return "s3://" in string
 
 
 def _is_url(string):
-    '''
-    Checks if the given string is an url path.
-    Returns a boolean.
-    '''
+    """Checks if the given string is an url path. Returns a boolean."""
     return 'http' in string
 
 
 def _reformat_to_latlong(latlong, use_list=False):
-    """Reformats LatLong columns to be tuples of floats. Uses np.nan for null values.
-    """
+    """Reformats LatLong columns to be tuples of floats. Uses np.nan for null values."""
     if _is_null_latlong(latlong):
         return np.nan
 
@@ -252,9 +242,7 @@ def _reformat_to_latlong(latlong, use_list=False):
 
 
 def _to_latlong_float(val):
-    '''
-    Attempts to convert a value to a float, propogating null values.
-    '''
+    """Attempts to convert a value to a float, propagating null values."""
     if _is_null_latlong(val):
         return np.nan
 
@@ -265,8 +253,8 @@ def _to_latlong_float(val):
 
 
 def _is_valid_latlong_series(series):
-    '''Returns True if all elements in the series contain properly formatted LatLong values,
-    otherwise returns False'''
+    """Returns True if all elements in the series contain properly formatted LatLong values,
+    otherwise returns False"""
     dd = import_or_none('dask.dataframe')
     ks = import_or_none('databricks.koalas')
     if dd and isinstance(series, dd.Series):
@@ -282,8 +270,8 @@ def _is_valid_latlong_series(series):
 
 
 def _is_valid_latlong_value(val, bracket_type=tuple):
-    '''Returns True if the value provided is a properly formatted LatLong value for a
-    pandas, Dask or Koalas Series, otherwise returns False.'''
+    """Returns True if the value provided is a properly formatted LatLong value for a
+    pandas, Dask or Koalas Series, otherwise returns False."""
     if isinstance(val, bracket_type) and len(val) == 2:
         latitude, longitude = val
         if isinstance(latitude, float) and isinstance(longitude, float):


### PR DESCRIPTION
- Update docstrings and API Reference
- Closes #604 

This PR makes several updates to accessor related docstrings for consistent formatting and completeness. All public methods and properties have been added to the API Reference Document.

In order for documentation on some methods to show in the proper location, adding these methods to the WoodworkTableAccessor class was necessary.