### PR TITLE
Update to fix mutual information documentation warning

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
         * Restrict Koalas version to ``<1.7.0`` due to breaking changes (:pr:`674`)
         * Include unique columns in mutual information calculations (:pr:`687`) 
     * Documentation Changes
+        * Update to remove warning message from statistical insights guide (:pr:`690`)
     * Testing Changes
         * Update branch reference in tests to run on main (:pr:`641`)
         * Make release notes updated check separate from unit tests (:pr:`642`)

--- a/woodwork/datatable.py
+++ b/woodwork/datatable.py
@@ -1024,7 +1024,7 @@ class DataTable(object):
         valid_columns = [col.name for col in self.columns.values() if (
             col.name != self.index and _get_ltype_class(col.logical_type) in valid_types)]
 
-        data = self._dataframe[valid_columns]
+        data = self._dataframe.loc[:, valid_columns]
         if dd and isinstance(data, dd.DataFrame):
             data = data.compute()
         if ks and isinstance(self._dataframe, ks.DataFrame):


### PR DESCRIPTION
- Update to fix mutual information documentation warning
- Closes #689 

Small update to `DataTable.mutual_information_dict` to prevent pandas `SettingWithCopyWarning` from appearing in documentation for mutual information.