### PR TITLE
Remove dtype from Schema

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -72,7 +72,6 @@ Schema
     Schema.add_semantic_tags
     Schema.index
     Schema.logical_types
-    Schema.physical_types
     Schema.rename
     Schema.remove_semantic_tags
     Schema.reset_semantic_tags

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -48,6 +48,7 @@ Release Notes
         * Bump min Koalas version to 1.4.0 (:pr:`638`)
         * Preserve pandas underlying index when not creating a Woodwork index (:pr:`664`)
         * Restrict Koalas version to ``<1.7.0`` due to breaking changes (:pr:`674`)
+        * Remove dtype from Schema dictionary (:pr:`668`)
     * Documentation Changes
         * Update docstrings and API Reference page (:pr:`660`)
     * Testing Changes

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -134,4 +134,3 @@ def _get_valid_ltype_dtype(series, logical_type):
     if ks and isinstance(series, ks.Series) and backup_dtype:
         dtype = backup_dtype
     return dtype
-# --> dont pass in whole series just type?? or a needs_backup

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -65,7 +65,7 @@ def _update_column_dtype(series, logical_type):
             series = ks.from_pandas(formatted_series)
         else:
             series = series.apply(_reformat_to_latlong)
-    if logical_type.pandas_dtype != str(series.dtype):  # --> should this be cheking the valid ltype dtype or just pandas?
+    if logical_type.pandas_dtype != str(series.dtype):
         # Update the underlying series
         try:
             if _get_ltype_class(logical_type) == Datetime:

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -80,7 +80,7 @@ def _update_column_dtype(series, logical_type):
                 else:
                     series = pd.to_datetime(series, format=logical_type.datetime_format)
             else:
-                new_dtype = _get_valid_ltype_dtype_str(series, logical_type)
+                new_dtype = _get_valid_ltype_dtype(series, logical_type)
                 series = series.astype(new_dtype)
         except (TypeError, ValueError):
             error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
@@ -110,7 +110,7 @@ def _is_dataframe(data):
     return False
 
 
-def _get_valid_underlying_dtype_str(series, logical_type):
+def _get_valid_underlying_dtype(series, logical_type):
     """Return the dtype that is considered valid for a series
     with the given logical_type"""
     backup_dtype = logical_type.backup_dtype
@@ -126,13 +126,12 @@ def _get_valid_underlying_dtype_str(series, logical_type):
     return str(valid_dtype)
 
 
-# --> maybe pick a better name for these - also the str at the end might be redundant
-def _get_valid_ltype_dtype_str(series, logical_type):
+def _get_valid_ltype_dtype(series, logical_type):
     """Return the dtype that is considered valid for a given logical_type"""
     dtype = logical_type.pandas_dtype
 
     backup_dtype = logical_type.backup_dtype
     if ks and isinstance(series, ks.Series) and backup_dtype:
         dtype = backup_dtype
-    return str(dtype)
+    return dtype
 # --> dont pass in whole series just type?? or a needs_backup

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -65,7 +65,7 @@ def _update_column_dtype(series, logical_type):
             series = ks.from_pandas(formatted_series)
         else:
             series = series.apply(_reformat_to_latlong)
-    if logical_type.pandas_dtype != str(series.dtype):
+    if logical_type.pandas_dtype != str(series.dtype):  # --> should this be cheking the valid ltype dtype or just pandas?
         # Update the underlying series
         try:
             if _get_ltype_class(logical_type) == Datetime:
@@ -80,10 +80,7 @@ def _update_column_dtype(series, logical_type):
                 else:
                     series = pd.to_datetime(series, format=logical_type.datetime_format)
             else:
-                if ks and isinstance(series, ks.Series) and logical_type.backup_dtype:
-                    new_dtype = logical_type.backup_dtype
-                else:
-                    new_dtype = logical_type.pandas_dtype
+                new_dtype = _get_valid_ltype_dtype_str(series, logical_type)
                 series = series.astype(new_dtype)
         except (TypeError, ValueError):
             error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
@@ -113,7 +110,7 @@ def _is_dataframe(data):
     return False
 
 
-def _get_valid_dtype(series, logical_type):
+def _get_valid_underlying_dtype_str(series, logical_type):
     """Return the dtype that is considered valid for a series
     with the given logical_type"""
     backup_dtype = logical_type.backup_dtype
@@ -126,4 +123,16 @@ def _get_valid_dtype(series, logical_type):
     else:
         valid_dtype = logical_type.pandas_dtype
 
-    return valid_dtype
+    return str(valid_dtype)
+
+
+# --> maybe pick a better name for these - also the str at the end might be redundant
+def _get_valid_ltype_dtype_str(series, logical_type):
+    """Return the dtype that is considered valid for a given logical_type"""
+    dtype = logical_type.pandas_dtype
+
+    backup_dtype = logical_type.backup_dtype
+    if ks and isinstance(series, ks.Series) and backup_dtype:
+        dtype = backup_dtype
+    return str(dtype)
+# --> dont pass in whole series just type?? or a needs_backup

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -198,7 +198,6 @@ class WoodworkColumnAccessor:
                 # Try to initialize Woodwork with the existing Schema
                 if _is_series(result):
                     valid_dtype = _get_valid_underlying_dtype(result, self._schema['logical_type'])
-                    # --> test a situation where result dtype might have been int and valid might be Int
                     if str(result.dtype) == valid_dtype:
                         schema = copy.deepcopy(self._schema)
                         result.ww.init(**schema, use_standard_tags=self.use_standard_tags)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -3,7 +3,12 @@ import warnings
 
 import pandas as pd
 
-from woodwork.accessor_utils import _get_valid_dtype, _is_series, init_series
+from woodwork.accessor_utils import (
+    _get_valid_ltype_dtype_str,
+    _get_valid_underlying_dtype_str,
+    _is_series,
+    init_series
+)
 from woodwork.exceptions import TypingInfoMismatchWarning
 from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 from woodwork.logical_types import LatLong, Ordinal
@@ -174,7 +179,7 @@ class WoodworkColumnAccessor:
         if self._schema is None:
             _raise_init_error()
         msg = u"<Series: {} ".format(self._series.name)
