### PR TITLE
Remove dtype from Schema dictionary

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -72,7 +72,6 @@ Schema
     Schema.add_semantic_tags
     Schema.index
     Schema.logical_types
-    Schema.physical_types
     Schema.rename
     Schema.remove_semantic_tags
     Schema.reset_semantic_tags

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -51,6 +51,8 @@ Release Notes
         * Preserve pandas underlying index when not creating a Woodwork index (:pr:`664`)
         * Restrict Koalas version to ``<1.7.0`` due to breaking changes (:pr:`674`)
         * Clean up dtype usage across Woodwork (:pr:`682`)
+        * Remove dtype from Schema dictionary (:pr:`685`)
+
     * Documentation Changes
         * Update docstrings and API Reference page (:pr:`660`)
     * Testing Changes

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -65,8 +65,8 @@ def _update_column_dtype(series, logical_type):
             series = ks.from_pandas(formatted_series)
         else:
             series = series.apply(_reformat_to_latlong)
-    if _get_valid_dtype(series, logical_type) != str(series.dtype):
-        new_dtype = _get_valid_dtype(type(series), logical_type)
+    new_dtype = _get_valid_dtype(type(series), logical_type)
+    if new_dtype != str(series.dtype):
         # Update the underlying series
         try:
             if _get_ltype_class(logical_type) == Datetime:

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -65,7 +65,7 @@ def _update_column_dtype(series, logical_type):
             series = ks.from_pandas(formatted_series)
         else:
             series = series.apply(_reformat_to_latlong)
-    if logical_type.primary_dtype != str(series.dtype):
+    if _get_valid_dtype(series, logical_type) != str(series.dtype):
         new_dtype = _get_valid_dtype(type(series), logical_type)
         # Update the underlying series
         try:

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -195,8 +195,6 @@ class WoodworkColumnAccessor:
                     valid_dtype = _get_valid_dtype(type(result), self._schema['logical_type'])
                     if str(result.dtype) == valid_dtype:
                         schema = copy.deepcopy(self._schema)
-                        # We don't need to pass dtype from the schema to init
-                        del schema['dtype']
                         result.ww.init(**schema, use_standard_tags=self.use_standard_tags)
                     else:
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -90,7 +90,6 @@ def _process_selection(selection, original_data):
             # Selecting a new Series from an existing Series
             schema = copy.deepcopy(original_data.ww._schema)
         if schema:
-            del schema['dtype']
             selection.ww.init(**schema, use_standard_tags=original_data.ww.use_standard_tags)
     elif _is_dataframe(selection):
         # Selecting a new DataFrame from an existing DataFrame

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -127,11 +127,6 @@ class Schema(object):
         """A dictionary containing logical types for each column"""
         return {col_name: col['logical_type'] for col_name, col in self.columns.items()}
 
-    # @property #--> add to table accessor
-    # def physical_types(self):
-    #     """A dictionary containing physical types for each column"""
-    #     return {col_name: col['dtype'] for col_name, col in self.columns.items()}
-
     @property
     def semantic_tags(self):
         """A dictionary containing semantic tags for each column"""

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -109,7 +109,8 @@ class Schema(object):
         typing_info = {}
         for col_name, col_dict in self.columns.items():
 
