### PR TITLE
Include DataFrame in accessor equality check

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -55,7 +55,7 @@ Release Notes
         * Improve error when calling accessor properties or methods before init (:pr:`683`)
         * Remove dtype from Schema dictionary (:pr:`685`)
         * Add ``include_index`` param and allow unique columns in Accessor mutual information (:pr:`699`)
-        * Include DataFrame equality in WoodworkTableAccessor equality check (:pr:`700`)
+        * Include DataFrame equality and ``use_standard_tags`` in WoodworkTableAccessor equality check (:pr:`700`)
     * Documentation Changes
         * Update README.md and Get Started guide to use accessor (:pr:`655`)
         * Update Understanding Types and Tags guide to use accessor (:pr:`657`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -55,6 +55,7 @@ Release Notes
         * Improve error when calling accessor properties or methods before init (:pr:`683`)
         * Remove dtype from Schema dictionary (:pr:`685`)
         * Add ``include_index`` param and allow unique columns in Accessor mutual information (:pr:`699`)
+        * Include DataFrame equality in WoodworkTableAccessor equality check (:pr:`700`)
     * Documentation Changes
         * Update README.md and Get Started guide to use accessor (:pr:`655`)
         * Update Understanding Types and Tags guide to use accessor (:pr:`657`)

--- a/woodwork/deserialize_accessor.py
+++ b/woodwork/deserialize_accessor.py
@@ -118,7 +118,7 @@ def _typing_information_to_woodwork_table(table_typing_info, **kwargs):
         time_index=table_typing_info.get('time_index'),
         logical_types=logical_types,
         semantic_tags=semantic_tags,
-        use_standard_tags=False,
+        use_standard_tags=table_typing_info.get('use_standard_tags'),
         table_metadata=table_typing_info.get('table_metadata'),
         column_metadata=column_metadata,
         column_descriptions=column_descriptions)

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -82,6 +82,8 @@ class Schema(object):
             return False
         if self.time_index != other.time_index:
             return False
+        if self.use_standard_tags != other.use_standard_tags:
+            return False
         if self.columns != other.columns:
             return False
         if self.metadata != other.metadata:

--- a/woodwork/serialize_accessor.py
+++ b/woodwork/serialize_accessor.py
@@ -17,7 +17,7 @@ from woodwork.utils import _is_s3, _is_url, import_or_none
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
 
-SCHEMA_VERSION = '6.0.0'
+SCHEMA_VERSION = '7.0.0'
 FORMATS = ['csv', 'pickle', 'parquet']
 
 
@@ -62,6 +62,7 @@ def typing_info_to_dict(dataframe):
         'name': dataframe.ww.name,
         'index': dataframe.ww.index,
         'time_index': dataframe.ww.time_index,