-        msg += u"(Physical Type = {}) ".format(self._series.dtype)
+        msg += u"(Physical Type = {}) ".format(_get_valid_ltype_dtype_str(self._series, self.logical_type))
         msg += u"(Logical Type = {}) ".format(self.logical_type)
         msg += u"(Semantic Tags = {})>".format(self.semantic_tags)
         return msg
@@ -192,13 +197,15 @@ class WoodworkColumnAccessor:
 
                 # Try to initialize Woodwork with the existing Schema
                 if _is_series(result):
-                    valid_dtype = _get_valid_dtype(result, self._schema['logical_type'])
-                    if result.dtype == valid_dtype:
+                    valid_dtype = _get_valid_underlying_dtype_str(result, self._schema['logical_type'])
+                    # --> test a situation where result dtype might have been int and valid might be Int
+                    if str(result.dtype) == valid_dtype:
                         schema = copy.deepcopy(self._schema)
                         result.ww.init(**schema, use_standard_tags=self.use_standard_tags)
                     else:
+                        user_dtype = _get_valid_ltype_dtype_str(result, self._schema['logical_type'])
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \
-                            f'{valid_dtype}, and returned dtype, {result.dtype}'
+                            f'{user_dtype}, and returned dtype, {result.dtype}'
                         warning_message = TypingInfoMismatchWarning().get_warning_message(attr,
                                                                                           invalid_schema_message,
                                                                                           'Series')
@@ -212,14 +219,11 @@ class WoodworkColumnAccessor:
     def _validate_logical_type(self, logical_type):
         """Validates that a logical type is consistent with the series dtype. Performs additional type
         specific validation, as required."""
-        valid_dtype = _get_valid_dtype(self._series, logical_type)
+        valid_dtype = _get_valid_underlying_dtype_str(self._series, logical_type)
         if valid_dtype != str(self._series.dtype):
