### PR TITLE
Include unique columns in DataTable mutual information calculations

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
     * Fixes
     * Changes
         * Restrict Koalas version to ``<1.7.0`` due to breaking changes (:pr:`674`)
+        * Include unique columns in mutual information calculations (:pr:`687`) 
     * Documentation Changes
     * Testing Changes
         * Update branch reference in tests to run on main (:pr:`641`)
@@ -14,7 +15,7 @@ Release Notes
         * Update release branch naming instructions (:pr:`644`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 **v0.0.10 February 25, 2021**
     * Changes

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -1038,10 +1038,6 @@ class DataTable(object):
         not_null_cols = data.columns[data.notnull().any()]
         if set(not_null_cols) != set(valid_columns):
             data = data.loc[:, not_null_cols]
-        # remove columns that are unique
-        not_unique_cols = [col for col in data.columns if not data[col].is_unique]
-        if set(not_unique_cols) != set(valid_columns):
-            data = data.loc[:, not_unique_cols]
 
         data = self._replace_nans_for_mutual_info(data)
         data = self._make_categorical_for_mutual_info(data, num_bins)

--- a/woodwork/tests/datatable/test_datatable.py
+++ b/woodwork/tests/datatable/test_datatable.py
@@ -959,7 +959,8 @@ def test_datatable_mutual_information(df_mi):
     pd.testing.assert_frame_equal(mi, mi_many_rows)
 
     mi = dt.mutual_information(nrows=1)
-    assert mi.shape[0] == 0
+    assert mi.shape[0] == 10
+    assert (mi['mutual_info'] == 1.0).all()
 
     mi = dt.mutual_information(num_bins=2)
     assert mi.shape[0] == 10
@@ -998,8 +999,8 @@ def test_mutual_info_unique(df_mi_unique):
     mi = dt.mutual_information()
 
     cols_used = set(np.unique(mi[['column_1', 'column_2']].values))
-    assert 'unique' not in cols_used
-    assert 'unique_with_one_nan' not in cols_used
+    assert 'unique' in cols_used
+    assert 'unique_with_one_nan' in cols_used
     assert 'unique_with_nans' in cols_used
     assert 'ints' in cols_used
 


### PR DESCRIPTION
- Allows unique columns to be included as a part of the mutual information calculations
- Closes #676 