### PR TITLE
Fix bug in _reset_semantic_tags causing columns to share the same semantic tags set

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -42,6 +42,7 @@ Release Notes
         * Adds ``__getitem__`` to WoodworkTableAccessor (:pr:`633`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
+        * Fix bug in ``_reset_semantic_tags`` causing columns to share same semantic tags set (:pr:`666`)
     * Changes
         * Move mutual information logic to statistics utils file (:pr:`584`)
         * Bump min Koalas version to 1.4.0 (:pr:`638`)

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -136,7 +136,7 @@ def _reset_semantic_tags(standard_tags, use_standard_tags):
         use_standard_tags (bool): If True, retain standard tags after reset
     """
     if use_standard_tags:
-        return standard_tags
+        return set(standard_tags)
     return set()
 
 

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -18,6 +18,7 @@ from woodwork.schema_column import (
     _is_col_categorical,
     _is_col_datetime,
     _is_col_numeric,
+    _reset_semantic_tags,
     _validate_description,
     _validate_logical_type,
     _validate_metadata
@@ -148,3 +149,10 @@ def test_is_col_datetime():
 
     double_column = _get_column_dict('floats', Double)
     assert not _is_col_datetime(double_column)
+
+
+def test_reset_semantic_tags_returns_new_object():
+    standard_tags = {'tag1', 'tag2'}
+    reset_tags = _reset_semantic_tags(standard_tags, use_standard_tags=True)
+    assert reset_tags is not standard_tags
+    assert reset_tags == standard_tags


### PR DESCRIPTION
- Fix bug in _reset_semantic_tags causing columns to share the same semantic tags set
- Closes #662 

This PR fixes a bug in `_reset_semantic_tags` that was causing multiple schema columns to share the same semantic tags set after reset. This was being cause by resetting the tags to `LogicalType.standard_tags` without creating a new set, so any columns that shared the same logical type were using the same set after the reset. This fix creates a new set, so that each column now has a unique set, and adds a test to verify this.