-            types = [col_dict['dtype'], col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
+            # --> shouldn't have physical type in schema!!!!!!!!!!!! - should have own mehtod that adds onto this one!!
+            types = [col_dict['logical_type'].pandas_dtype, col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
             typing_info[col_name] = types
 
         columns = ['Physical Type', 'Logical Type', 'Semantic Tag(s)']
@@ -126,10 +127,10 @@ class Schema(object):
         """A dictionary containing logical types for each column"""
         return {col_name: col['logical_type'] for col_name, col in self.columns.items()}
 
-    @property
-    def physical_types(self):
-        """A dictionary containing physical types for each column"""
-        return {col_name: col['dtype'] for col_name, col in self.columns.items()}
+    # @property #--> add to table accessor
+    # def physical_types(self):
+    #     """A dictionary containing physical types for each column"""
+    #     return {col_name: col['dtype'] for col_name, col in self.columns.items()}
 
     @property
     def semantic_tags(self):

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -109,11 +109,10 @@ class Schema(object):
         typing_info = {}
         for col_name, col_dict in self.columns.items():
 
-            # --> shouldn't have physical type in schema!!!!!!!!!!!! - should have own mehtod that adds onto this one!!
-            types = [col_dict['logical_type'].primary_dtype, col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
+            types = [col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
             typing_info[col_name] = types
 
-        columns = ['Physical Type', 'Logical Type', 'Semantic Tag(s)']
+        columns = ['Logical Type', 'Semantic Tag(s)']
 
         df = pd.DataFrame.from_dict(typing_info,
                                     orient='index',

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -110,7 +110,7 @@ class Schema(object):
         for col_name, col_dict in self.columns.items():
 
             # --> shouldn't have physical type in schema!!!!!!!!!!!! - should have own mehtod that adds onto this one!!
-            types = [col_dict['logical_type'].pandas_dtype, col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
+            types = [col_dict['logical_type'].primary_dtype, col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
             typing_info[col_name] = types
 
         columns = ['Physical Type', 'Logical Type', 'Semantic Tag(s)']

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -36,7 +36,6 @@ def _get_column_dict(name,
     semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name)
 
     return {
-        'dtype': logical_type.primary_dtype,
         'logical_type': logical_type,
         'semantic_tags': semantic_tags,
         'description': description,

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -93,7 +93,7 @@ def _get_describe_dict(dataframe, include=None):
 
         values["nan_count"] = series.isna().sum()
         values["mode"] = mode
-        values["physical_type"] = column['dtype']
+        values["physical_type"] = series.dtype
         values["logical_type"] = logical_type
         values["semantic_tags"] = semantic_tags
         results[column_name] = values

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -168,17 +168,16 @@ class WoodworkTableAccessor:
         return series
 
     def __repr__(self):
+        """A string representation of a Woodwork table containing typing information"""
         return repr(self._get_typing_info())
 
     def _repr_html_(self):
-        '''An HTML representation of a Schema for IPython.display in Jupyter Notebooks
-        containing typing information and a preview of the data.
-        '''
+        """An HTML representation of a Woodwork table for IPython.display in Jupyter Notebooks
+        containing typing information and a preview of the data."""
         return self._get_typing_info().to_html()
 
     def _get_typing_info(self):
-        '''Creates a DataFrame that contains the typing information for a Woodwork table.
-        '''
+        """Creates a DataFrame that contains the typing information for a Woodwork table."""
         typing_info = self._schema._get_typing_info().copy()
         typing_info.insert(0, 'Physical Type', pd.Series(self.physical_types))
         # Maintain the same column order used in the DataFrame

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -178,6 +178,8 @@ class WoodworkTableAccessor:
 
     def _get_typing_info(self):
         """Creates a DataFrame that contains the typing information for a Woodwork table."""
+        if self._schema is None:
+            _raise_init_error()
         typing_info = self._schema._get_typing_info().copy()
         typing_info.insert(0, 'Physical Type', pd.Series(self.physical_types))
         # Maintain the same column order used in the DataFrame

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -231,6 +231,14 @@ class WoodworkTableAccessor:
             return self._schema._get_subset_schema(list(self._dataframe.columns))
 
     @property
+    def physical_types(self):
+        """A dictionary containing physical types for each column"""
+        if ks and isinstance(self._dataframe, ks.DataFrame):
+            return {col_name: self.schema.logical_types[col_name].backup_dtype for col_name in self._dataframe.columns}
+        else:
+            return {col_name: self.schema.logical_types[col_name].primary_dtype for col_name in self._dataframe.columns}
+
+    @property
     def types(self):
         """DataFrame containing the physical dtypes, logical types and semantic
         tags for the Schema."""
@@ -244,11 +252,6 @@ class WoodworkTableAccessor:
     def logical_types(self):
         """A dictionary containing logical types for each column"""
         return self._schema.logical_types
-
-    @property
-    def physical_types(self):
-        """A dictionary containing physical types for each column"""
-        return self._schema.physical_types
 
     @property
     def semantic_tags(self):
@@ -546,7 +549,6 @@ class WoodworkTableAccessor:
 
         # Initialize Woodwork typing info for series
         col_schema = self._schema.columns[column_name]
-        del col_schema['dtype']
         series.ww.init(**col_schema, use_standard_tags=self.use_standard_tags)
 
         # Update schema to not include popped column

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -163,7 +163,6 @@ class WoodworkTableAccessor:
 
         series = self._dataframe[key]
         column = self.schema.columns[key]
-        del column['dtype']
         column['semantic_tags'] -= {'index', 'time_index'}
         series.ww.init(**column, use_standard_tags=self.use_standard_tags)
         return series

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -112,6 +112,21 @@ def test_accessor_schema_property(sample_df):
     assert sample_df.ww._schema == sample_df.ww.schema
 
 
+def test_accessor_physical_types_property(sample_df):
+    sample_df.ww.init()
+
+    assert isinstance(sample_df.ww.physical_types, dict)
+    assert set(sample_df.ww.physical_types.keys()) == set(sample_df.columns)
+    for k, v in sample_df.ww.physical_types.items():
+        logical_type = sample_df.ww.columns[k]['logical_type']
+        if ks and isinstance(sample_df, ks.DataFrame):
+            assert v == logical_type.backup_dtype
+        else:
+            assert v == logical_type.primary_dtype
+
+
+# --> add test for tyypes property
+
 def test_accessor_separation_of_params(sample_df):
     # mix up order of acccessor and schema params
     schema_df = sample_df.copy()
@@ -514,7 +529,6 @@ def test_sets_category_dtype_on_init():
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
             assert df.ww.columns[column_name]['logical_type'] == logical_type
-            assert df.ww.columns[column_name]['dtype'] == logical_type.primary_dtype
             assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -526,10 +540,8 @@ def test_sets_object_dtype_on_init(latlong_df):
         df = latlong_df.loc[:, [column_name]]
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == LatLong
-        assert df.ww.columns[column_name]['dtype'] == LatLong.primary_dtype
         assert df[column_name].dtype == LatLong.primary_dtype
-        df_pandas = to_pandas(df[column_name])
-        expected_val = (3, 4)
+
         if ks and isinstance(latlong_df, ks.DataFrame):
             expected_val = [3, 4]
         assert df_pandas.iloc[-1] == expected_val
@@ -562,7 +574,6 @@ def test_sets_string_dtype_on_init():
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
             assert df.ww.columns[column_name]['logical_type'] == logical_type
-            assert df.ww.columns[column_name]['dtype'] == logical_type.primary_dtype
             assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -584,7 +595,6 @@ def test_sets_boolean_dtype_on_init():
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == logical_type
-        assert df.ww.columns[column_name]['dtype'] == logical_type.primary_dtype
         assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -607,7 +617,6 @@ def test_sets_int64_dtype_on_init():
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
             assert df.ww.columns[column_name]['logical_type'] == logical_type
-            assert df.ww.columns[column_name]['dtype'] == logical_type.primary_dtype
             assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -628,7 +637,6 @@ def test_sets_float64_dtype_on_init():
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == logical_type
-        assert df.ww.columns[column_name]['dtype'] == logical_type.primary_dtype
         assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -651,12 +659,7 @@ def test_sets_datetime64_dtype_on_init():
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == logical_type
-        assert df.ww.columns[column_name]['dtype'] == logical_type.primary_dtype
         assert df[column_name].dtype == logical_type.primary_dtype
-
-
-def test_invalid_dtype_casting():
-    column_name = 'test_series'
 
     # Cannot cast a column with pd.NA to Double
     series = pd.Series([1.1, pd.NA, 3], name=column_name)
@@ -1684,7 +1687,6 @@ def test_accessor_rename(sample_df):
     new_col = new_df.ww.columns['birthday']
     assert old_col['logical_type'] == new_col['logical_type']
     assert old_col['semantic_tags'] == new_col['semantic_tags']
-    assert old_col['dtype'] == new_col['dtype']
 
     new_df = sample_df.ww.rename({'age': 'full_name', 'full_name': 'age'})
 
@@ -1722,7 +1724,7 @@ def test_accessor_schema_properties(sample_df):
     sample_df.ww.init(index='id',
                       time_index='signup_date')
 
-    schema_properties = ['types', 'logical_types', 'physical_types', 'semantic_tags', 'index', 'time_index']
+    schema_properties = ['types', 'logical_types', 'semantic_tags', 'index', 'time_index']
     for schema_property in schema_properties:
         prop_from_accessor = getattr(sample_df.ww, schema_property)
         prop_from_schema = getattr(sample_df.ww.schema, schema_property)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1832,7 +1832,30 @@ def test_accessor_types(sample_df):
     assert 'Semantic Tag(s)' in returned_types.columns
     assert returned_types.shape[1] == 3
     assert len(returned_types.index) == len(sample_df.columns)
-    # --> need to check physical types with koalas
+
+    if ks and isinstance(sample_df, ks.DataFrame):
+        string_dtype = 'str'
+        boolean_dtype = 'bool'
+        int_dtype = 'int64'
+    else:
+        string_dtype = 'string'
+        boolean_dtype = 'boolean'
+        int_dtype = 'Int64'
+
+    correct_physical_types = {
+        'id': int_dtype,
+        'full_name': string_dtype,
+        'email': string_dtype,
+        'phone_number': string_dtype,
+        'age': int_dtype,
+        'signup_date': 'datetime64[ns]',
+        'is_registered': boolean_dtype,
+    }
+    correct_physical_types = pd.Series(list(correct_physical_types.values()),
+                                       index=list(correct_physical_types.keys()))
+    print(returned_types['Physical Type'])
+    assert correct_physical_types.equals(returned_types['Physical Type'])
+
     correct_logical_types = {
         'id': Integer,
         'full_name': NaturalLanguage,
@@ -1861,6 +1884,7 @@ def test_accessor_types(sample_df):
 
 
 def test_accessor_repr(small_df):
+    # --> koalas is broken need to actually look at repr
     small_df.ww.init()
 
     table_repr = repr(small_df.ww)
@@ -1872,11 +1896,8 @@ def test_accessor_repr(small_df):
     assert table_html_repr == expected_repr
 
 
-def test_accessor_repr_empty():
-    # --> confirm this is how we do things with dask and koalas - from dt file
-    df = pd.DataFrame()
-    df.ww.init()
+def test_accessor_repr_empty(empty_df):
+    empty_df.ww.init()
 
-    assert repr(df.ww) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
-
-    assert df.ww._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'
+    assert repr(empty_df.ww) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
+    assert empty_df.ww._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -656,6 +656,10 @@ def test_sets_datetime64_dtype_on_init():
         assert df.ww.columns[column_name]['logical_type'] == logical_type
         assert df[column_name].dtype == logical_type.primary_dtype
 
+
+def test_invalid_dtype_casting():
+    column_name = 'test_series'
+
     # Cannot cast a column with pd.NA to Double
     series = pd.Series([1.1, pd.NA, 3], name=column_name)
     ltypes = {
@@ -1145,15 +1149,12 @@ def test_dataframe_methods_on_accessor_to_pandas(sample_df):
 
     if dd and isinstance(sample_df, dd.DataFrame):
         pd_df = sample_df.ww.compute()
-        assert isinstance(pd_df, pd.DataFrame)
-        assert pd_df.ww.index == 'id'
-        assert pd_df.ww.name == 'woodwork'
-
     elif ks and isinstance(sample_df, ks.DataFrame):
         pd_df = sample_df.ww.to_pandas()
-        assert isinstance(pd_df, pd.DataFrame)
-        assert pd_df.ww.index == 'id'
-        assert pd_df.ww.name == 'woodwork'
+
+    assert isinstance(pd_df, pd.DataFrame)
+    assert pd_df.ww.index == 'id'
+    assert pd_df.ww.name == 'woodwork'
 
 
 def test_get_subset_df_with_schema(sample_df):
@@ -1827,9 +1828,7 @@ def test_accessor_types(sample_df):
 
     returned_types = sample_df.ww.types
     assert isinstance(returned_types, pd.DataFrame)
-    assert 'Physical Type' in returned_types.columns
-    assert 'Logical Type' in returned_types.columns
-    assert 'Semantic Tag(s)' in returned_types.columns
+    assert all(returned_types.columns == ['Physical Type', 'Logical Type', 'Semantic Tag(s)'])
     assert returned_types.shape[1] == 3
     assert len(returned_types.index) == len(sample_df.columns)
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -541,7 +541,8 @@ def test_sets_object_dtype_on_init(latlong_df):
         df.ww.init(logical_types=ltypes)
         assert df.ww.columns[column_name]['logical_type'] == LatLong
         assert df[column_name].dtype == LatLong.primary_dtype
-
+        df_pandas = to_pandas(df[column_name])
+        expected_val = (3, 4)
         if ks and isinstance(latlong_df, ks.DataFrame):
             expected_val = [3, 4]
         assert df_pandas.iloc[-1] == expected_val
@@ -1147,6 +1148,25 @@ def test_dataframe_methods_on_accessor_other_returns(sample_df):
     if dd and not isinstance(sample_df, dd.DataFrame):
         # keys() not supported with Dask
         pd.testing.assert_index_equal(schema_df.ww.keys(), schema_df.keys())
+
+
+def test_dataframe_methods_on_accessor_to_pandas(sample_df):
+    if isinstance(sample_df, pd.DataFrame):
+        pytest.skip("No need to test converting pandas DataFrame to pandas")
+
+    sample_df.ww.init(name='woodwork', index='id')
+
+    if dd and isinstance(sample_df, dd.DataFrame):
+        pd_df = sample_df.ww.compute()
+        assert isinstance(pd_df, pd.DataFrame)
+        assert pd_df.ww.index == 'id'
+        assert pd_df.ww.name == 'woodwork'
+
+    elif ks and isinstance(sample_df, ks.DataFrame):
+        pd_df = sample_df.ww.to_pandas()
+        assert isinstance(pd_df, pd.DataFrame)
+        assert pd_df.ww.index == 'id'
+        assert pd_df.ww.name == 'woodwork'
 
 
 def test_get_subset_df_with_schema(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1833,14 +1833,9 @@ def test_accessor_types(sample_df):
     assert returned_types.shape[1] == 3
     assert len(returned_types.index) == len(sample_df.columns)
 
-    if ks and isinstance(sample_df, ks.DataFrame):
-        string_dtype = 'str'
-        boolean_dtype = 'bool'
-        int_dtype = 'int64'
-    else:
-        string_dtype = 'string'
-        boolean_dtype = 'boolean'
-        int_dtype = 'Int64'
+    string_dtype = 'string'
+    boolean_dtype = 'boolean'
+    int_dtype = 'Int64'
 
     correct_physical_types = {
         'id': int_dtype,
@@ -1853,7 +1848,6 @@ def test_accessor_types(sample_df):
     }
     correct_physical_types = pd.Series(list(correct_physical_types.values()),
                                        index=list(correct_physical_types.keys()))
-    print(returned_types['Physical Type'])
     assert correct_physical_types.equals(returned_types['Physical Type'])
 
     correct_logical_types = {
@@ -1884,7 +1878,6 @@ def test_accessor_types(sample_df):
 
 
 def test_accessor_repr(small_df):
-    # --> koalas is broken need to actually look at repr
     small_df.ww.init()
 
     table_repr = repr(small_df.ww)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -113,7 +113,7 @@ def test_accessor_schema_property(sample_df):
 
 
 def test_accessor_physical_types_property(sample_df):
-    sample_df.ww.init()
+    sample_df.ww.init(logical_types={'age': 'Categorical'})
 
     assert isinstance(sample_df.ww.physical_types, dict)
     assert set(sample_df.ww.physical_types.keys()) == set(sample_df.columns)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -119,13 +119,11 @@ def test_accessor_physical_types_property(sample_df):
     assert set(sample_df.ww.physical_types.keys()) == set(sample_df.columns)
     for k, v in sample_df.ww.physical_types.items():
         logical_type = sample_df.ww.columns[k]['logical_type']
-        if ks and isinstance(sample_df, ks.DataFrame):
+        if ks and isinstance(sample_df, ks.DataFrame) and logical_type.backup_dtype is not None:
             assert v == logical_type.backup_dtype
         else:
             assert v == logical_type.primary_dtype
 
-
-# --> add test for tyypes property
 
 def test_accessor_separation_of_params(sample_df):
     # mix up order of acccessor and schema params
@@ -285,10 +283,6 @@ def test_accessor_equality_with_schema(sample_df, sample_column_names, sample_in
 
     # eq not implemented on Accessor class, so Schema's eq is called
     assert schema_df.ww.__eq__(comparison_schema)
-
-    # Since there's a repr on Accessor, it gets called
-    assert schema_df.ww._repr_html_() == comparison_schema._repr_html_()
-    assert schema_df.ww.__repr__() == comparison_schema.__repr__()
 
     logical_types = {
         'id': Double,
@@ -971,13 +965,6 @@ def test_accessor_with_falsy_column_names(falsy_names_df):
     renamed_df = schema_df.ww.rename({0: 'col_with_name'})
     assert 0 not in renamed_df.columns
     assert 'col_with_name' in renamed_df.columns
-
-
-def test_accessor_repr(sample_df, sample_column_names, sample_inferred_logical_types):
-    schema = Schema(sample_column_names, sample_inferred_logical_types)
-    sample_df.ww.init()
-
-    assert repr(schema) == repr(sample_df.ww)
 
 
 def test_get_invalid_schema_message(sample_df):
@@ -1744,15 +1731,12 @@ def test_accessor_schema_properties(sample_df):
     sample_df.ww.init(index='id',
                       time_index='signup_date')
 
-    schema_properties = ['types', 'logical_types', 'semantic_tags', 'index', 'time_index']
+    schema_properties = ['logical_types', 'semantic_tags', 'index', 'time_index']
     for schema_property in schema_properties:
         prop_from_accessor = getattr(sample_df.ww, schema_property)
         prop_from_schema = getattr(sample_df.ww.schema, schema_property)
 
-        if schema_property == 'types':
-            pd.testing.assert_frame_equal(prop_from_accessor, prop_from_schema)
-        else:
-            assert prop_from_accessor == prop_from_schema
+        assert prop_from_accessor == prop_from_schema
 
         # Assumes we don't have setters for any of these attributes
         error = "can't set attribute"
@@ -1836,3 +1820,63 @@ def test_maintain_column_order_disordered_schema(sample_df):
     sample_df.ww.init(schema=scramble_df.ww.schema)
     assert all(sample_df.columns == column_order)
     assert all(sample_df.ww.types.index == column_order)
+
+
+def test_accessor_types(sample_df):
+    sample_df.ww.init()
+
+    returned_types = sample_df.ww.types
+    assert isinstance(returned_types, pd.DataFrame)
+    assert 'Physical Type' in returned_types.columns
+    assert 'Logical Type' in returned_types.columns
+    assert 'Semantic Tag(s)' in returned_types.columns
+    assert returned_types.shape[1] == 3
+    assert len(returned_types.index) == len(sample_df.columns)
+    # --> need to check physical types with koalas
+    correct_logical_types = {
+        'id': Integer,
+        'full_name': NaturalLanguage,
+        'email': NaturalLanguage,
+        'phone_number': NaturalLanguage,
+        'age': Integer,
+        'signup_date': Datetime,
+        'is_registered': Boolean,
+    }
+    correct_logical_types = pd.Series(list(correct_logical_types.values()),
+                                      index=list(correct_logical_types.keys()))
+    assert correct_logical_types.equals(returned_types['Logical Type'])
+
+    correct_semantic_tags = {
+        'id': "['numeric']",
+        'full_name': "[]",
+        'email': "[]",
+        'phone_number': "[]",
+        'age': "['numeric']",
+        'signup_date': "[]",
+        'is_registered': "[]",
+    }
+    correct_semantic_tags = pd.Series(list(correct_semantic_tags.values()),
+                                      index=list(correct_semantic_tags.keys()))
+    assert correct_semantic_tags.equals(returned_types['Semantic Tag(s)'])
+
+
+def test_accessor_repr(small_df):
+    small_df.ww.init()
+
+    table_repr = repr(small_df.ww)
+    expected_repr = '                         Physical Type Logical Type Semantic Tag(s)\nColumn                                                             \nsample_datetime_series  datetime64[ns]     Datetime              []'
+    assert table_repr == expected_repr
+
+    table_html_repr = small_df.ww._repr_html_()
+    expected_repr = '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>sample_datetime_series</th>\n      <td>datetime64[ns]</td>\n      <td>Datetime</td>\n      <td>[]</td>\n    </tr>\n  </tbody>\n</table>'
+    assert table_html_repr == expected_repr
+
+
+def test_accessor_repr_empty():
+    # --> confirm this is how we do things with dask and koalas - from dt file
+    df = pd.DataFrame()
+    df.ww.init()
+
+    assert repr(df.ww) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
+
+    assert df.ww._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1878,6 +1878,9 @@ def test_accessor_types(sample_df):
 
 
 def test_accessor_repr(small_df):
+    error = 'Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init'
+    with pytest.raises(AttributeError, match=error):
+        repr(small_df.ww)
     small_df.ww.init()
 
     table_repr = repr(small_df.ww)

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -19,13 +19,13 @@ from woodwork.logical_types import (
 )
 from woodwork.schema import Schema
 
-
-def test_schema_physical_types(sample_column_names, sample_inferred_logical_types):
-    schema = Schema(sample_column_names, sample_inferred_logical_types)
-    assert isinstance(schema.physical_types, dict)
-    assert set(schema.physical_types.keys()) == set(sample_column_names)
-    for k, v in schema.physical_types.items():
-        assert v == schema.columns[k]['logical_type'].primary_dtype
+# --> add to table accessor tests
+# def test_schema_physical_types(sample_column_names, sample_inferred_logical_types):
+#     schema = Schema(sample_column_names, sample_inferred_logical_types)
+#     assert isinstance(schema.physical_types, dict)
+#     assert set(schema.physical_types.keys()) == set(sample_column_names)
+#     for k, v in schema.physical_types.items():
+#         assert v == schema.columns[k]['logical_type'].pandas_dtype
 
 
 def test_schema_logical_types(sample_column_names, sample_inferred_logical_types):
@@ -836,7 +836,6 @@ def test_schema_rename(sample_column_names, sample_inferred_logical_types):
     new_col = renamed_schema.columns['birthday']
     assert old_col['logical_type'] == new_col['logical_type']
     assert old_col['semantic_tags'] == new_col['semantic_tags']
-    assert old_col['dtype'] == new_col['dtype']
 
     swapped_schema = schema.rename({'age': 'full_name', 'full_name': 'age'})
     swapped_back_schema = swapped_schema.rename({'age': 'full_name', 'full_name': 'age'})

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -50,10 +50,9 @@ def test_schema_types(sample_column_names, sample_inferred_logical_types):
 
     returned_types = schema.types
     assert isinstance(returned_types, pd.DataFrame)
-    assert 'Physical Type' in returned_types.columns
     assert 'Logical Type' in returned_types.columns
     assert 'Semantic Tag(s)' in returned_types.columns
-    assert returned_types.shape[1] == 3
+    assert returned_types.shape[1] == 2
     assert len(returned_types.index) == len(sample_column_names)
     correct_logical_types = {
         'id': Integer,

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -19,14 +19,6 @@ from woodwork.logical_types import (
 )
 from woodwork.schema import Schema
 
-# --> add to table accessor tests
-# def test_schema_physical_types(sample_column_names, sample_inferred_logical_types):
-#     schema = Schema(sample_column_names, sample_inferred_logical_types)
-#     assert isinstance(schema.physical_types, dict)
-#     assert set(schema.physical_types.keys()) == set(sample_column_names)
-#     for k, v in schema.physical_types.items():
-#         assert v == schema.columns[k]['logical_type'].pandas_dtype
-
 
 def test_schema_logical_types(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types)

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -87,19 +87,19 @@ def test_schema_repr(small_df):
     schema = Schema(list(small_df.columns), logical_types={'sample_datetime_series': Datetime})
 
     schema_repr = repr(schema)
-    expected_repr = '                         Physical Type Logical Type Semantic Tag(s)\nColumn                                                             \nsample_datetime_series  datetime64[ns]     Datetime              []'
+    expected_repr = '                       Logical Type Semantic Tag(s)\nColumn                                             \nsample_datetime_series     Datetime              []'
     assert schema_repr == expected_repr
 
     schema_html_repr = schema._repr_html_()
-    expected_repr = '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>sample_datetime_series</th>\n      <td>datetime64[ns]</td>\n      <td>Datetime</td>\n      <td>[]</td>\n    </tr>\n  </tbody>\n</table>'
+    expected_repr = '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>sample_datetime_series</th>\n      <td>Datetime</td>\n      <td>[]</td>\n    </tr>\n  </tbody>\n</table>'
     assert schema_html_repr == expected_repr
 
 
 def test_schema_repr_empty():
     schema = Schema([], {})
-    assert repr(schema) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
+    assert repr(schema) == 'Empty DataFrame\nColumns: [Logical Type, Semantic Tag(s)]\nIndex: []'
 
-    assert schema._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'
+    assert schema._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'
 
 
 def test_schema_equality(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -60,10 +60,9 @@ def test_validate_metadata_errors():
 def test_get_column_dict():
     column = _get_column_dict('column', Integer, semantic_tags='test_tag')
 
-    assert set(column.keys()) == {'dtype', 'logical_type', 'semantic_tags', 'description', 'metadata'}
+    assert set(column.keys()) == {'logical_type', 'semantic_tags', 'description', 'metadata'}
 
     assert column.get('logical_type') == Integer
-    assert column.get('dtype') == 'Int64'
     assert column.get('semantic_tags') == {'numeric', 'test_tag'}
 
     assert column.get('description') is None

--- a/woodwork/tests/testing_utils/datatable_utils.py
+++ b/woodwork/tests/testing_utils/datatable_utils.py
@@ -25,7 +25,6 @@ def validate_subset_schema(subset_schema, schema):
         col = schema.columns[subset_col_name]
         assert subset_col['logical_type'] == col['logical_type']
         assert subset_col['semantic_tags'] == col['semantic_tags']
-        assert subset_col['dtype'] == col['dtype']
 
 
 def mi_between_cols(col1, col2, df):


### PR DESCRIPTION
- Removes the `dtype` field from the Schema columns dictionary, relying on Series dtype when checking the dtype of a column.
- Adds a separate repr for Schema and Table Accessor since only the Table Accessor has access to physical types
- Closes #653 