### PR TITLE
Change backup dtype from str to object for relevant Logical Types

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -48,6 +48,7 @@ Release Notes
         * Bump min Koalas version to 1.4.0 (:pr:`638`)
         * Preserve pandas underlying index when not creating a Woodwork index (:pr:`664`)
         * Restrict Koalas version to ``<1.7.0`` due to breaking changes (:pr:`674`)
+        * Stop using ``str`` for backup dtype and use ``object`` instead (:pr:`672`)
     * Documentation Changes
         * Update docstrings and API Reference page (:pr:`660`)
     * Testing Changes

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -80,7 +80,7 @@ def _update_column_dtype(series, logical_type):
                 else:
                     series = pd.to_datetime(series, format=logical_type.datetime_format)
             else:
-                new_dtype = _get_dtype_to_convert(series, logical_type)
+                new_dtype = _get_dtype_to_convert(ks and isinstance(series, ks.Series), logical_type)
                 series = series.astype(new_dtype)
         except (TypeError, ValueError):
             error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
@@ -110,22 +110,22 @@ def _is_dataframe(data):
     return False
 
 
-def _get_valid_dtype(series, logical_type):
+def _get_valid_dtype_for_package(needs_backup, logical_type):
     """Return the dtype that is considered valid for a series
-    with the given logical_type"""
+    with the given logical_type. To be used when grabbing series.dtype is not suffiecient."""
     backup_dtype = logical_type.backup_dtype
     valid_dtype = logical_type.pandas_dtype
-    if ks and isinstance(series, ks.Series) and backup_dtype:
+    if needs_backup and backup_dtype:
         valid_dtype = backup_dtype
 
     return valid_dtype
 
 
-def _get_dtype_to_convert(series, logical_type):
+def _get_dtype_to_convert(needs_backup, logical_type):
     """Return the dtype that should be used to convert the dtype of a series
     to match Woodwork Logical Types"""
     backup_dtype = logical_type.backup_dtype
-    if ks and isinstance(series, ks.Series) and backup_dtype:
+    if needs_backup and backup_dtype:
         if backup_dtype == 'object':
             # Koalas dtype may be 'object', but we need 'str' to convert with astype()
             convert_dtype = 'str'

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -110,7 +110,7 @@ def _is_dataframe(data):
     return False
 
 
-def _get_valid_dtype_for_package(needs_backup, logical_type):
+def _get_valid_dtype(needs_backup, logical_type):
     """Return the dtype that is considered valid for a series
     with the given logical_type. To be used when grabbing series.dtype is not suffiecient."""
     backup_dtype = logical_type.backup_dtype

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -65,7 +65,8 @@ def _update_column_dtype(series, logical_type):
             series = ks.from_pandas(formatted_series)
         else:
             series = series.apply(_reformat_to_latlong)
-    if logical_type.pandas_dtype != str(series.dtype):
+    valid_dtype = _get_valid_dtype(ks and isinstance(series, ks.Series), logical_type)
+    if valid_dtype != str(series.dtype):
         # Update the underlying series
         try:
             if _get_ltype_class(logical_type) == Datetime:
@@ -84,7 +85,7 @@ def _update_column_dtype(series, logical_type):
                 series = series.astype(new_dtype)
         except (TypeError, ValueError):
             error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
-                f'to type {logical_type.pandas_dtype}. Please confirm the underlying data is consistent with ' \
+                f'to type {valid_dtype}. Please confirm the underlying data is consistent with ' \
                 f'logical type {logical_type}.'
             raise TypeConversionError(error_msg)
     return series

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -114,23 +114,20 @@ def _get_valid_dtype(series, logical_type):
     """Return the dtype that is considered valid for a series
     with the given logical_type"""
     backup_dtype = logical_type.backup_dtype
+    valid_dtype = logical_type.pandas_dtype
     if ks and isinstance(series, ks.Series) and backup_dtype:
-        if backup_dtype == 'str':
-            # Koalas will have a dtype of object even after `ks.Series.astype('str')`
-            valid_dtype = 'object'
-        else:
-            valid_dtype = backup_dtype
-    else:
-        valid_dtype = logical_type.pandas_dtype
+        valid_dtype = backup_dtype
 
     return valid_dtype
 
 
 def _get_dtype_to_convert(series, logical_type):
+    """Return the dtype that should be used to convert the dtype of a series
+    to match Woodwork Logical Types"""
     backup_dtype = logical_type.backup_dtype
     if ks and isinstance(series, ks.Series) and backup_dtype:
         if backup_dtype == 'object':
-            # Koalas dtype may be 'object', but we need 'str' to convert astype()
+            # Koalas dtype may be 'object', but we need 'str' to convert with astype()
             convert_dtype = 'str'
         else:
             convert_dtype = backup_dtype

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -3,7 +3,12 @@ import warnings
 
 import pandas as pd
 
-from woodwork.accessor_utils import _get_dtype_to_convert, _get_valid_dtype, _is_series, init_series
+from woodwork.accessor_utils import (
+    _get_dtype_to_convert,
+    _get_valid_dtype_for_package,
+    _is_series,
+    init_series
+)
 from woodwork.exceptions import TypingInfoMismatchWarning
 from woodwork.indexers import _iLocIndexerAccessor, _locIndexerAccessor
 from woodwork.logical_types import LatLong, Ordinal
@@ -192,7 +197,7 @@ class WoodworkColumnAccessor:
 
                 # Try to initialize Woodwork with the existing Schema
                 if _is_series(result):
-                    valid_dtype = _get_valid_dtype(result, self._schema['logical_type'])
+                    valid_dtype = _get_valid_dtype_for_package(ks and isinstance(result, ks.Series), self._schema['logical_type'])
                     if result.dtype == valid_dtype:
                         schema = copy.deepcopy(self._schema)
                         # We don't need to pass dtype from the schema to init
@@ -214,11 +219,12 @@ class WoodworkColumnAccessor:
     def _validate_logical_type(self, logical_type):
         """Validates that a logical type is consistent with the series dtype. Performs additional type
         specific validation, as required."""
-        valid_dtype = _get_valid_dtype(self._series, logical_type)
+        is_koalas = ks and isinstance(self._series, ks.Series)
+        valid_dtype = _get_valid_dtype_for_package(is_koalas, logical_type)
         if valid_dtype != str(self._series.dtype):
             # Koalas may have a dtype of `object`, but astype('object') raises an error,
             # so users must call astype'str') in that case.
-            convert_dtype = _get_dtype_to_convert(self._series, logical_type)
+            convert_dtype = _get_dtype_to_convert(is_koalas, logical_type)
 
             raise ValueError(f"Cannot initialize Woodwork. Series dtype '{self._series.dtype}' is "
                              f"incompatible with {logical_type} dtype. Try converting series "

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from woodwork.accessor_utils import (
     _get_dtype_to_convert,
-    _get_valid_dtype_for_package,
+    _get_valid_dtype,
     _is_series,
     init_series
 )
@@ -197,7 +197,7 @@ class WoodworkColumnAccessor:
 
                 # Try to initialize Woodwork with the existing Schema
                 if _is_series(result):
-                    valid_dtype = _get_valid_dtype_for_package(ks and isinstance(result, ks.Series), self._schema['logical_type'])
+                    valid_dtype = _get_valid_dtype(ks and isinstance(result, ks.Series), self._schema['logical_type'])
                     if result.dtype == valid_dtype:
                         schema = copy.deepcopy(self._schema)
                         # We don't need to pass dtype from the schema to init
@@ -220,7 +220,7 @@ class WoodworkColumnAccessor:
         """Validates that a logical type is consistent with the series dtype. Performs additional type
         specific validation, as required."""
         is_koalas = ks and isinstance(self._series, ks.Series)
-        valid_dtype = _get_valid_dtype_for_package(is_koalas, logical_type)
+        valid_dtype = _get_valid_dtype(is_koalas, logical_type)
         if valid_dtype != str(self._series.dtype):
             # Koalas may have a dtype of `object`, but astype('object') raises an error,
             # so users must call astype'str') in that case.

--- a/woodwork/datacolumn.py
+++ b/woodwork/datacolumn.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 import woodwork as ww
+from woodwork.accessor_utils import _get_dtype_to_convert
 from woodwork.exceptions import (
     ColumnNameMismatchWarning,
     DuplicateTagsWarning,
@@ -129,10 +130,7 @@ class DataColumn(object):
                     else:
                         self._series = pd.to_datetime(self._series, format=self.logical_type.datetime_format)
                 else:
-                    if ks and isinstance(self._series, ks.Series) and self.logical_type.backup_dtype:
-                        new_dtype = self.logical_type.backup_dtype
-                    else:
-                        new_dtype = self.logical_type.pandas_dtype
+                    new_dtype = _get_dtype_to_convert(self._series, self.logical_type)
                     self._series = self._series.astype(new_dtype)
             except (TypeError, ValueError):
                 error_msg = f'Error converting datatype for column {self.name} from type {str(self._series.dtype)} ' \

--- a/woodwork/datacolumn.py
+++ b/woodwork/datacolumn.py
@@ -130,7 +130,7 @@ class DataColumn(object):
                     else:
                         self._series = pd.to_datetime(self._series, format=self.logical_type.datetime_format)
                 else:
-                    new_dtype = _get_dtype_to_convert(self._series, self.logical_type)
+                    new_dtype = _get_dtype_to_convert(ks and isinstance(self._series, ks.Series), self.logical_type)
                     self._series = self._series.astype(new_dtype)
             except (TypeError, ValueError):
                 error_msg = f'Error converting datatype for column {self.name} from type {str(self._series.dtype)} ' \

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -56,7 +56,7 @@ class Categorical(LogicalType):
             [3, 1, 2]
     """
     pandas_dtype = 'category'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
     standard_tags = {'category'}
 
     def __init__(self, encoding=None):
