### PR TITLE
Include index and allow unique columns in Accessor mutual info

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -54,6 +54,7 @@ Release Notes
         * Clean up dtype usage across Woodwork (:pr:`682`)
         * Improve error when calling accessor properties or methods before init (:pr:`683`)
         * Remove dtype from Schema dictionary (:pr:`685`)
+        * Add ``include_index`` param and allow unique columns in Accessor mutual information (:pr:`699`)
     * Documentation Changes
         * Update README.md and Get Started guide to use accessor (:pr:`655`)
         * Update docstrings and API Reference page (:pr:`660`)

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -164,7 +164,7 @@ def _make_categorical_for_mutual_info(schema, data, num_bins):
     return data
 
 
-def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None):
+def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None, include_index=False):
     """Calculates mutual information between all pairs of columns in the DataFrame that
     support mutual information. Logical Types that support mutual information are as
     follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
@@ -178,6 +178,10 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None):
         nrows (int): The number of rows to sample for when determining mutual info.
             If specified, samples the desired number of rows from the data.
             Defaults to using all rows.
+        include_index (bool): If True, the column specified as the index will be
+            included as long as its LogicalType is valid for mutual information calculations.
+            If False, the index column will not have mutual information calculated for it.
+            Defaults to False.
 
     Returns:
         list(dict): A list containing dictionaries that have keys `column_1`,
@@ -186,8 +190,10 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None):
         (perfect dependency).
         """
     valid_types = get_valid_mi_types()
-    valid_columns = [col_name for col_name, col in dataframe.ww.columns.items() if (
-        col_name != dataframe.ww.index and _get_ltype_class(col['logical_type']) in valid_types)]
+    valid_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col['logical_type']) in valid_types]
+
+    if not include_index and dataframe.ww.index is not None:
+        valid_columns.remove(dataframe.ww.index)
 
     data = dataframe[valid_columns]
     if dd and isinstance(data, dd.DataFrame):

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -203,10 +203,6 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None):
     not_null_cols = data.columns[data.notnull().any()]
     if set(not_null_cols) != set(valid_columns):
         data = data.loc[:, not_null_cols]
-    # remove columns that are unique
-    not_unique_cols = [col for col in data.columns if not data[col].is_unique]
-    if set(not_unique_cols) != set(valid_columns):
-        data = data.loc[:, not_unique_cols]
 
     data = _replace_nans_for_mutual_info(dataframe.ww.schema, data)
     data = _make_categorical_for_mutual_info(dataframe.ww.schema, data, num_bins)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -667,7 +667,7 @@ class WoodworkTableAccessor:
         new_df.ww.init(schema=new_schema)
         return new_df
 
-    def mutual_information_dict(self, num_bins=10, nrows=None):
+    def mutual_information_dict(self, num_bins=10, nrows=None, include_index=False):
         """
         Calculates mutual information between all pairs of columns in the DataFrame that
         support mutual information. Logical Types that support mutual information are as
@@ -678,8 +678,12 @@ class WoodworkTableAccessor:
             num_bins (int): Determines number of bins to use for converting
                 numeric features into categorical.
             nrows (int): The number of rows to sample for when determining mutual info.
-            If specified, samples the desired number of rows from the data.
+                If specified, samples the desired number of rows from the data.
                 Defaults to using all rows.
+            include_index (bool): If True, the column specified as the index will be
+                included as long as its LogicalType is valid for mutual information calculations.
+                If False, the index column will not have mutual information calculated for it.
+                Defaults to False.
 
         Returns:
             list(dict): A list containing dictionaries that have keys `column_1`,
@@ -689,9 +693,9 @@ class WoodworkTableAccessor:
         """
         if self._schema is None:
             _raise_init_error()
-        return _get_mutual_information_dict(self._dataframe, num_bins=num_bins, nrows=nrows)
+        return _get_mutual_information_dict(self._dataframe, num_bins=num_bins, nrows=nrows, include_index=include_index)
 
-    def mutual_information(self, num_bins=10, nrows=None):
+    def mutual_information(self, num_bins=10, nrows=None, include_index=False):
         """Calculates mutual information between all pairs of columns in the DataFrame that
         support mutual information. Logical Types that support mutual information are as
         follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
@@ -703,6 +707,10 @@ class WoodworkTableAccessor:
             nrows (int): The number of rows to sample for when determining mutual info.
                 If specified, samples the desired number of rows from the data.
                 Defaults to using all rows.
+            include_index (bool): If True, the column specified as the index will be
+                included as long as its LogicalType is valid for mutual information calculations.
+                If False, the index column will not have mutual information calculated for it.
+                Defaults to False.
 
         Returns:
             pd.DataFrame: A DataFrame containing mutual information with columns `column_1`,
@@ -710,7 +718,7 @@ class WoodworkTableAccessor:
             Mutual information values are between 0 (no mutual information) and 1
             (perfect dependency).
         """
-        mutual_info = self.mutual_information_dict(num_bins, nrows)
+        mutual_info = self.mutual_information_dict(num_bins, nrows, include_index)
         return pd.DataFrame(mutual_info)
 
     def describe_dict(self, include=None):

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -142,11 +142,14 @@ def test_mutual_info(df_mi):
     pd.testing.assert_frame_equal(to_pandas(df_mi), to_pandas(original_df))
 
 
-def test_mutual_info_does_not_include_index(sample_df):
+def test_mutual_info_on_index(sample_df):
     sample_df.ww.init(index='id')
     mi = sample_df.ww.mutual_information()
 
-    assert 'id' not in mi['column_1'].values
+    assert not ('id' in mi['column_1'].values or 'id' in mi['column_2'].values)
+
+    mi = sample_df.ww.mutual_information(include_index=True)
+    assert 'id' in mi['column_1'].values or 'id' in mi['column_2'].values
 
 
 def test_mutual_info_returns_empty_df_properly(sample_df):

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -127,7 +127,8 @@ def test_mutual_info(df_mi):
     pd.testing.assert_frame_equal(mi, mi_many_rows)
 
     mi = df_mi.ww.mutual_information(nrows=1)
-    assert mi.shape[0] == 0
+    assert mi.shape[0] == 10
+    assert (mi['mutual_info'] == 1.0).all()
 
     mi = df_mi.ww.mutual_information(num_bins=2)
     assert mi.shape[0] == 10
@@ -177,8 +178,8 @@ def test_mutual_info_unique_cols(df_mi_unique):
     mi = df_mi_unique.ww.mutual_information()
 
     cols_used = set(np.unique(mi[['column_1', 'column_2']].values))
-    assert 'unique' not in cols_used
-    assert 'unique_with_one_nan' not in cols_used
+    assert 'unique' in cols_used
+    assert 'unique_with_one_nan' in cols_used
     assert 'unique_with_nans' in cols_used
     assert 'ints' in cols_used
 


### PR DESCRIPTION
- Updates Accessor's mutual information to allow users to include the index and to not exclude unique columns.
- Closes #688, closes #694 