+        'use_standard_tags': dataframe.ww.use_standard_tags,
         'column_typing_info': column_typing_info,
         'loading_info': {
             'table_type': table_type

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -138,6 +138,15 @@ class WoodworkTableAccessor:
             if self._schema.time_index is not None:
                 self._sort_columns(already_sorted)
 
+    def __eq__(self, other):
+        if self._schema != other.ww._schema:
+            return False
+
+        # Only check pandas DataFrames for equality
+        if isinstance(self._dataframe, pd.DataFrame) and isinstance(other.ww._dataframe, pd.DataFrame):
+            return self._dataframe.equals(other.ww._dataframe)
+        return True
+
     def __getattr__(self, attr):
         # If the method is present on the Accessor, uses that method.
         # If the method is present on Schema, uses that method.

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -338,34 +338,24 @@ def test_getitem_invalid_input(sample_df):
         df.ww['invalid_column']
 
 
-def test_accessor_equality_with_schema(sample_df, sample_column_names, sample_inferred_logical_types):
-    comparison_schema = Schema(sample_column_names, sample_inferred_logical_types)
-
+def test_accessor_equality(sample_df):
+    # Confirm equality with same schema and same data
     schema_df = sample_df.copy()
     schema_df.ww.init()
 
-    # eq not implemented on Accessor class, so Schema's eq is called
-    assert schema_df.ww.__eq__(comparison_schema)
+    copy_df = schema_df.ww.copy()
+    assert schema_df.ww == copy_df.ww
 
-    logical_types = {
-        'id': Double,
-        'full_name': FullName
-    }
-    semantic_tags = {
-        'email': 'test_tag',
-    }
-    comparison_schema = Schema(sample_column_names,
-                               logical_types={**sample_inferred_logical_types, **logical_types},
-                               index='id',
-                               time_index='signup_date',
-                               semantic_tags=semantic_tags)
-    schema_df = sample_df.copy()
-    schema_df.ww.init(logical_types=logical_types,
-                      index='id',
-                      time_index='signup_date',
-                      semantic_tags=semantic_tags,
-                      already_sorted=True)
-    assert schema_df.ww == comparison_schema
+    # Confirm not equal with different schema but same data
+    copy_df.ww.set_index('id')
+    assert schema_df.ww != copy_df.ww
+
+    # Confirm not equal with same schema but different data - only pandas
+    iloc_df = schema_df.ww.loc[:2, :]
+    if isinstance(sample_df, pd.DataFrame):
+        assert schema_df.ww != iloc_df
+    else:
+        assert schema_df.ww == iloc_df
 
 
 def test_accessor_init_with_valid_string_time_index(time_index_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -358,6 +358,26 @@ def test_accessor_equality(sample_df):
         assert schema_df.ww == iloc_df
 
 
+def test_accessor_equality_standard_tags(sample_df):
+    schema_df = sample_df.copy()
+    schema_df.ww.init()
+
+    # Different standard tags values - using logical types with standard tags
+    no_standard_tags_df = sample_df.copy()
+    no_standard_tags_df.ww.init(use_standard_tags=False)
+
+    assert schema_df.ww.use_standard_tags != no_standard_tags_df.ww.use_standard_tags
+    assert schema_df.ww != no_standard_tags_df.ww
+
+    # Different standard tags values - no logical types that have standard tags
+    nl_ltypes = {col_name: NaturalLanguage for col_name in schema_df.columns}
+    schema_df.ww.set_types(logical_types=nl_ltypes)
+    no_standard_tags_df.ww.set_types(logical_types=nl_ltypes)
+
+    assert schema_df.ww.use_standard_tags != no_standard_tags_df.ww.use_standard_tags
+    assert schema_df.ww == no_standard_tags_df.ww
+
+
 def test_accessor_init_with_valid_string_time_index(time_index_df):
     time_index_df.ww.init(name='schema',
                           index='id',

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -347,7 +347,7 @@ def test_accessor_equality(sample_df):
     assert schema_df.ww == copy_df.ww
 
     # Confirm not equal with different schema but same data
-    copy_df.ww.set_index('id')
+    copy_df.ww.set_time_index('signup_date')
     assert schema_df.ww != copy_df.ww
 
     # Confirm not equal with same schema but different data - only pandas

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -358,26 +358,6 @@ def test_accessor_equality(sample_df):
         assert schema_df.ww == iloc_df
 
 
-def test_accessor_equality_standard_tags(sample_df):
-    schema_df = sample_df.copy()
-    schema_df.ww.init()
-
-    # Different standard tags values - using logical types with standard tags
-    no_standard_tags_df = sample_df.copy()
-    no_standard_tags_df.ww.init(use_standard_tags=False)
-
-    assert schema_df.ww.use_standard_tags != no_standard_tags_df.ww.use_standard_tags
-    assert schema_df.ww != no_standard_tags_df.ww
-
-    # Different standard tags values - no logical types that have standard tags
-    nl_ltypes = {col_name: NaturalLanguage for col_name in schema_df.columns}
-    schema_df.ww.set_types(logical_types=nl_ltypes)
-    no_standard_tags_df.ww.set_types(logical_types=nl_ltypes)
-
-    assert schema_df.ww.use_standard_tags != no_standard_tags_df.ww.use_standard_tags
-    assert schema_df.ww == no_standard_tags_df.ww
-
-
 def test_accessor_init_with_valid_string_time_index(time_index_df):
     time_index_df.ww.init(name='schema',
                           index='id',

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -159,7 +159,7 @@ def test_schema_equality_standard_tags(sample_column_names, sample_inferred_logi
     no_standard_tags_schema.set_types(logical_types=nl_ltypes)
 
     assert schema.use_standard_tags != no_standard_tags_schema.use_standard_tags
-    assert schema == no_standard_tags_schema
+    assert schema != no_standard_tags_schema
 
 
 def test_schema_table_metadata(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -144,6 +144,24 @@ def test_schema_equality(sample_column_names, sample_inferred_logical_types):
                   table_metadata={'created_by': 'user2'}) != schema_with_metadata
 
 
+def test_schema_equality_standard_tags(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types)
+    no_standard_tags_schema = Schema(sample_column_names, sample_inferred_logical_types,
+                                     use_standard_tags=False)
+
+    # Different standard tags values - using logical types with standard tags
+    assert schema.use_standard_tags != no_standard_tags_schema.use_standard_tags
+    assert schema != no_standard_tags_schema
+
+    # Different standard tags values - no logical types that have standard tags
+    nl_ltypes = {col_name: NaturalLanguage for col_name in sample_column_names}
+    schema.set_types(logical_types=nl_ltypes)
+    no_standard_tags_schema.set_types(logical_types=nl_ltypes)
+
+    assert schema.use_standard_tags != no_standard_tags_schema.use_standard_tags
+    assert schema == no_standard_tags_schema
+
+
 def test_schema_table_metadata(sample_column_names, sample_inferred_logical_types):
     metadata = {'secondary_time_index': {'is_registered': 'age'}, 'date_created': '11/13/20'}
 


### PR DESCRIPTION
- Adds an `__eq__` method to WoodworkTableAccessor that checks for equality in the underlying data as well as the Schema
- Closes #686 