@@ -76,7 +76,7 @@ class CountryCode(LogicalType):
             ["GB", "NZ", "DE"]
     """
     pandas_dtype = 'category'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
     standard_tags = {'category'}
 
 
@@ -142,7 +142,7 @@ class EmailAddress(LogicalType):
              "team@example.com"]
     """
     pandas_dtype = 'string'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
 
 
 class Filepath(LogicalType):
@@ -157,7 +157,7 @@ class Filepath(LogicalType):
              "/tmp"]
     """
     pandas_dtype = 'string'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
 
 
 class FullName(LogicalType):
@@ -172,7 +172,7 @@ class FullName(LogicalType):
              "James Brown"]
     """
     pandas_dtype = 'string'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
 
 
 class IPAddress(LogicalType):
@@ -187,7 +187,7 @@ class IPAddress(LogicalType):
              "2001:0db8:0000:0000:0000:ff00:0042:8329"]
     """
     pandas_dtype = 'string'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
 
 
 class LatLong(LogicalType):
@@ -224,7 +224,7 @@ class NaturalLanguage(LogicalType):
              "When will humans go to mars?"]
     """
     pandas_dtype = 'string'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
 
 
 class Ordinal(LogicalType):
@@ -243,7 +243,7 @@ class Ordinal(LogicalType):
             ["bronze", "silver", "gold"]
     """
     pandas_dtype = 'category'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
     standard_tags = {'category'}
 
     def __init__(self, order):
@@ -276,7 +276,7 @@ class PhoneNumber(LogicalType):
              "5551235495"]
     """
     pandas_dtype = 'string'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
 
 
 class SubRegionCode(LogicalType):
