### PR TITLE
Preserve pandas underlying index when not creating a Woodwork index

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -45,6 +45,7 @@ Release Notes
     * Changes
         * Move mutual information logic to statistics utils file (:pr:`584`)
         * Bump min Koalas version to 1.4.0 (:pr:`638`)
+        * Preserve pandas underlying index when not creating a Woodwork index (:pr:`664`)
     * Documentation Changes
         * Update docstrings and API Reference page (:pr:`660`)
     * Testing Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -455,19 +455,14 @@ class WoodworkTableAccessor:
             self._dataframe.sort_values(sort_cols, inplace=True)
 
     def _set_underlying_index(self):
-        """Sets the index of the underlying DataFrame.
-        If there is an index specified for the Schema, will be set to that index.
-        If no index is specified and the DataFrame's index isn't a RangeIndex, will reset the DataFrame's index,
-        meaning that the index will be a pd.RangeIndex starting from zero.
+        """Sets the index of the underlying DataFrame to match the index column as
+        specified by the Schema. Does not change the underlying index if no Woodwork index is
+        specified. Only sets underlying index for pandas DataFrames.
         """
-        if isinstance(self._dataframe, pd.DataFrame):
-            if self._schema.index is not None:
-                self._dataframe.set_index(self._schema.index, drop=False, inplace=True)
-                # Drop index name to not overlap with the original column
-                self._dataframe.index.name = None
-            # Only reset the index if the index isn't a RangeIndex
-            elif not isinstance(self._dataframe.index, pd.RangeIndex):
-                self._dataframe.reset_index(drop=True, inplace=True)
+        if isinstance(self._dataframe, pd.DataFrame) and self._schema.index is not None:
+            self._dataframe.set_index(self._schema.index, drop=False, inplace=True)
+            # Drop index name to not overlap with the original column
+            self._dataframe.index.name = None
 
     def _make_schema_call(self, attr):
         """Forwards the requested attribute onto the schema object.

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1465,7 +1465,7 @@ def test_accessor_set_index(sample_df):
     assert sample_df.ww.index is None
     if isinstance(sample_df, pd.DataFrame):
         # underlying index not set for Dask/Koalas
-        # Check that underlying index doesn't get reset when Woodworki index is removed
+        # Check that underlying index doesn't get reset when Woodwork index is removed
         assert (sample_df.index == sample_df['full_name']).all()
 
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -795,7 +795,7 @@ def test_underlying_index_reset(sample_df):
     assert type(sample_df.index) == unspecified_index
 
 
-def test_underlying_index_after_updates(sample_df):
+def test_underlying_index_unchanged_after_updates(sample_df):
     if dd and isinstance(sample_df, dd.DataFrame):
         pytest.xfail('Setting underlying index is not supported with Dask input')
     if ks and isinstance(sample_df, ks.DataFrame):
@@ -1465,6 +1465,7 @@ def test_accessor_set_index(sample_df):
     assert sample_df.ww.index is None
     if isinstance(sample_df, pd.DataFrame):
         # underlying index not set for Dask/Koalas
+        # Check that underlying index doesn't get reset when Woodworki index is removed
         assert (sample_df.index == sample_df['full_name']).all()
 
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -776,10 +776,21 @@ def test_underlying_index_reset(sample_df):
     sample_df.ww.set_index('full_name')
     assert type(sample_df.index) == specified_index
 
+    copied_df = sample_df.ww.copy()
+    warning = ("Index mismatch between DataFrame and typing information")
+    with pytest.warns(TypingInfoMismatchWarning, match=warning):
+        copied_df.ww.reset_index(drop=True, inplace=True)
+    assert copied_df.ww.schema is None
+    assert type(copied_df.index) == unspecified_index
+
     sample_df.ww.set_index(None)
     assert type(sample_df.index) == specified_index
 
     # Use pandas operation to reset index
