### PR TITLE
Adds __setitem__ to WoodworkTableAccessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -40,6 +40,7 @@ Release Notes
         * Add Schema properties to WoodworkTableAccessor (:pr:`651`)
         * Add KoalasTableAccessor (:pr:`652`)
         * Adds ``__getitem__`` to WoodworkTableAccessor (:pr:`633`)
+        * Adds ``__setitem__`` to WoodworkTableAccessor (:pr:`669`)
     * Fixes
         * Create new Schema object when performing pandas operation on Accessors (:pr:`595`)
     * Changes
@@ -52,7 +53,7 @@ Release Notes
         * Update release branch naming instructions (:pr:`644`)
 
     Thanks to the following people for contributing to this release:
-    :user:`johnbridstrup`, :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
+    :user:`johnbridstrup`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 **v0.0.10 February 25, 2021**
     * Changes

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -15,8 +15,8 @@ class StandardTagsRemovalWarning(UserWarning):
 
 class StandardTagsChangedWarning(UserWarning):
     def get_warning_message(self, use_standard_tags, col_name):
-        managed, changed = ('used', 'added to') if use_standard_tags else ('not used', 'removed from')
-        return f'Standard tags are {managed} by the data frame and have been {changed} "{col_name}"'
+        changed = 'added to' if use_standard_tags else 'removed from'
+        return f'Standard tags have been {changed} "{col_name}"'
 
 
 class UpgradeSchemaWarning(UserWarning):

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -13,6 +13,12 @@ class StandardTagsRemovalWarning(UserWarning):
         return f"Removing standard semantic tag(s) '{', '.join(standard_tags_to_remove)}' from column '{name}'"
 
 