-            if ks and isinstance(self._series, ks.Series) and logical_type.backup_dtype:
-                # Koalas will have a dtype of `object` even after `ks.Series.astype('str')` but we want to inform
-                # users to try to convert to the backup dtype not the dtype considered valid for the series
-                convert_dtype = logical_type.backup_dtype
-            else:
-                convert_dtype = valid_dtype
+            # Koalas will have a dtype of `object` even after `ks.Series.astype('str')` but we want to inform
+            # users to try to convert to the Logical Type's backup dtype not the dtype considered valid for the series
+            convert_dtype = _get_valid_ltype_dtype_str(self._series, logical_type)
             raise ValueError(f"Cannot initialize Woodwork. Series dtype '{self._series.dtype}' is "
                              f"incompatible with {logical_type} dtype. Try converting series "
                              f"dtype to '{convert_dtype}' before initializing or use the "

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -195,8 +195,6 @@ class WoodworkColumnAccessor:
                     valid_dtype = _get_valid_dtype(result, self._schema['logical_type'])
                     if result.dtype == valid_dtype:
                         schema = copy.deepcopy(self._schema)
-                        # We don't need to pass dtype from the schema to init
-                        del schema['dtype']
                         result.ww.init(**schema, use_standard_tags=self.use_standard_tags)
                     else:
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -4,8 +4,8 @@ import warnings
 import pandas as pd
 
 from woodwork.accessor_utils import (
-    _get_valid_ltype_dtype_str,
-    _get_valid_underlying_dtype_str,
+    _get_valid_ltype_dtype,
+    _get_valid_underlying_dtype,
     _is_series,
     init_series
 )
@@ -179,7 +179,7 @@ class WoodworkColumnAccessor:
         if self._schema is None:
             _raise_init_error()
         msg = u"<Series: {} ".format(self._series.name)
-        msg += u"(Physical Type = {}) ".format(_get_valid_ltype_dtype_str(self._series, self.logical_type))
+        msg += u"(Physical Type = {}) ".format(_get_valid_ltype_dtype(self._series, self.logical_type))
         msg += u"(Logical Type = {}) ".format(self.logical_type)
         msg += u"(Semantic Tags = {})>".format(self.semantic_tags)
         return msg
@@ -197,13 +197,13 @@ class WoodworkColumnAccessor:
 
                 # Try to initialize Woodwork with the existing Schema
                 if _is_series(result):
-                    valid_dtype = _get_valid_underlying_dtype_str(result, self._schema['logical_type'])
+                    valid_dtype = _get_valid_underlying_dtype(result, self._schema['logical_type'])
                     # --> test a situation where result dtype might have been int and valid might be Int
                     if str(result.dtype) == valid_dtype:
                         schema = copy.deepcopy(self._schema)
                         result.ww.init(**schema, use_standard_tags=self.use_standard_tags)
                     else:
-                        user_dtype = _get_valid_ltype_dtype_str(result, self._schema['logical_type'])
+                        user_dtype = _get_valid_ltype_dtype(result, self._schema['logical_type'])
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \
                             f'{user_dtype}, and returned dtype, {result.dtype}'
                         warning_message = TypingInfoMismatchWarning().get_warning_message(attr,
@@ -219,11 +219,11 @@ class WoodworkColumnAccessor:
     def _validate_logical_type(self, logical_type):
         """Validates that a logical type is consistent with the series dtype. Performs additional type
         specific validation, as required."""
-        valid_dtype = _get_valid_underlying_dtype_str(self._series, logical_type)
+        valid_dtype = _get_valid_underlying_dtype(self._series, logical_type)
         if valid_dtype != str(self._series.dtype):
             # Koalas will have a dtype of `object` even after `ks.Series.astype('str')` but we want to inform
             # users to try to convert to the Logical Type's backup dtype not the dtype considered valid for the series
-            convert_dtype = _get_valid_ltype_dtype_str(self._series, logical_type)
+            convert_dtype = _get_valid_ltype_dtype(self._series, logical_type)
             raise ValueError(f"Cannot initialize Woodwork. Series dtype '{self._series.dtype}' is "
                              f"incompatible with {logical_type} dtype. Try converting series "
                              f"dtype to '{convert_dtype}' before initializing or use the "

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -90,7 +90,6 @@ def _process_selection(selection, original_data):
             # Selecting a new Series from an existing Series
             schema = copy.deepcopy(original_data.ww._schema)
         if schema:
-            del schema['dtype']
             selection.ww.init(**schema, use_standard_tags=original_data.ww.use_standard_tags)
     elif _is_dataframe(selection):
         # Selecting a new DataFrame from an existing DataFrame

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -127,11 +127,6 @@ class Schema(object):
         """A dictionary containing logical types for each column"""
         return {col_name: col['logical_type'] for col_name, col in self.columns.items()}
 
-    # @property #--> add to table accessor
-    # def physical_types(self):
-    #     """A dictionary containing physical types for each column"""
-    #     return {col_name: col['dtype'] for col_name, col in self.columns.items()}
-
     @property
     def semantic_tags(self):
         """A dictionary containing semantic tags for each column"""

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -100,8 +100,7 @@ class Schema(object):
 
     @property
     def types(self):
-        """DataFrame containing the physical dtypes, logical types and semantic
-        tags for the Schema."""
+        """DataFrame containing the logical types and semantic tags for the Schema."""
         return self._get_typing_info()
 
     def _get_typing_info(self):

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -109,11 +109,10 @@ class Schema(object):
         typing_info = {}
         for col_name, col_dict in self.columns.items():
 
-            # --> shouldn't have physical type in schema!!!!!!!!!!!! - should have own mehtod that adds onto this one!!
-            types = [col_dict['logical_type'].pandas_dtype, col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
+            types = [col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
             typing_info[col_name] = types
 
-        columns = ['Physical Type', 'Logical Type', 'Semantic Tag(s)']
+        columns = ['Logical Type', 'Semantic Tag(s)']
 
         df = pd.DataFrame.from_dict(typing_info,
                                     orient='index',

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -109,7 +109,8 @@ class Schema(object):
         typing_info = {}
         for col_name, col_dict in self.columns.items():
 
-            types = [col_dict['dtype'], col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
+            # --> shouldn't have physical type in schema!!!!!!!!!!!! - should have own mehtod that adds onto this one!!
+            types = [col_dict['logical_type'].pandas_dtype, col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
             typing_info[col_name] = types
 
         columns = ['Physical Type', 'Logical Type', 'Semantic Tag(s)']
@@ -126,10 +127,10 @@ class Schema(object):
         """A dictionary containing logical types for each column"""
         return {col_name: col['logical_type'] for col_name, col in self.columns.items()}
 
-    @property
-    def physical_types(self):
-        """A dictionary containing physical types for each column"""
-        return {col_name: col['dtype'] for col_name, col in self.columns.items()}
+    # @property #--> add to table accessor
+    # def physical_types(self):
+    #     """A dictionary containing physical types for each column"""
+    #     return {col_name: col['dtype'] for col_name, col in self.columns.items()}
 
     @property
     def semantic_tags(self):

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -36,7 +36,6 @@ def _get_column_dict(name,
     semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name)
 
     return {
-        'dtype': logical_type.pandas_dtype,
         'logical_type': logical_type,
         'semantic_tags': semantic_tags,
         'description': description,

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -7,6 +7,7 @@ import tempfile
 import pandas as pd
 
 import woodwork as ww
+from woodwork.accessor_utils import _get_valid_ltype_dtype_str
 from woodwork.s3_utils import get_transport_params, use_smartopen
 from woodwork.type_sys.utils import (
     _get_ltype_class,
@@ -41,7 +42,7 @@ def typing_info_to_dict(dataframe):
              'type': str(_get_ltype_class(col['logical_type']))
          },
          'physical_type': {
-             'type': str(dataframe[col_name].dtype)
+             'type': _get_valid_ltype_dtype_str(dataframe[col_name], col['logical_type'])
          },
          'semantic_tags': sorted(list(col['semantic_tags'])),
          'description': col['description'],

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -7,7 +7,7 @@ import tempfile
 import pandas as pd
 
 import woodwork as ww
-from woodwork.accessor_utils import _get_valid_ltype_dtype_str
+from woodwork.accessor_utils import _get_valid_ltype_dtype
 from woodwork.s3_utils import get_transport_params, use_smartopen
 from woodwork.type_sys.utils import (
     _get_ltype_class,
@@ -42,7 +42,7 @@ def typing_info_to_dict(dataframe):
              'type': str(_get_ltype_class(col['logical_type']))
          },
          'physical_type': {
-             'type': _get_valid_ltype_dtype_str(dataframe[col_name], col['logical_type'])
+             'type': _get_valid_ltype_dtype(dataframe[col_name], col['logical_type'])
          },
          'semantic_tags': sorted(list(col['semantic_tags'])),
          'description': col['description'],

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics.cluster import normalized_mutual_info_score
 
-from woodwork.accessor_utils import _get_valid_ltype_dtype_str
+from woodwork.accessor_utils import _get_valid_ltype_dtype
 from woodwork.logical_types import Datetime, Double, LatLong
 from woodwork.schema_column import (
     _is_col_boolean,
@@ -97,7 +97,7 @@ def _get_describe_dict(dataframe, include=None):
 
         values["nan_count"] = series.isna().sum()
         values["mode"] = mode
-        values["physical_type"] = _get_valid_ltype_dtype_str(dataframe[column_name], logical_type)
+        values["physical_type"] = _get_valid_ltype_dtype(dataframe[column_name], logical_type)
         values["logical_type"] = logical_type
         values["semantic_tags"] = semantic_tags
         results[column_name] = values

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics.cluster import normalized_mutual_info_score
 
-from woodwork.accessor_utils import _get_valid_dtype
 from woodwork.logical_types import Datetime, Double, LatLong
 from woodwork.schema_column import (
     _is_col_boolean,

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics.cluster import normalized_mutual_info_score
 
+from woodwork.accessor_utils import _get_valid_ltype_dtype_str
 from woodwork.logical_types import Datetime, Double, LatLong
 from woodwork.schema_column import (
     _is_col_boolean,
@@ -89,18 +90,14 @@ def _get_describe_dict(dataframe, include=None):
             values["third_quartile"] = quant_values[2]
 
         mode = _get_mode(series)
-        # --> should have a get_user_facing_dtype????
-        physical_type = logical_type.pandas_dtype
-        if ks and isinstance(dataframe, ks.DataFrame):
-            physical_type = logical_type.backup_dtype
 
-            # The format of the mode should match its format in the DataFrame
-            if series.name in latlong_columns:
-                mode = list(mode)
+        # The format of the mode should match its format in the DataFrame
+        if ks and isinstance(dataframe, ks.DataFrame) and series.name in latlong_columns:
+            mode = list(mode)
 
         values["nan_count"] = series.isna().sum()
         values["mode"] = mode
-        values["physical_type"] = physical_type
+        values["physical_type"] = _get_valid_ltype_dtype_str(dataframe[column_name], logical_type)
         values["logical_type"] = logical_type
         values["semantic_tags"] = semantic_tags
         results[column_name] = values

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics.cluster import normalized_mutual_info_score
 
+from woodwork.accessor_utils import _get_valid_dtype
 from woodwork.logical_types import Datetime, Double, LatLong
 from woodwork.schema_column import (
     _is_col_boolean,
@@ -89,13 +90,18 @@ def _get_describe_dict(dataframe, include=None):
             values["third_quartile"] = quant_values[2]
 
         mode = _get_mode(series)
-        # The format of the mode should match its format in the DataFrame
-        if ks and isinstance(dataframe, ks.DataFrame) and series.name in latlong_columns:
-            mode = list(mode)
+        # --> should have a get_user_facing_dtype????
+        physical_type = logical_type.pandas_dtype
+        if ks and isinstance(dataframe, ks.DataFrame):
+            physical_type = logical_type.backup_dtype
+
+            # The format of the mode should match its format in the DataFrame
+            if series.name in latlong_columns:
+                mode = list(mode)
 
         values["nan_count"] = series.isna().sum()
         values["mode"] = mode
-        values["physical_type"] = column['dtype']
+        values["physical_type"] = physical_type
         values["logical_type"] = logical_type
         values["semantic_tags"] = semantic_tags
         results[column_name] = values

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -231,20 +231,24 @@ class WoodworkTableAccessor:
             return self._schema._get_subset_schema(list(self.columns.keys()))
 
     @property
+    def physical_types(self):
+        """A dictionary containing physical types for each column"""
+        if ks and isinstance(self._dataframe, ks.DataFrame):
+            return {col_name: self.schema.logical_types[col_name].backup_dtype for col_name in self._dataframe.columns}
+        else:
+            return {col_name: self.schema.logical_types[col_name].pandas_dtype for col_name in self._dataframe.columns}
+
+    @property
     def types(self):
         """DataFrame containing the physical dtypes, logical types and semantic
         tags for the Schema."""
+        # --> should be its own things where it adds ptypes
         return self._schema.types
 
     @property
     def logical_types(self):
         """A dictionary containing logical types for each column"""
         return self._schema.logical_types
-
-    @property
-    def physical_types(self):
-        """A dictionary containing physical types for each column"""
-        return self._schema.physical_types
 
     @property
     def semantic_tags(self):
@@ -542,7 +546,6 @@ class WoodworkTableAccessor:
 
         # Initialize Woodwork typing info for series
         col_schema = self._schema.columns[column_name]
-        del col_schema['dtype']
         series.ww.init(**col_schema, use_standard_tags=self.use_standard_tags)
 
         # Update schema to not include popped column

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -809,7 +809,7 @@ def _get_invalid_schema_message(dataframe, schema):
     for name in dataframe.columns:
         df_dtype = dataframe[name].dtype
         valid_dtype = _get_valid_dtype(dataframe[name], schema.logical_types[name])
-        if df_dtype != valid_dtype:
+        if str(df_dtype) != str(valid_dtype):
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'
     if schema.index is not None and isinstance(dataframe, pd.DataFrame):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -179,6 +179,8 @@ class WoodworkTableAccessor:
 
     def _get_typing_info(self):
         """Creates a DataFrame that contains the typing information for a Woodwork table."""
+        if self._schema is None:
+            _raise_init_error()
         typing_info = self._schema._get_typing_info().copy()
         typing_info.insert(0, 'Physical Type', pd.Series(self.physical_types))
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -163,7 +163,6 @@ class WoodworkTableAccessor:
 
         series = self._dataframe[key]
         column = self.schema.columns[key]
-        del column['dtype']
         column['semantic_tags'] -= {'index', 'time_index'}
         series.ww.init(**column, use_standard_tags=self.use_standard_tags)
         return series

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -246,10 +246,14 @@ class WoodworkTableAccessor:
     @property
     def physical_types(self):
         """A dictionary containing physical types for each column"""
+        # --> probably a cleaner way to do this--also look at when we want the underlying dtype vs when we want the woodwork dtype
+
+        physical_types = {col_name: self.schema.logical_types[col_name].pandas_dtype for col_name in self._dataframe.columns}
         if ks and isinstance(self._dataframe, ks.DataFrame):
-            return {col_name: self.schema.logical_types[col_name].backup_dtype for col_name in self._dataframe.columns}
-        else:
-            return {col_name: self.schema.logical_types[col_name].pandas_dtype for col_name in self._dataframe.columns}
+            backup_dtypes = {col_name: self.schema.logical_types[col_name].backup_dtype for col_name in self._dataframe.columns if self.schema.logical_types[col_name].backup_dtype is not None}
+            physical_types = {**physical_types, **backup_dtypes}
+
+        return physical_types
 
     @property
     def types(self):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -168,17 +168,16 @@ class WoodworkTableAccessor:
         return series
 
     def __repr__(self):
+        """A string representation of a Woodwork table containing typing information"""
         return repr(self._get_typing_info())
 
     def _repr_html_(self):
-        '''An HTML representation of a Schema for IPython.display in Jupyter Notebooks
-        containing typing information and a preview of the data.
-        '''
+        """An HTML representation of a Woodwork table for IPython.display in Jupyter Notebooks
+        containing typing information and a preview of the data."""
         return self._get_typing_info().to_html()
 
     def _get_typing_info(self):
-        '''Creates a DataFrame that contains the typing information for a Woodwork table.
-        '''
+        """Creates a DataFrame that contains the typing information for a Woodwork table."""
         typing_info = self._schema._get_typing_info().copy()
         typing_info.insert(0, 'Physical Type', pd.Series(self.physical_types))
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -4,8 +4,8 @@ import pandas as pd
 
 import woodwork.serialize_accessor as serialize
 from woodwork.accessor_utils import (
-    _get_valid_ltype_dtype_str,
-    _get_valid_underlying_dtype_str,
+    _get_valid_ltype_dtype,
+    _get_valid_underlying_dtype,
     _is_dataframe,
     _update_column_dtype
 )
@@ -246,7 +246,7 @@ class WoodworkTableAccessor:
     @property
     def physical_types(self):
         """A dictionary containing physical types for each column"""
-        return {col_name: _get_valid_ltype_dtype_str(self._dataframe[col_name], self.schema.logical_types[col_name]) for col_name in self._dataframe.columns}
+        return {col_name: _get_valid_ltype_dtype(self._dataframe[col_name], self.schema.logical_types[col_name]) for col_name in self._dataframe.columns}
 
     @property
     def types(self):
@@ -817,7 +817,7 @@ def _get_invalid_schema_message(dataframe, schema):
             f'{schema_cols_not_in_df}'
     for name in dataframe.columns:
         df_dtype = dataframe[name].dtype
-        valid_dtype = _get_valid_underlying_dtype_str(dataframe[name], schema.logical_types[name])
+        valid_dtype = _get_valid_underlying_dtype(dataframe[name], schema.logical_types[name])
         if str(df_dtype) != valid_dtype:
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -169,7 +169,21 @@ class WoodworkTableAccessor:
         return series
 
     def __repr__(self):
-        return repr(self._schema)
+        return repr(self._get_typing_info())
+
+    def _repr_html_(self):
+        '''An HTML representation of a Schema for IPython.display in Jupyter Notebooks
+        containing typing information and a preview of the data.
+        '''
+        return self._get_typing_info().to_html()
+
+    def _get_typing_info(self):
+        '''Creates a DataFrame that contains the typing information for a Woodwork table.
+        '''
+        typing_info = self._schema._get_typing_info().copy()
+        typing_info.insert(0, 'Physical Type', pd.Series(self.physical_types))
+
+        return typing_info
 
     @property
     def iloc(self):
@@ -242,8 +256,7 @@ class WoodworkTableAccessor:
     def types(self):
         """DataFrame containing the physical dtypes, logical types and semantic
         tags for the Schema."""
-        # --> should be its own things where it adds ptypes
-        return self._schema.types
+        return self._get_typing_info()
 
     @property
     def logical_types(self):

--- a/woodwork/tests/accessor/test_accessor_utils.py
+++ b/woodwork/tests/accessor/test_accessor_utils.py
@@ -1,7 +1,8 @@
 import pytest
 
 from woodwork.accessor_utils import (
-    _get_valid_underlying_dtype_str,
+    _get_valid_ltype_dtype,
+    _get_valid_underlying_dtype,
     _is_dataframe,
     _is_series,
     init_series
@@ -22,14 +23,14 @@ ks = import_or_none('databricks.koalas')
 def test_init_series_valid_conversion_specified_ltype(sample_series):
     series = init_series(sample_series, logical_type='categorical')
     assert series is not sample_series
-    correct_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
+    correct_dtype = _get_valid_underlying_dtype(sample_series, Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'category'}
 
     series = init_series(sample_series, logical_type='natural_language')
     assert series is not sample_series
-    correct_dtype = _get_valid_underlying_dtype_str(sample_series, NaturalLanguage)
+    correct_dtype = _get_valid_underlying_dtype(sample_series, NaturalLanguage)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == NaturalLanguage
     assert series.ww.semantic_tags == set()
@@ -38,7 +39,7 @@ def test_init_series_valid_conversion_specified_ltype(sample_series):
 def test_init_series_valid_conversion_inferred_ltype(sample_series):
     series = init_series(sample_series)
     assert series is not sample_series
-    correct_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
+    correct_dtype = _get_valid_underlying_dtype(sample_series, Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'category'}
@@ -60,7 +61,7 @@ def test_init_series_all_parameters(sample_series):
                          description=description,
                          use_standard_tags=False)
     assert series is not sample_series
-    correct_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
+    correct_dtype = _get_valid_underlying_dtype(sample_series, Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'custom_tag'}
@@ -90,15 +91,28 @@ def test_is_dataframe(sample_df):
     assert not _is_dataframe(sample_df['id'])
 
 
-def test_get_valid_underlying_dtype_str(sample_series):
-    # --> test str and test that values arent equal with lower and upper case ints
-    valid_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
+def test_get_valid_underlying_dtype(sample_series):
+    valid_dtype = _get_valid_underlying_dtype(sample_series, Categorical)
     if ks and isinstance(sample_series, ks.Series):
         assert valid_dtype == 'object'
     else:
         assert valid_dtype == 'category'
 
-    valid_dtype = _get_valid_underlying_dtype_str(sample_series, Boolean)
+    valid_dtype = _get_valid_underlying_dtype(sample_series, Boolean)
+    if ks and isinstance(sample_series, ks.Series):
+        assert valid_dtype == 'bool'
+    else:
+        assert valid_dtype == 'boolean'
+
+
+def test_get_valid_ltype_dtype(sample_series):
+    valid_dtype = _get_valid_ltype_dtype(sample_series, Categorical)
+    if ks and isinstance(sample_series, ks.Series):
+        assert valid_dtype == 'str'
+    else:
+        assert valid_dtype == 'category'
+
+    valid_dtype = _get_valid_ltype_dtype(sample_series, Boolean)
     if ks and isinstance(sample_series, ks.Series):
         assert valid_dtype == 'bool'
     else:

--- a/woodwork/tests/accessor/test_accessor_utils.py
+++ b/woodwork/tests/accessor/test_accessor_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from woodwork.accessor_utils import (
-    _get_valid_dtype,
+    _get_valid_underlying_dtype_str,
     _is_dataframe,
     _is_series,
     init_series
@@ -22,14 +22,14 @@ ks = import_or_none('databricks.koalas')
 def test_init_series_valid_conversion_specified_ltype(sample_series):
     series = init_series(sample_series, logical_type='categorical')
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype(sample_series, Categorical)
+    correct_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'category'}
 
     series = init_series(sample_series, logical_type='natural_language')
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype(sample_series, NaturalLanguage)
+    correct_dtype = _get_valid_underlying_dtype_str(sample_series, NaturalLanguage)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == NaturalLanguage
     assert series.ww.semantic_tags == set()
@@ -38,7 +38,7 @@ def test_init_series_valid_conversion_specified_ltype(sample_series):
 def test_init_series_valid_conversion_inferred_ltype(sample_series):
     series = init_series(sample_series)
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype(sample_series, Categorical)
+    correct_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'category'}
@@ -60,7 +60,7 @@ def test_init_series_all_parameters(sample_series):
                          description=description,
                          use_standard_tags=False)
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype(sample_series, Categorical)
+    correct_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'custom_tag'}
@@ -90,14 +90,15 @@ def test_is_dataframe(sample_df):
     assert not _is_dataframe(sample_df['id'])
 
 
-def test_get_valid_dtype(sample_series):
-    valid_dtype = _get_valid_dtype(sample_series, Categorical)
+def test_get_valid_underlying_dtype_str(sample_series):
+    # --> test str and test that values arent equal with lower and upper case ints
+    valid_dtype = _get_valid_underlying_dtype_str(sample_series, Categorical)
     if ks and isinstance(sample_series, ks.Series):
         assert valid_dtype == 'object'
     else:
         assert valid_dtype == 'category'
 
-    valid_dtype = _get_valid_dtype(sample_series, Boolean)
+    valid_dtype = _get_valid_underlying_dtype_str(sample_series, Boolean)
     if ks and isinstance(sample_series, ks.Series):
         assert valid_dtype == 'bool'
     else:

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -406,6 +406,25 @@ def test_series_methods_on_accessor_returning_series_valid_schema(sample_series)
     pd.testing.assert_series_equal(to_pandas(replace_series), to_pandas(series.replace('a', 'd')))
 
 
+def test_series_methods_on_accessor_dtype_mismatch(sample_df):
+    ints_series = convert_series(sample_df['id'], Integer)
+    ints_series.ww.init()
+
+    assert ints_series.ww.logical_type == Integer
+    dtype = 'Int64'
+    if ks and isinstance(ints_series, ks.Series):
+        dtype = 'int64'
+    assert str(ints_series.dtype) == dtype
+
+    if ks and not isinstance(ints_series, ks.Series):
+        error = ("Operation performed by astype has invalidated the Woodwork typing information:\n "
+                 "dtype mismatch between original dtype, Int64, and returned dtype, int64.\n "
+                 "Please initialize Woodwork with Series.ww.init")
+        with pytest.warns(TypingInfoMismatchWarning, match=error):
+            series = ints_series.ww.astype('int64')
+        assert series.ww._schema is None
+
+
 def test_series_methods_on_accessor_inplace(sample_series):
     # TODO: Try to find a supported inplace method for Dask, if one exists
     if dd and isinstance(sample_series, dd.Series):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -167,7 +167,7 @@ def test_accessor_repr(sample_series):
     series.ww.init(use_standard_tags=False)
     # Koalas doesn't support categorical
     if ks and isinstance(series, ks.Series):
-        dtype = 'object'
+        dtype = 'str'
     else:
         dtype = 'category'
     assert series.ww.__repr__() == f'<Series: sample_series (Physical Type = {dtype}) ' \
@@ -425,7 +425,7 @@ def test_series_methods_on_accessor_returning_series_invalid_schema(sample_serie
     series.ww.init()
 
     if ks and isinstance(sample_series, ks.Series):
-        original_type = 'object'
+        original_type = 'str'
         new_type = 'int64'
     else:
         original_type = 'category'

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -56,8 +56,8 @@ def test_to_dictionary(sample_df):
 
     if ks and isinstance(sample_df, ks.DataFrame):
         int_val = 'int64'
-        cat_val = 'object'
-        string_val = 'object'
+        cat_val = 'str'
+        string_val = 'str'
         bool_val = 'bool'
     else:
         int_val = 'Int64'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -119,7 +119,7 @@ def test_accessor_physical_types_property(sample_df):
     assert set(sample_df.ww.physical_types.keys()) == set(sample_df.columns)
     for k, v in sample_df.ww.physical_types.items():
         logical_type = sample_df.ww.columns[k]['logical_type']
-        if ks and isinstance(sample_df, ks.DataFrame):
+        if ks and isinstance(sample_df, ks.DataFrame) and logical_type.backup_dtype is not None:
             assert v == logical_type.backup_dtype
         else:
             assert v == logical_type.pandas_dtype
@@ -1804,7 +1804,6 @@ def test_accessor_types(sample_df):
     }
     correct_physical_types = pd.Series(list(correct_physical_types.values()),
                                        index=list(correct_physical_types.keys()))
-    print(returned_types['Physical Type'])
     assert correct_physical_types.equals(returned_types['Physical Type'])
 
     correct_logical_types = {

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1832,6 +1832,9 @@ def test_accessor_types(sample_df):
 
 
 def test_accessor_repr(small_df):
+    error = 'Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init'
+    with pytest.raises(AttributeError, match=error):
+        repr(small_df.ww)
     small_df.ww.init()
 
     table_repr = repr(small_df.ww)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -176,7 +176,6 @@ def test_init_accessor_with_schema_errors(sample_df):
              "The following columns in the typing information were missing from the DataFrame: {'is_registered'}")
     with pytest.raises(ValueError, match=error):
         iloc_df.ww.init(schema=schema)
-# --> add a test with invalid dtypes!!!!
 
 
 def test_accessor_with_schema_parameter_warning(sample_df):
@@ -999,7 +998,6 @@ def test_get_invalid_schema_message_dtype_mismatch(sample_df):
     schema = schema_df.ww.schema
 
     if ks and isinstance(sample_df, ks.DataFrame):
-        # all are valid backup dtypes
         incorrect_int_dtype_df = schema_df.ww.astype({'id': 'float64'})
         incorrect_bool_dtype_df = schema_df.ww.astype({'is_registered': 'str'})
         assert (_get_invalid_schema_message(incorrect_int_dtype_df, schema) ==
@@ -1834,7 +1832,6 @@ def test_accessor_types(sample_df):
 
 
 def test_accessor_repr(small_df):
-    # --> koalas is broken need to actually look at repr
     small_df.ww.init()
 
     table_repr = repr(small_df.ww)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1783,7 +1783,30 @@ def test_accessor_types(sample_df):
     assert 'Semantic Tag(s)' in returned_types.columns
     assert returned_types.shape[1] == 3
     assert len(returned_types.index) == len(sample_df.columns)
-    # --> need to check physical types with koalas
+
+    if ks and isinstance(sample_df, ks.DataFrame):
+        string_dtype = 'str'
+        boolean_dtype = 'bool'
+        int_dtype = 'int64'
+    else:
+        string_dtype = 'string'
+        boolean_dtype = 'boolean'
+        int_dtype = 'Int64'
+
+    correct_physical_types = {
+        'id': int_dtype,
+        'full_name': string_dtype,
+        'email': string_dtype,
+        'phone_number': string_dtype,
+        'age': int_dtype,
+        'signup_date': 'datetime64[ns]',
+        'is_registered': boolean_dtype,
+    }
+    correct_physical_types = pd.Series(list(correct_physical_types.values()),
+                                       index=list(correct_physical_types.keys()))
+    print(returned_types['Physical Type'])
+    assert correct_physical_types.equals(returned_types['Physical Type'])
+
     correct_logical_types = {
         'id': Integer,
         'full_name': NaturalLanguage,
@@ -1812,6 +1835,7 @@ def test_accessor_types(sample_df):
 
 
 def test_accessor_repr(small_df):
+    # --> koalas is broken need to actually look at repr
     small_df.ww.init()
 
     table_repr = repr(small_df.ww)
@@ -1823,11 +1847,8 @@ def test_accessor_repr(small_df):
     assert table_html_repr == expected_repr
 
 
-def test_accessor_repr_empty():
-    # --> confirm this is how we do things with dask and koalas - from dt file
-    df = pd.DataFrame()
-    df.ww.init()
+def test_accessor_repr_empty(empty_df):
+    empty_df.ww.init()
 
-    assert repr(df.ww) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
-
-    assert df.ww._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'
+    assert repr(empty_df.ww) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
+    assert empty_df.ww._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -112,6 +112,21 @@ def test_accessor_schema_property(sample_df):
     assert sample_df.ww._schema == sample_df.ww.schema
 
 
+def test_accessor_physical_types_property(sample_df):
+    sample_df.ww.init()
+
+    assert isinstance(sample_df.ww.physical_types, dict)
+    assert set(sample_df.ww.physical_types.keys()) == set(sample_df.columns)
+    for k, v in sample_df.ww.physical_types.items():
+        logical_type = sample_df.ww.columns[k]['logical_type']
+        if ks and isinstance(sample_df, ks.DataFrame):
+            assert v == logical_type.backup_dtype
+        else:
+            assert v == logical_type.pandas_dtype
+
+
+# --> add test for tyypes property
+
 def test_accessor_separation_of_params(sample_df):
     # mix up order of acccessor and schema params
     schema_df = sample_df.copy()
@@ -514,7 +529,6 @@ def test_sets_category_dtype_on_init():
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
             assert df.ww.columns[column_name]['logical_type'] == logical_type
-            assert df.ww.columns[column_name]['dtype'] == logical_type.pandas_dtype
             assert df[column_name].dtype == logical_type.pandas_dtype
 
 
@@ -526,7 +540,6 @@ def test_sets_object_dtype_on_init(latlong_df):
         df = latlong_df.loc[:, [column_name]]
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == LatLong
-        assert df.ww.columns[column_name]['dtype'] == LatLong.pandas_dtype
         assert df[column_name].dtype == LatLong.pandas_dtype
         df_pandas = to_pandas(df[column_name])
         expected_val = (3, 4)
@@ -562,7 +575,6 @@ def test_sets_string_dtype_on_init():
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
             assert df.ww.columns[column_name]['logical_type'] == logical_type
-            assert df.ww.columns[column_name]['dtype'] == logical_type.pandas_dtype
             assert df[column_name].dtype == logical_type.pandas_dtype
 
 
@@ -584,7 +596,6 @@ def test_sets_boolean_dtype_on_init():
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == logical_type
-        assert df.ww.columns[column_name]['dtype'] == logical_type.pandas_dtype
         assert df[column_name].dtype == logical_type.pandas_dtype
 
 
@@ -607,7 +618,6 @@ def test_sets_int64_dtype_on_init():
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
             assert df.ww.columns[column_name]['logical_type'] == logical_type
-            assert df.ww.columns[column_name]['dtype'] == logical_type.pandas_dtype
             assert df[column_name].dtype == logical_type.pandas_dtype
 
 
@@ -628,7 +638,6 @@ def test_sets_float64_dtype_on_init():
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == logical_type
-        assert df.ww.columns[column_name]['dtype'] == logical_type.pandas_dtype
         assert df[column_name].dtype == logical_type.pandas_dtype
 
 
@@ -651,7 +660,6 @@ def test_sets_datetime64_dtype_on_init():
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == logical_type
-        assert df.ww.columns[column_name]['dtype'] == logical_type.pandas_dtype
         assert df[column_name].dtype == logical_type.pandas_dtype
 
 
@@ -1668,7 +1676,6 @@ def test_accessor_rename(sample_df):
     new_col = new_df.ww.columns['birthday']
     assert old_col['logical_type'] == new_col['logical_type']
     assert old_col['semantic_tags'] == new_col['semantic_tags']
-    assert old_col['dtype'] == new_col['dtype']
 
     new_df = sample_df.ww.rename({'age': 'full_name', 'full_name': 'age'})
 
@@ -1706,7 +1713,7 @@ def test_accessor_schema_properties(sample_df):
     sample_df.ww.init(index='id',
                       time_index='signup_date')
 
-    schema_properties = ['types', 'logical_types', 'physical_types', 'semantic_tags', 'index', 'time_index']
+    schema_properties = ['types', 'logical_types', 'semantic_tags', 'index', 'time_index']
     for schema_property in schema_properties:
         prop_from_accessor = getattr(sample_df.ww, schema_property)
         prop_from_schema = getattr(sample_df.ww.schema, schema_property)

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -50,10 +50,9 @@ def test_schema_types(sample_column_names, sample_inferred_logical_types):
 
     returned_types = schema.types
     assert isinstance(returned_types, pd.DataFrame)
-    assert 'Physical Type' in returned_types.columns
     assert 'Logical Type' in returned_types.columns
     assert 'Semantic Tag(s)' in returned_types.columns
-    assert returned_types.shape[1] == 3
+    assert returned_types.shape[1] == 2
     assert len(returned_types.index) == len(sample_column_names)
     correct_logical_types = {
         'id': Integer,

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -19,14 +19,6 @@ from woodwork.logical_types import (
 )
 from woodwork.schema import Schema
 
-# --> add to table accessor tests
-# def test_schema_physical_types(sample_column_names, sample_inferred_logical_types):
-#     schema = Schema(sample_column_names, sample_inferred_logical_types)
-#     assert isinstance(schema.physical_types, dict)
-#     assert set(schema.physical_types.keys()) == set(sample_column_names)
-#     for k, v in schema.physical_types.items():
-#         assert v == schema.columns[k]['logical_type'].pandas_dtype
-
 
 def test_schema_logical_types(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types)

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -19,13 +19,13 @@ from woodwork.logical_types import (
 )
 from woodwork.schema import Schema
 
-
-def test_schema_physical_types(sample_column_names, sample_inferred_logical_types):
-    schema = Schema(sample_column_names, sample_inferred_logical_types)
-    assert isinstance(schema.physical_types, dict)
-    assert set(schema.physical_types.keys()) == set(sample_column_names)
-    for k, v in schema.physical_types.items():
-        assert v == schema.columns[k]['logical_type'].pandas_dtype
+# --> add to table accessor tests
+# def test_schema_physical_types(sample_column_names, sample_inferred_logical_types):
+#     schema = Schema(sample_column_names, sample_inferred_logical_types)
+#     assert isinstance(schema.physical_types, dict)
+#     assert set(schema.physical_types.keys()) == set(sample_column_names)
+#     for k, v in schema.physical_types.items():
+#         assert v == schema.columns[k]['logical_type'].pandas_dtype
 
 
 def test_schema_logical_types(sample_column_names, sample_inferred_logical_types):
@@ -836,7 +836,6 @@ def test_schema_rename(sample_column_names, sample_inferred_logical_types):
     new_col = renamed_schema.columns['birthday']
     assert old_col['logical_type'] == new_col['logical_type']
     assert old_col['semantic_tags'] == new_col['semantic_tags']
-    assert old_col['dtype'] == new_col['dtype']
 
     swapped_schema = schema.rename({'age': 'full_name', 'full_name': 'age'})
     swapped_back_schema = swapped_schema.rename({'age': 'full_name', 'full_name': 'age'})

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -87,19 +87,19 @@ def test_schema_repr(small_df):
     schema = Schema(list(small_df.columns), logical_types={'sample_datetime_series': Datetime})
 
     schema_repr = repr(schema)
-    expected_repr = '                         Physical Type Logical Type Semantic Tag(s)\nColumn                                                             \nsample_datetime_series  datetime64[ns]     Datetime              []'
+    expected_repr = '                       Logical Type Semantic Tag(s)\nColumn                                             \nsample_datetime_series     Datetime              []'
     assert schema_repr == expected_repr
 
     schema_html_repr = schema._repr_html_()
-    expected_repr = '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>sample_datetime_series</th>\n      <td>datetime64[ns]</td>\n      <td>Datetime</td>\n      <td>[]</td>\n    </tr>\n  </tbody>\n</table>'
+    expected_repr = '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>sample_datetime_series</th>\n      <td>Datetime</td>\n      <td>[]</td>\n    </tr>\n  </tbody>\n</table>'
     assert schema_html_repr == expected_repr
 
 
 def test_schema_repr_empty():
     schema = Schema([], {})
-    assert repr(schema) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
+    assert repr(schema) == 'Empty DataFrame\nColumns: [Logical Type, Semantic Tag(s)]\nIndex: []'
 
-    assert schema._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'
+    assert schema._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'
 
 
 def test_schema_equality(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -60,10 +60,9 @@ def test_validate_metadata_errors():
 def test_get_column_dict():
     column = _get_column_dict('column', Integer, semantic_tags='test_tag')
 
-    assert set(column.keys()) == {'dtype', 'logical_type', 'semantic_tags', 'description', 'metadata'}
+    assert set(column.keys()) == {'logical_type', 'semantic_tags', 'description', 'metadata'}
 
     assert column.get('logical_type') == Integer
-    assert column.get('dtype') == 'Int64'
     assert column.get('semantic_tags') == {'numeric', 'test_tag'}
 
     assert column.get('description') is None

--- a/woodwork/tests/testing_utils/datatable_utils.py
+++ b/woodwork/tests/testing_utils/datatable_utils.py
@@ -25,7 +25,6 @@ def validate_subset_schema(subset_schema, schema):
         col = schema.columns[subset_col_name]
         assert subset_col['logical_type'] == col['logical_type']
         assert subset_col['semantic_tags'] == col['semantic_tags']
-        assert subset_col['dtype'] == col['dtype']
 
 
 def mi_between_cols(col1, col2, df):

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -74,7 +74,7 @@ def list_logical_types():
         [{'name': ltype.__name__,
           'type_string': ltype.type_string,
           'description': ltype.__doc__,
-          'physical_type': ltype.pandas_dtype,
+          'physical_type': ltype.pandas_dtype,  # --> should we offer both pd dtype and backup?
           'standard_tags': ltype.standard_tags,
           'is_default_type': ltype in ww.type_system._default_inference_functions,
           'is_registered': ltype in ww.type_system.registered_types,

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -74,7 +74,7 @@ def list_logical_types():
         [{'name': ltype.__name__,
           'type_string': ltype.type_string,
           'description': ltype.__doc__,
-          'physical_type': ltype.pandas_dtype,  # --> should we offer both pd dtype and backup?
+          'physical_type': ltype.pandas_dtype,
           'standard_tags': ltype.standard_tags,
           'is_default_type': ltype in ww.type_system._default_inference_functions,
           'is_registered': ltype in ww.type_system.registered_types,


### PR DESCRIPTION
- Removes the dtype field from the Schema class so that we're not storing the dtype in multiple ways
    - updates Schema repr to no longer contain physical type since it would need to know the DataFrame type
    - Adds reprs that contain physical type to Table Accessor 
    - Adds `_get_valid_ltype_dtype` helper to get the user-facing dtype (as opposed to the actual dtype of the series)
- Closes #653 , closes #658, closes #656