+    reset_df = sample_df.ww.reset_index(drop=True, inplace=False)
+    assert type(sample_df.index) == specified_index
+    assert type(reset_df.index) == unspecified_index
+
     sample_df.ww.reset_index(drop=True, inplace=True)
     assert type(sample_df.index) == unspecified_index
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1454,7 +1454,7 @@ def test_accessor_set_index(sample_df):
     assert sample_df.ww.index is None
     if isinstance(sample_df, pd.DataFrame):
         # underlying index not set for Dask/Koalas
-        assert (sample_df.index == range(4)).all()
+        assert (sample_df.index == sample_df['full_name']).all()
 
 
 def test_accessor_set_index_errors(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -784,6 +784,65 @@ def test_underlying_index_reset(sample_df):
     assert type(sample_df.index) == unspecified_index
 
 
+def test_underlying_index_after_updates(sample_df):
+    if dd and isinstance(sample_df, dd.DataFrame):
+        pytest.xfail('Setting underlying index is not supported with Dask input')
+    if ks and isinstance(sample_df, ks.DataFrame):
+        pytest.xfail('Setting underlying index is not supported with Koalas input')
+
+    sample_df.ww.init(index='full_name')
+    assert 'full_name' in sample_df
+    assert sample_df.ww.index == 'full_name'
+    assert (sample_df.index == sample_df['full_name']).all()
+
+    copied_df = sample_df.ww.copy()
+
+    dropped_df = copied_df.ww.drop('full_name')
+    assert 'full_name' not in dropped_df
+    assert dropped_df.ww.index is None
+    assert (dropped_df.index == sample_df['full_name']).all()
+
+    selected_df = copied_df.ww.select('Integer')
+    assert 'full_name' not in dropped_df
+    assert selected_df.ww.index is None
+    assert (selected_df.index == sample_df['full_name']).all()
+
+    iloc_df = copied_df.ww.iloc[:, 2:]
+    assert 'full_name' not in iloc_df
+    assert iloc_df.ww.index is None
+    assert (iloc_df.index == sample_df['full_name']).all()
+
+    loc_df = copied_df.ww.loc[:, ['id', 'email']]
+    assert 'full_name' not in loc_df
+    assert loc_df.ww.index is None
+    assert (loc_df.index == sample_df['full_name']).all()
+
+    subset_df = copied_df.ww[['id', 'email']]
+    assert 'full_name' not in subset_df
+    assert subset_df.ww.index is None
+    assert (subset_df.index == sample_df['full_name']).all()
+
+    reset_tags_df = sample_df.ww.copy()
+    reset_tags_df.ww.reset_semantic_tags('full_name', retain_index_tags=False)
+    assert reset_tags_df.ww.index is None
+    assert (reset_tags_df.index == sample_df['full_name']).all()
+
+    remove_tags_df = sample_df.ww.copy()
+    remove_tags_df.ww.remove_semantic_tags({'full_name': 'index'})
+    assert remove_tags_df.ww.index is None
+    assert (remove_tags_df.index == sample_df['full_name']).all()
+
+    set_types_df = sample_df.ww.copy()
+    set_types_df.ww.set_types(semantic_tags={'full_name': 'new_tag'}, retain_index_tags=False)
+    assert set_types_df.ww.index is None
+    assert (set_types_df.index == sample_df['full_name']).all()
+
+    popped_df = sample_df.ww.copy()
+    popped_df.ww.pop('full_name')
+    assert popped_df.ww.index is None
+    assert (popped_df.index == sample_df['full_name']).all()
+
+
 def test_accessor_already_sorted(sample_unsorted_df):
     if dd and isinstance(sample_unsorted_df, dd.DataFrame):
         pytest.xfail('Sorting dataframe is not supported with Dask input')


### PR DESCRIPTION
- Only updates underlying pandas index when a Woodwork index is set. Otherwise leaves underlying index alone.
- Closes #597 