+class StandardTagsChangedWarning(UserWarning):
+    def get_warning_message(self, use_standard_tags, col_name):
+        managed, changed = ('used', 'added to') if use_standard_tags else ('not used', 'removed from')
+        return f'Standard tags are {managed} by the data frame and have been {changed} "{col_name}"'
+
+
 class UpgradeSchemaWarning(UserWarning):
     def get_warning_message(self, saved_version_str, current_schema_version):
         return ('The schema version of the saved Woodwork table '

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -121,7 +121,7 @@ def _remove_semantic_tags(tags_to_remove, current_tags, name, standard_tags, use
         raise LookupError(f"Semantic tag(s) '{', '.join(invalid_tags)}' not present on column '{name}'")
     standard_tags_to_remove = sorted(list(tags_to_remove.intersection(standard_tags)))
     if standard_tags_to_remove and use_standard_tags:
-        warnings.warn(StandardTagsChangedWarning().get_warning_message(use_standard_tags, name),
+        warnings.warn(StandardTagsChangedWarning().get_warning_message(not use_standard_tags, name),
                       StandardTagsChangedWarning)
     return current_tags.difference(tags_to_remove)
 

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -3,7 +3,7 @@ import warnings
 import woodwork as ww
 from woodwork.exceptions import (
     DuplicateTagsWarning,
-    StandardTagsRemovalWarning
+    StandardTagsChangedWarning
 )
 from woodwork.logical_types import Boolean, Datetime, Ordinal
 from woodwork.type_sys.utils import _get_ltype_class
@@ -121,8 +121,8 @@ def _remove_semantic_tags(tags_to_remove, current_tags, name, standard_tags, use
         raise LookupError(f"Semantic tag(s) '{', '.join(invalid_tags)}' not present on column '{name}'")
     standard_tags_to_remove = sorted(list(tags_to_remove.intersection(standard_tags)))
     if standard_tags_to_remove and use_standard_tags:
-        warnings.warn(StandardTagsRemovalWarning().get_warning_message(standard_tags_to_remove, name),
-                      StandardTagsRemovalWarning)
+        warnings.warn(StandardTagsChangedWarning().get_warning_message(use_standard_tags, name),
+                      StandardTagsChangedWarning)
     return current_tags.difference(tags_to_remove)
 
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -13,6 +13,7 @@ from woodwork.exceptions import (
     ColumnNameMismatchWarning,
     ColumnNotPresentError,
     ParametersIgnoredWarning,
+    StandardTagsChangedWarning,
     TypingInfoMismatchWarning
 )
 from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
@@ -189,10 +190,12 @@ class WoodworkTableAccessor:
             column = init_series(column, use_standard_tags=self.use_standard_tags)
         elif self.use_standard_tags and not column.ww.use_standard_tags:
             column.ww._schema['semantic_tags'] |= column.ww.logical_type.standard_tags
-            warnings.warn(f'Standard tags are used by the data frame and have been added to "{col_name}"')
+            message = StandardTagsChangedWarning().get_warning_message(self.use_standard_tags, col_name)
+            warnings.warn(message, StandardTagsChangedWarning)
         elif not self.use_standard_tags and column.ww.use_standard_tags:
             column.ww._schema['semantic_tags'] -= column.ww.logical_type.standard_tags
-            warnings.warn(f'Standard tags are not used by the data frame and have been removed from "{col_name}"')
+            message = StandardTagsChangedWarning().get_warning_message(self.use_standard_tags, col_name)
+            warnings.warn(message, StandardTagsChangedWarning)
 
         self._dataframe[col_name] = column
         self._schema.columns[col_name] = column.ww._schema

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -187,11 +187,10 @@ class WoodworkTableAccessor:
                           ColumnNameMismatchWarning)
 
         if column.ww._schema is None:
-            column.ww.init()
+            column.ww.init(use_standard_tags=self.use_standard_tags)
 
         self._dataframe[col_name] = column
         self._schema.columns[col_name] = column.ww._schema
-
 
     def __repr__(self):
         return repr(self._schema)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -9,6 +9,7 @@ from woodwork.accessor_utils import (
     _update_column_dtype
 )
 from woodwork.exceptions import (
+    ColumnNameMismatchWarning,
     ColumnNotPresentError,
     ParametersIgnoredWarning,
     TypingInfoMismatchWarning

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -178,9 +178,9 @@ class WoodworkTableAccessor:
 
         # Don't allow reassigning of index or time index with setitem
         if self.index == col_name:
-            raise KeyError('Cannot reassign index. Change column name and then use dt.set_index to reassign index.')
+            raise KeyError('Cannot reassign index. Change column name and then use df.ww.set_index to reassign index.')
         if self.time_index == col_name:
-            raise KeyError('Cannot reassign time index. Change column name and then use dt.set_time_index to reassign time index.')
+            raise KeyError('Cannot reassign time index. Change column name and then use df.ww.set_time_index to reassign time index.')
 
         if column.name is not None and column.name != col_name:
             warnings.warn(ColumnNameMismatchWarning().get_warning_message(column.name, col_name),

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -187,6 +187,12 @@ class WoodworkTableAccessor:
 
         if column.ww._schema is None:
             column = init_series(column, use_standard_tags=self.use_standard_tags)
+        elif self.use_standard_tags and not column.ww.use_standard_tags:
+            column.ww._schema['semantic_tags'] |= column.ww.logical_type.standard_tags
+            warnings.warn(f'Standard tags are used by the data frame and have been added to "{col_name}"')
+        elif not self.use_standard_tags and column.ww.use_standard_tags:
+            column.ww._schema['semantic_tags'] -= column.ww.logical_type.standard_tags
+            warnings.warn(f'Standard tags are not used by the data frame and have been removed from "{col_name}"')
 
         self._dataframe[col_name] = column
         self._schema.columns[col_name] = column.ww._schema

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -6,7 +6,8 @@ import woodwork.serialize_accessor as serialize
 from woodwork.accessor_utils import (
     _get_valid_dtype,
     _is_dataframe,
-    _update_column_dtype
+    _update_column_dtype,
+    init_series
 )
 from woodwork.exceptions import (
     ColumnNameMismatchWarning,
@@ -185,7 +186,7 @@ class WoodworkTableAccessor:
                           ColumnNameMismatchWarning)
 
         if column.ww._schema is None:
-            column.ww.init(use_standard_tags=self.use_standard_tags)
+            column = init_series(column, use_standard_tags=self.use_standard_tags)
 
         self._dataframe[col_name] = column
         self._schema.columns[col_name] = column.ww._schema

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -344,7 +344,7 @@ def test_remove_standard_semantic_tag(sample_series):
     series = convert_series(sample_series, Categorical)
     # Check that warning is raised if use_standard_tags is True - tag should be removed
     series.ww.init(logical_type=Categorical, semantic_tags='tag1', use_standard_tags=True)
-    expected_message = 'Standard tags are used by the data frame and have been added to "sample_series"'
+    expected_message = 'Standard tags have been added to "sample_series"'
     with pytest.warns(UserWarning) as record:
         series.ww.remove_semantic_tags(['tag1', 'category'])
     assert len(record) == 1

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -345,7 +345,7 @@ def test_remove_standard_semantic_tag(sample_series):
     series = convert_series(sample_series, Categorical)
     # Check that warning is raised if use_standard_tags is True - tag should be removed
     series.ww.init(logical_type=Categorical, semantic_tags='tag1', use_standard_tags=True)
-    expected_message = 'Standard tags have been added to "sample_series"'
+    expected_message = 'Standard tags have been removed from "sample_series"'
     with pytest.warns(StandardTagsChangedWarning) as record:
         series.ww.remove_semantic_tags(['tag1', 'category'])
     assert len(record) == 1

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -7,6 +7,7 @@ import pytest
 from woodwork.accessor_utils import init_series
 from woodwork.exceptions import (
     DuplicateTagsWarning,
+    StandardTagsChangedWarning,
     TypeConversionError,
     TypingInfoMismatchWarning
 )
@@ -345,7 +346,7 @@ def test_remove_standard_semantic_tag(sample_series):
     # Check that warning is raised if use_standard_tags is True - tag should be removed
     series.ww.init(logical_type=Categorical, semantic_tags='tag1', use_standard_tags=True)
     expected_message = 'Standard tags have been added to "sample_series"'
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(StandardTagsChangedWarning) as record:
         series.ww.remove_semantic_tags(['tag1', 'category'])
     assert len(record) == 1
     assert record[0].message.args[0] == expected_message

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -344,7 +344,7 @@ def test_remove_standard_semantic_tag(sample_series):
     series = convert_series(sample_series, Categorical)
     # Check that warning is raised if use_standard_tags is True - tag should be removed
     series.ww.init(logical_type=Categorical, semantic_tags='tag1', use_standard_tags=True)
-    expected_message = "Removing standard semantic tag(s) 'category' from column 'sample_series'"
+    expected_message = 'Standard tags are used by the data frame and have been added to "sample_series"'
     with pytest.warns(UserWarning) as record:
         series.ww.remove_semantic_tags(['tag1', 'category'])
     assert len(record) == 1

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1694,7 +1694,7 @@ def test_setitem_new_column(sample_df):
 
     df.ww['test_col2'] = new_series
     assert 'test_col2' in df.columns
-    assert 'test_col2' in df.ww.columns
+    assert 'test_col2' in df.ww._schema.columns.keys()
     assert df.ww['test_col2'].ww.logical_type == Integer
     assert df.ww['test_col2'].ww.semantic_tags == set()
     assert df.ww['test_col2'].name == 'test_col2'
@@ -1712,7 +1712,7 @@ def test_setitem_new_column(sample_df):
     new_series.ww.init()
     df.ww['test_col'] = new_series
     assert 'test_col' in df.columns
-    assert 'test_col' in df.ww.columns
+    assert 'test_col' in df.ww._schema.columns.keys()
     assert df.ww['test_col'].ww.logical_type == Categorical
     assert df.ww['test_col'].ww.semantic_tags == {'category'}
     assert df.ww['test_col'].name == 'test_col'
@@ -1730,7 +1730,7 @@ def test_setitem_new_column(sample_df):
 
     df.ww['test_col3'] = new_series
     assert 'test_col3' in df.columns
-    assert 'test_col3' in df.ww.columns
+    assert 'test_col3' in df.ww._schema.columns.keys()
     assert df.ww['test_col3'].ww.logical_type == Double
     assert df.ww['test_col3'].ww.semantic_tags == {'test_tag'}
     assert df.ww['test_col3'].name == 'test_col3'
@@ -1760,7 +1760,7 @@ def test_setitem_overwrite_column(sample_df):
     df.ww['age'] = new_series
 
     assert 'age' in df.columns
-    assert 'age' in df.ww.columns
+    assert 'age' in df.ww._schema.columns.keys()
     assert df.ww['age'].ww.logical_type == original_col.ww.logical_type
     assert df.ww['age'].ww.semantic_tags == original_col.ww.semantic_tags
     assert df.ww['age'].dtype == dtype
@@ -1783,7 +1783,7 @@ def test_setitem_overwrite_column(sample_df):
 
     df.ww['full_name'] = new_series
     assert 'full_name' in df.columns
-    assert 'full_name' in df.ww.columns
+    assert 'full_name' in df.ww._schema.columns.keys()
     assert df.ww['full_name'].ww.logical_type == Boolean
     assert df.ww['full_name'].ww.semantic_tags == {'test_tag'}
     assert df.ww['full_name'].dtype == dtype

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1888,7 +1888,7 @@ def test_setitem_overwrite_column(sample_df):
         semantic_tags='test_tag',
     )
 
-    match = 'Standard tags are used by the data frame and have been added to "full_name"'
+    match = 'Standard tags have been added to "full_name"'
     with pytest.warns(StandardTagsChangedWarning, match=match):
         df.ww['full_name'] = new_series
 
@@ -1913,7 +1913,7 @@ def test_setitem_overwrite_column(sample_df):
         semantic_tags='test_tag',
     )
 
-    match = 'Standard tags are not used by the data frame and have been removed from "full_name"'
+    match = 'Standard tags have been removed from "full_name"'
     with pytest.warns(StandardTagsChangedWarning, match=match):
         df.ww['full_name'] = new_series
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1864,13 +1864,9 @@ def test_setitem_overwrite_column(sample_df):
 
     # Change dtype, logical types, and tags with conflicting use_standard_tags
     original_col = df['full_name']
-    new_series = pd.Series([True, False, False])
+    new_series = pd.Series([0, 1, 2], dtype='float')
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series = ks.Series(new_series)
-        dtype = 'bool'
-    else:
-        dtype = 'boolean'
-        new_series = new_series.astype(dtype)
 
     new_series = init_series(
         new_series,
@@ -1881,7 +1877,29 @@ def test_setitem_overwrite_column(sample_df):
     df.ww['full_name'] = new_series
     assert 'full_name' in df.columns
     assert 'full_name' in df.ww._schema.columns.keys()
-    assert df.ww['full_name'].ww.logical_type == Boolean
+    assert df.ww['full_name'].ww.logical_type == Double
+    assert df.ww['full_name'].ww.semantic_tags == {'test_tag', 'numeric'}
+    assert df.ww['full_name'].dtype == 'float'
+    assert original_col is not df.ww['full_name']
+
+    df = sample_df.copy()
+    df.ww.init(use_standard_tags=False)
+
+    original_col = df['full_name']
+    new_series = pd.Series([0, 1, 2], dtype='float')
+    if ks and isinstance(sample_df, ks.DataFrame):
+        new_series = ks.Series(new_series)
+
+    new_series = init_series(
+        new_series,
+        use_standard_tags=True,
+        semantic_tags='test_tag',
+    )
+
+    df.ww['full_name'] = new_series
+    assert 'full_name' in df.columns
+    assert 'full_name' in df.ww._schema.columns.keys()
+    assert df.ww['full_name'].ww.logical_type == Double
     assert df.ww['full_name'].ww.semantic_tags == {'test_tag'}
-    assert df.ww['full_name'].dtype == dtype
+    assert df.ww['full_name'].dtype == 'float'
     assert original_col is not df.ww['full_name']

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1642,11 +1642,11 @@ def test_setitem_invalid_input(sample_df):
     with pytest.raises(ValueError, match=error_msg):
         df.ww['test'] = [1, 2, 3]
 
-    error_msg = 'Cannot reassign index. Change column name and then use dt.set_index to reassign index.'
+    error_msg = 'Cannot reassign index. Change column name and then use df.ww.set_index to reassign index.'
     with pytest.raises(KeyError, match=error_msg):
         df.ww['id'] = df.id
 
-    error_msg = 'Cannot reassign time index. Change column name and then use dt.set_time_index to reassign time index.'
+    error_msg = 'Cannot reassign time index. Change column name and then use df.ww.set_time_index to reassign time index.'
     with pytest.raises(KeyError, match=error_msg):
         df.ww['signup_date'] = df.signup_date
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1746,8 +1746,7 @@ def test_setitem_overwrite_column(sample_df):
     )
 
     # Change to column no change in types
-    original_col = df['age']
-    original_col.ww.init()
+    original_col = df.ww['age'] 
     new_series = pd.Series([1, 2, 3])
     if ks and isinstance(sample_df, ks.DataFrame):
         dtype = 'int64'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1797,13 +1797,10 @@ def test_setitem_new_column(sample_df):
     df = sample_df.copy()
     df.ww.init(use_standard_tags=False)
 
+    new_series = pd.Series([1, 2, 3])
     if ks and isinstance(sample_df, ks.DataFrame):
-        dtype = 'int64'
-        new_series = pd.Series([1, 2, 3], dtype=dtype)
         new_series = ks.Series(new_series)
-    else:
-        dtype = 'Int64'
-        new_series = pd.Series([1, 2, 3], dtype=dtype)
+    dtype = 'Int64'
 
     df.ww['test_col2'] = new_series
     assert 'test_col2' in df.columns
@@ -1836,13 +1833,12 @@ def test_setitem_new_column(sample_df):
     df = sample_df.copy()
     df.ww.init(use_standard_tags=True)
 
+    new_series = pd.Series(['new', 'column', 'inserted'], name='test_col')
     if ks and isinstance(sample_df, ks.DataFrame):
-        dtype = 'object'
-        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
+        dtype = 'string'
         new_series = ks.Series(new_series)
     else:
         dtype = 'category'
-        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
 
     new_series = init_series(new_series)
     df.ww['test_col'] = new_series

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1863,12 +1863,9 @@ def test_setitem_overwrite_column(sample_df):
     original_col = df.ww['age']
     new_series = pd.Series([1, 2, 3])
     if ks and isinstance(sample_df, ks.DataFrame):
-        dtype = 'int64'
         new_series = ks.Series(new_series)
-    else:
-        dtype = 'Int64'
-        new_series = new_series.astype(dtype)
 
+    dtype = 'Int64'
     new_series = init_series(new_series, use_standard_tags=True)
     df.ww['age'] = new_series
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -10,6 +10,7 @@ from woodwork.exceptions import (
     ColumnNameMismatchWarning,
     ColumnNotPresentError,
     ParametersIgnoredWarning,
+    StandardTagsChangedWarning,
     TypeConversionError,
     TypingInfoMismatchWarning
 )
@@ -1890,7 +1891,10 @@ def test_setitem_overwrite_column(sample_df):
         semantic_tags='test_tag',
     )
 
-    df.ww['full_name'] = new_series
+    match = 'Standard tags are used by the data frame and have been added to "full_name"'
+    with pytest.warns(StandardTagsChangedWarning, match=match):
+        df.ww['full_name'] = new_series
+
     assert 'full_name' in df.columns
     assert 'full_name' in df.ww._schema.columns.keys()
     assert df.ww['full_name'].ww.logical_type == Double
@@ -1912,7 +1916,10 @@ def test_setitem_overwrite_column(sample_df):
         semantic_tags='test_tag',
     )
 
-    df.ww['full_name'] = new_series
+    match = 'Standard tags are not used by the data frame and have been removed from "full_name"'
+    with pytest.warns(StandardTagsChangedWarning, match=match):
+        df.ww['full_name'] = new_series
+
     assert 'full_name' in df.columns
     assert 'full_name' in df.ww._schema.columns.keys()
     assert df.ww['full_name'].ww.logical_type == Double

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1683,3 +1683,60 @@ def test_setitem_different_name(sample_df):
 
     assert df.ww['col_with_name'].name == 'col_with_name'
     assert 'wrong' not in df.ww.columns
+
+
+def test_setitem_new_column(sample_df):
+    df = sample_df.copy()
+    df.ww.init(use_standard_tags=False)
+
+    if ks and isinstance(sample_df, ks.DataFrame):
+        dtype = 'int64'
+        new_series = pd.Series([1, 2, 3], dtype=dtype)
+        new_series = ks.Series(new_series)
+    else:
+        dtype = 'Int64'
+        new_series = pd.Series([1, 2, 3], dtype=dtype)
+
+    df.ww['test_col2'] = new_series
+    assert 'test_col2' in df.columns
+    assert 'test_col2' in df.ww.columns
+    assert df.ww['test_col2'].ww.logical_type == Integer
+    assert df.ww['test_col2'].ww.semantic_tags == set()
+    assert df.ww['test_col2'].name == 'test_col2'
+    assert df.ww['test_col2'].dtype == dtype
+
+    # Standard tags and no logical type
+    if ks and isinstance(sample_df, ks.DataFrame):
+        dtype = 'object'
+        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
+        new_series = ks.Series(new_series)
+    else:
+        dtype = 'category'
+        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
+
+    new_series.ww.init()
+    df.ww['test_col'] = new_series
+    assert 'test_col' in df.columns
+    assert 'test_col' in df.ww.columns
+    assert df.ww['test_col'].ww.logical_type == Categorical
+    assert df.ww['test_col'].ww.semantic_tags == {'category'}
+    assert df.ww['test_col'].name == 'test_col'
+    assert df.ww['test_col'].dtype == dtype
+
+    new_series = pd.Series([1, 2, 3], dtype='float')
+    if ks and isinstance(sample_df, ks.DataFrame):
+        new_series = ks.Series(new_series)
+
+    new_series.ww.init(
+        logical_type=Double,
+        use_standard_tags=False,
+        semantic_tags={'test_tag'},
+    )
+
+    df.ww['test_col3'] = new_series
+    assert 'test_col3' in df.columns
+    assert 'test_col3' in df.ww.columns
+    assert df.ww['test_col3'].ww.logical_type == Double
+    assert df.ww['test_col3'].ww.semantic_tags == {'test_tag'}
+    assert df.ww['test_col3'].name == 'test_col3'
+    assert df.ww['test_col3'].dtype == 'float'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1653,17 +1653,18 @@ def test_setitem_invalid_input(sample_df):
 
 def test_setitem_different_name(sample_df):
     df = sample_df.copy()
-    df.ww.init(index='id', time_index='signup_date')
+    df.ww.init()
 
     new_series = pd.Series([1, 2, 3, 4], name='wrong', dtype='float')
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series = ks.Series(new_series)
 
-    warning = 'Name mismatch between wrong and right. Series name is now right'
+    warning = 'Name mismatch between wrong and id. Series name is now id'
     with pytest.warns(ColumnNameMismatchWarning, match=warning):
-        df.ww['right'] = new_series
+        df.ww['id'] = new_series
 
-    assert df.ww['right'].name == 'right'
+    assert df.ww['id'].name == 'id'
+    assert 'id' in df.ww._schema.columns.keys()
     assert 'wrong' not in df.ww.columns
 
     new_series2 = pd.Series([1, 2, 3, 4], name='wrong2', dtype='float')
@@ -1675,14 +1676,8 @@ def test_setitem_different_name(sample_df):
         df.ww['new_col'] = new_series2
 
     assert df.ww['new_col'].name == 'new_col'
+    assert 'new_col' in df.ww._schema.columns.keys()
     assert 'wrong2' not in df.ww.columns
-
-    warning = 'Name mismatch between wrong and col_with_name. Series name is now col_with_name'
-    with pytest.warns(ColumnNameMismatchWarning, match=warning):
-        df.ww['col_with_name'] = new_series
-
-    assert df.ww['col_with_name'].name == 'col_with_name'
-    assert 'wrong' not in df.ww.columns
 
 
 def test_setitem_new_column(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1797,24 +1797,6 @@ def test_setitem_new_column(sample_df):
     assert df.ww['test_col2'].name == 'test_col2'
     assert df.ww['test_col2'].dtype == dtype
 
-    # Standard tags and no logical type
-    if ks and isinstance(sample_df, ks.DataFrame):
-        dtype = 'object'
-        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
-        new_series = ks.Series(new_series)
-    else:
-        dtype = 'category'
-        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
-
-    new_series = init_series(new_series)
-    df.ww['test_col'] = new_series
-    assert 'test_col' in df.columns
-    assert 'test_col' in df.ww._schema.columns.keys()
-    assert df.ww['test_col'].ww.logical_type == Categorical
-    assert df.ww['test_col'].ww.semantic_tags == {'category'}
-    assert df.ww['test_col'].name == 'test_col'
-    assert df.ww['test_col'].dtype == dtype
-
     new_series = pd.Series([1, 2, 3], dtype='float')
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series = ks.Series(new_series)
@@ -1833,6 +1815,27 @@ def test_setitem_new_column(sample_df):
     assert df.ww['test_col3'].ww.semantic_tags == {'test_tag'}
     assert df.ww['test_col3'].name == 'test_col3'
     assert df.ww['test_col3'].dtype == 'float'
+
+    # Standard tags and no logical type
+    df = sample_df.copy()
+    df.ww.init(use_standard_tags=True)
+
+    if ks and isinstance(sample_df, ks.DataFrame):
+        dtype = 'object'
+        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
+        new_series = ks.Series(new_series)
+    else:
+        dtype = 'category'
+        new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
+
+    new_series = init_series(new_series)
+    df.ww['test_col'] = new_series
+    assert 'test_col' in df.columns
+    assert 'test_col' in df.ww._schema.columns.keys()
+    assert df.ww['test_col'].ww.logical_type == Categorical
+    assert df.ww['test_col'].ww.semantic_tags == {'category'}
+    assert df.ww['test_col'].name == 'test_col'
+    assert df.ww['test_col'].dtype == dtype
 
 
 def test_setitem_overwrite_column(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import woodwork as ww
+from woodwork.accessor_utils import init_series
 from woodwork.exceptions import (
     ColumnNameMismatchWarning,
     ColumnNotPresentError,
@@ -1851,7 +1852,7 @@ def test_setitem_overwrite_column(sample_df):
         dtype = 'Int64'
         new_series = new_series.astype(dtype)
 
-    new_series.ww.init(use_standard_tags=True)
+    new_series = init_series(new_series, use_standard_tags=True)
     df.ww['age'] = new_series
 
     assert 'age' in df.columns
@@ -1871,7 +1872,8 @@ def test_setitem_overwrite_column(sample_df):
         dtype = 'boolean'
         new_series = new_series.astype(dtype)
 
-    new_series.ww.init(
+    new_series = init_series(
+        new_series,
         use_standard_tags=False,
         semantic_tags='test_tag',
     )

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1775,6 +1775,7 @@ def test_setitem_different_name(sample_df):
         df.ww['id'] = new_series
 
     assert df.ww['id'].name == 'id'
+    assert 'id' in df.columns
     assert 'id' in df.ww._schema.columns.keys()
     assert 'wrong' not in df.ww.columns
 
@@ -1787,6 +1788,7 @@ def test_setitem_different_name(sample_df):
         df.ww['new_col'] = new_series2
 
     assert df.ww['new_col'].name == 'new_col'
+    assert 'new_col' in df.columns
     assert 'new_col' in df.ww._schema.columns.keys()
     assert 'wrong2' not in df.ww.columns
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -953,7 +953,7 @@ def test_accessor_with_falsy_column_names(falsy_names_df):
     schema_df.ww.set_time_index('')
     assert schema_df.ww.time_index == ''
 
-    schema_df.ww.pop('')
+    popped_col = schema_df.ww.pop('')
     assert '' not in schema_df
     assert '' not in schema_df.ww.columns
     assert schema_df.ww.time_index is None
@@ -961,10 +961,8 @@ def test_accessor_with_falsy_column_names(falsy_names_df):
     schema_df.ww.set_index(None)
     assert schema_df.ww.index is None
 
-    # --> add back in if setitem is implemented
-    # dt[''] = popped_col
-    # assert dt[''].name == ''
-    # assert dt['']._series.name == ''
+    schema_df.ww[''] = popped_col
+    assert schema_df.ww[''].name == ''
 
     renamed_df = schema_df.ww.rename({0: 'col_with_name'})
     assert 0 not in renamed_df.columns

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1776,9 +1776,9 @@ def test_setitem_different_name(sample_df):
         df.ww['id'] = new_series
 
     assert df.ww['id'].name == 'id'
-    assert 'id' in df.columns
-    assert 'id' in df.ww._schema.columns.keys()
+    assert 'id' in df.ww.columns
     assert 'wrong' not in df.ww.columns
+    assert 'wrong' not in df.columns
 
     new_series2 = pd.Series([1, 2, 3, 4], name='wrong2', dtype='float')
     if ks and isinstance(sample_df, ks.DataFrame):
@@ -1789,9 +1789,9 @@ def test_setitem_different_name(sample_df):
         df.ww['new_col'] = new_series2
 
     assert df.ww['new_col'].name == 'new_col'
-    assert 'new_col' in df.columns
-    assert 'new_col' in df.ww._schema.columns.keys()
+    assert 'new_col' in df.ww.columns
     assert 'wrong2' not in df.ww.columns
+    assert 'wrong2' not in df.columns
 
 
 def test_setitem_new_column(sample_df):
@@ -1823,8 +1823,7 @@ def test_setitem_new_column(sample_df):
     )
 
     df.ww['test_col3'] = new_series
-    assert 'test_col3' in df.columns
-    assert 'test_col3' in df.ww._schema.columns.keys()
+    assert 'test_col3' in df.ww.columns
     assert df.ww['test_col3'].ww.logical_type == Double
     assert df.ww['test_col3'].ww.semantic_tags == {'test_tag'}
     assert df.ww['test_col3'].name == 'test_col3'
@@ -1843,8 +1842,7 @@ def test_setitem_new_column(sample_df):
 
     new_series = init_series(new_series)
     df.ww['test_col'] = new_series
-    assert 'test_col' in df.columns
-    assert 'test_col' in df.ww._schema.columns.keys()
+    assert 'test_col' in df.ww.columns
     assert df.ww['test_col'].ww.logical_type == Categorical
     assert df.ww['test_col'].ww.semantic_tags == {'category'}
     assert df.ww['test_col'].name == 'test_col'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1746,7 +1746,7 @@ def test_setitem_overwrite_column(sample_df):
     )
 
     # Change to column no change in types
-    original_col = df.ww['age'] 
+    original_col = df.ww['age']
     new_series = pd.Series([1, 2, 3])
     if ks and isinstance(sample_df, ks.DataFrame):
         dtype = 'int64'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1806,7 +1806,7 @@ def test_setitem_new_column(sample_df):
         dtype = 'category'
         new_series = pd.Series(['new', 'column', 'inserted'], name='test_col', dtype=dtype)
 
-    new_series.ww.init()
+    new_series = init_series(new_series)
     df.ww['test_col'] = new_series
     assert 'test_col' in df.columns
     assert 'test_col' in df.ww._schema.columns.keys()
@@ -1819,7 +1819,8 @@ def test_setitem_new_column(sample_df):
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series = ks.Series(new_series)
 
-    new_series.ww.init(
+    new_series = init_series(
+        new_series,
         logical_type=Double,
         use_standard_tags=False,
         semantic_tags={'test_tag'},


### PR DESCRIPTION
Closes #647 by adding the method `__setitem__` to the WoodworkTableAccessor