@@ -290,7 +290,7 @@ class SubRegionCode(LogicalType):
             ["AU-NSW", "AU-TAS", "AU-QLD"]
     """
     pandas_dtype = 'category'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
     standard_tags = {'category'}
 
 
@@ -319,7 +319,7 @@ class URL(LogicalType):
              "example.com"]
     """
     pandas_dtype = 'string'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
 
 
 class ZIPCode(LogicalType):
@@ -335,5 +335,5 @@ class ZIPCode(LogicalType):
              "10021"]
     """
     pandas_dtype = 'category'
-    backup_dtype = 'str'
+    backup_dtype = 'object'
     standard_tags = {'category'}

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 import woodwork.serialize_accessor as serialize
 from woodwork.accessor_utils import (
-    _get_valid_dtype_for_package,
+    _get_valid_dtype,
     _is_dataframe,
     _update_column_dtype
 )
@@ -805,7 +805,7 @@ def _get_invalid_schema_message(dataframe, schema):
             f'{schema_cols_not_in_df}'
     for name in dataframe.columns:
         df_dtype = dataframe[name].dtype
-        valid_dtype = _get_valid_dtype_for_package(ks and isinstance(dataframe, ks.DataFrame), schema.logical_types[name])
+        valid_dtype = _get_valid_dtype(ks and isinstance(dataframe, ks.DataFrame), schema.logical_types[name])
         if df_dtype != valid_dtype:
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 import woodwork.serialize_accessor as serialize
 from woodwork.accessor_utils import (
-    _get_valid_dtype,
+    _get_valid_dtype_for_package,
     _is_dataframe,
     _update_column_dtype
 )
@@ -805,7 +805,7 @@ def _get_invalid_schema_message(dataframe, schema):
             f'{schema_cols_not_in_df}'
     for name in dataframe.columns:
         df_dtype = dataframe[name].dtype
-        valid_dtype = _get_valid_dtype(dataframe[name], schema.logical_types[name])
+        valid_dtype = _get_valid_dtype_for_package(ks and isinstance(dataframe, ks.DataFrame), schema.logical_types[name])
         if df_dtype != valid_dtype:
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'

--- a/woodwork/tests/accessor/test_accessor_utils.py
+++ b/woodwork/tests/accessor/test_accessor_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 from woodwork.accessor_utils import (
     _get_dtype_to_convert,
-    _get_valid_dtype_for_package,
+    _get_valid_dtype,
     _is_dataframe,
     _is_series,
     init_series
@@ -23,14 +23,14 @@ ks = import_or_none('databricks.koalas')
 def test_init_series_valid_conversion_specified_ltype(sample_series):
     series = init_series(sample_series, logical_type='categorical')
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype_for_package(ks and isinstance(sample_series, ks.Series), Categorical)
+    correct_dtype = _get_valid_dtype(ks and isinstance(sample_series, ks.Series), Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'category'}
 
     series = init_series(sample_series, logical_type='natural_language')
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype_for_package(ks and isinstance(sample_series, ks.Series), NaturalLanguage)
+    correct_dtype = _get_valid_dtype(ks and isinstance(sample_series, ks.Series), NaturalLanguage)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == NaturalLanguage
     assert series.ww.semantic_tags == set()
@@ -39,7 +39,7 @@ def test_init_series_valid_conversion_specified_ltype(sample_series):
 def test_init_series_valid_conversion_inferred_ltype(sample_series):
     series = init_series(sample_series)
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype_for_package(ks and isinstance(sample_series, ks.Series), Categorical)
+    correct_dtype = _get_valid_dtype(ks and isinstance(sample_series, ks.Series), Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'category'}
@@ -61,7 +61,7 @@ def test_init_series_all_parameters(sample_series):
                          description=description,
                          use_standard_tags=False)
     assert series is not sample_series
-    correct_dtype = _get_valid_dtype_for_package(ks and isinstance(sample_series, ks.Series), Categorical)
+    correct_dtype = _get_valid_dtype(ks and isinstance(sample_series, ks.Series), Categorical)
     assert series.dtype == correct_dtype
     assert series.ww.logical_type == Categorical
     assert series.ww.semantic_tags == {'custom_tag'}
@@ -91,15 +91,15 @@ def test_is_dataframe(sample_df):
     assert not _is_dataframe(sample_df['id'])
 
 
-def test_get_valid_dtype_for_package(sample_series):
+def test_get_valid_dtype(sample_series):
     is_koalas = ks and isinstance(sample_series, ks.Series)
-    valid_dtype = _get_valid_dtype_for_package(is_koalas, Categorical)
+    valid_dtype = _get_valid_dtype(is_koalas, Categorical)
     if is_koalas:
         assert valid_dtype == 'object'
     else:
         assert valid_dtype == 'category'
 
-    valid_dtype = _get_valid_dtype_for_package(is_koalas, Boolean)
+    valid_dtype = _get_valid_dtype(is_koalas, Boolean)
     if is_koalas:
         assert valid_dtype == 'bool'
     else:

--- a/woodwork/tests/accessor/test_accessor_utils.py
+++ b/woodwork/tests/accessor/test_accessor_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from woodwork.accessor_utils import (
+    _get_dtype_to_convert,
     _get_valid_dtype,
     _is_dataframe,
     _is_series,
@@ -98,6 +99,20 @@ def test_get_valid_dtype(sample_series):
         assert valid_dtype == 'category'
 
     valid_dtype = _get_valid_dtype(sample_series, Boolean)
+    if ks and isinstance(sample_series, ks.Series):
+        assert valid_dtype == 'bool'
+    else:
+        assert valid_dtype == 'boolean'
+
+
+def test_get_dtype_to_convert(sample_series):
+    convert_dtype = _get_dtype_to_convert(sample_series, Categorical)
+    if ks and isinstance(sample_series, ks.Series):
+        assert convert_dtype == 'str'
+    else:
+        assert convert_dtype == 'category'
+
+    valid_dtype = _get_dtype_to_convert(sample_series, Boolean)
     if ks and isinstance(sample_series, ks.Series):
         assert valid_dtype == 'bool'
     else:

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -60,7 +60,7 @@ def test_accessor_init_with_invalid_logical_type(sample_series):
         # Koalas uses `object` as the dtype for NaturalLanguage, so need to use something else
         series = sample_series.astype('float')
         series_dtype = 'float64'
-        correct_dtype = 'object'
+        correct_dtype = 'str'
     else:
         series = sample_series
         series_dtype = 'object'

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -60,7 +60,7 @@ def test_accessor_init_with_invalid_logical_type(sample_series):
         # Koalas uses `object` as the dtype for NaturalLanguage, so need to use something else
         series = sample_series.astype('float')
         series_dtype = 'float64'
-        correct_dtype = 'str'
+        correct_dtype = 'object'
     else:
         series = sample_series
         series_dtype = 'object'

--- a/woodwork/tests/testing_utils/column_utils.py
+++ b/woodwork/tests/testing_utils/column_utils.py
@@ -7,5 +7,5 @@ ks = import_or_none('databricks.koalas')
 def convert_series(series, logical_type):
     """Converts a series to match the pandas_dtype of the provided logical type
     for pandas/Dask, or converts to the backup_dtype for Koalas if one is defined"""
-    convert_dtype = _get_dtype_to_convert(series, logical_type)
+    convert_dtype = _get_dtype_to_convert(ks and isinstance(series, ks.Series), logical_type)
     return series.astype(convert_dtype)

--- a/woodwork/tests/testing_utils/column_utils.py
+++ b/woodwork/tests/testing_utils/column_utils.py
@@ -1,3 +1,4 @@
+from woodwork.accessor_utils import _get_dtype_to_convert
 from woodwork.utils import import_or_none
 
 ks = import_or_none('databricks.koalas')
@@ -6,7 +7,5 @@ ks = import_or_none('databricks.koalas')
 def convert_series(series, logical_type):
     """Converts a series to match the pandas_dtype of the provided logical type
     for pandas/Dask, or converts to the backup_dtype for Koalas if one is defined"""
-    if ks and isinstance(series, ks.Series) and logical_type.backup_dtype:
-        return series.astype(logical_type.backup_dtype)
-    else:
-        return series.astype(logical_type.pandas_dtype)
+    convert_dtype = _get_dtype_to_convert(series, logical_type)
+    return series.astype(convert_dtype)


### PR DESCRIPTION
- Changes the backup dtype for certain LogicalTypes to be `object` so that a column's physical type will match its series' dtype.
- Updates `_get_valid_dtype` to take in a boolean `needs_backup` to make it clear that the function never looks at a series' dtype; it's determining a valid dtype for a Logical Type. 
- Closes #670 

With this change, we should be able to avoid having to use `backup_dtype` or `pandas_dtype` directly. Either we can use the helpers in `accessor_utils` or we can get the dtype directly from the series.