### PR TITLE
Limit koalas to <1.7.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Restrict Koalas version to ``<1.7.0`` due to breaking changes (:pr:`674`)
     * Documentation Changes
     * Testing Changes
         * Update branch reference in tests to run on main (:pr:`641`)
@@ -13,7 +14,7 @@ Release Notes
         * Update release branch naming instructions (:pr:`644`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`thehomebrewnerd`
 
 **v0.0.10 February 25, 2021**
     * Changes

--- a/koalas-requirements.txt
+++ b/koalas-requirements.txt
@@ -1,3 +1,3 @@
 pyspark>=3.0.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
-koalas>=1.3.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
+koalas>=1.3.0,<1.7.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
 numpy<1.20.0 # remove when koalas supports 1.20.0


### PR DESCRIPTION
- Limit koalas to <1.7.0

Restrict Koalas version to `<1.7.0` as a result of breaking changes with version `1.7.0`.