### PR TITLE
Add missing tests to Schema/Accessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -64,6 +64,7 @@ Release Notes
         * Update Customizing Type Inference guide to use accessor (:pr:`696`)
     * Documentation Changes
     * Testing Changes
+        * Add tests to Accessor/Schema that weren't previously covered (:pr:`712`)
 
     Thanks to the following people for contributing to this release:
     :user:`johnbridstrup`, :user:`jeff-hernandez`, :user:`tamargrey`, :user:`thehomebrewnerd`

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -270,7 +270,7 @@ def test_add_custom_tags(sample_series):
     assert series.ww.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'set_tag'}
 
 
-def test_warns_on_setting_duplicate_tag(sample_series):
+def test_warns_on_adding_duplicate_tag(sample_series):
     series = convert_series(sample_series, Categorical)
     semantic_tags = ['first_tag', 'second_tag']
     series.ww.init(semantic_tags=semantic_tags, use_standard_tags=False)

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -733,3 +733,13 @@ def test_accessor_metadata_error_on_update(sample_series):
     err_msg = "Column metadata must be a dictionary"
     with pytest.raises(TypeError, match=err_msg):
         series.ww.metadata = 123
+
+
+def test_non_string_column_name(sample_series):
+    series = convert_series(sample_series, Categorical)
+    series.name = 0
+    series.ww.init(semantic_tags={'test_tag'})
+
+    assert series.ww.name == 0
+    assert series.name == 0
+    assert series.ww.semantic_tags == {'category', 'test_tag'}

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -509,6 +509,12 @@ def test_describe_with_include(sample_df):
     multi_params_df['full_name'].equals(sample_df.ww.describe()['full_name'])
 
 
+def test_describe_with_no_match(sample_df):
+    sample_df.ww.init()
+    df = sample_df.ww.describe(include=['wrongname'])
+    assert df.empty
+
+
 def test_value_counts(categorical_df):
     logical_types = {
         'ints': Integer,

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -534,6 +534,46 @@ def test_datetime_dtype_inference_on_init():
     assert df['date_NA_specified'].dtype == 'datetime64[ns]'
 
 
+def test_datetime_inference_with_format_param():
+    df = pd.DataFrame({
+        'index': [0, 1, 2],
+        'dates': ["2019/01/01", "2019/01/02", "2019/01/03"],
+        'ymd_special': ["2019~01~01", "2019~01~02", "2019~01~03"],
+        'mdy_special': pd.Series(['3~11~2000', '3~12~2000', '3~13~2000'], dtype='string'),
+    })
+    df.ww.init(
+        name='dt_name',
+        logical_types={'ymd_special': Datetime(datetime_format='%Y~%m~%d'),
+                       'mdy_special': Datetime(datetime_format='%m~%d~%Y'),
+                       'dates': Datetime},
+        time_index='ymd_special')
+
+    assert df['dates'].dtype == 'datetime64[ns]'
+    assert df['ymd_special'].dtype == 'datetime64[ns]'
+    assert df['mdy_special'].dtype == 'datetime64[ns]'
+
+    assert df.ww.time_index == 'ymd_special'
+    assert df.ww['dates'].ww.logical_type == Datetime
+    assert isinstance(df.ww['ymd_special'].ww.logical_type, Datetime)
+    assert isinstance(df.ww['mdy_special'].ww.logical_type, Datetime)
+
+    df.ww.set_time_index('mdy_special')
+    assert df.ww.time_index == 'mdy_special'
+
+    df = pd.DataFrame({
+        'mdy_special': pd.Series(['3&11&2000', '3&12&2000', '3&13&2000'], dtype='string'),
+    })
+    df.ww.init()
+    assert df['mdy_special'].dtype == 'category'
+
+    df.ww.set_types(logical_types={'mdy_special': Datetime(datetime_format='%m&%d&%Y')})
+    assert df['mdy_special'].dtype == 'datetime64[ns]'
+
+    df.ww.set_time_index('mdy_special')
+    assert isinstance(df.ww['mdy_special'].ww.logical_type, Datetime)
+    assert df.ww.time_index == 'mdy_special'
+
+
 def test_timedelta_dtype_inference_on_init():
     df = pd.DataFrame({
         'delta_no_nans': (pd.Series([pd.to_datetime('2020-09-01')] * 2) - pd.to_datetime('2020-07-01')),
@@ -1522,6 +1562,28 @@ def test_select_repetitive(sample_df):
     df_repeat_ltypes = schema_df.ww.select(['PhoneNumber', PhoneNumber, 'phone_number'])
     assert len(df_repeat_ltypes.columns) == 1
     assert set(df_repeat_ltypes.columns) == {'phone_number'}
+
+
+def test_select_instantiated_ltype():
+    ymd_format = Datetime(datetime_format='%Y~%m~%d')
+
+    df = pd.DataFrame({
+        'dates': ["2019/01/01", "2019/01/02", "2019/01/03"],
+        'ymd': ["2019~01~01", "2019~01~02", "2019~01~03"],
+    })
+    df.ww.init(
+        logical_types={'ymd': ymd_format,
+                       'dates': Datetime})
+
+    new_df = df.ww.select('Datetime')
+    assert len(new_df.columns) == 2
+
+    new_df = df.ww.select(Datetime)
+    assert len(new_df.columns) == 2
+
+    err_msg = "Invalid selector used in include: Datetime cannot be instantiated"
+    with pytest.raises(TypeError, match=err_msg):
+        df.ww.select(ymd_format)
 
 
 def test_accessor_set_index(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -2124,3 +2124,21 @@ def test_accessor_repr_empty(empty_df):
 
     assert repr(empty_df.ww) == 'Empty DataFrame\nColumns: [Physical Type, Logical Type, Semantic Tag(s)]\nIndex: []'
     assert empty_df.ww._repr_html_() == '<table border="1" class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      <th>Physical Type</th>\n      <th>Logical Type</th>\n      <th>Semantic Tag(s)</th>\n    </tr>\n    <tr>\n      <th>Column</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>'
+
+
+def test_numeric_column_names(sample_df):
+    numeric_columns = {col_name: i for col_name, i in zip(sample_df.columns, range(0, len(sample_df.columns)))}
+
+    sample_df.ww.init()
+    numeric_via_woodwork = sample_df.ww.rename(numeric_columns)
+
+    assert numeric_via_woodwork.ww[0].ww._schema == sample_df.ww['id'].ww._schema
+
+    numeric_cols_df = sample_df.rename(columns=numeric_columns)
+    numeric_cols_df.ww.init()
+
+    assert numeric_cols_df.ww == numeric_via_woodwork.ww
+
+    numeric_cols_df.ww.set_index(0)
+    assert numeric_cols_df.ww.index == 0
+    assert numeric_cols_df.ww.semantic_tags[0] == {'index'}

--- a/woodwork/tests/type_system/test_custom_types.py
+++ b/woodwork/tests/type_system/test_custom_types.py
@@ -54,3 +54,38 @@ def test_override_default_function(sample_df):
     assert dt.to_dataframe()['age'].dtype == 'float64'
     # Reset global type system to original settings
     ww.type_system.reset_defaults()
+
+
+def test_custom_type_with_accessor(sample_df):
+    class AgesAbove20(LogicalType):
+        primary_dtype = 'float64'
+        standard_tags = {'age', 'numeric'}
+
+    def ages_func(series):
+        if all(series > 20):
+            return True
+        return False
+
+    ww.type_system.add_type(AgesAbove20, inference_function=ages_func, parent='Integer')
+    sample_df.ww.init()
+    assert sample_df.ww['age'].ww.logical_type == AgesAbove20
+    assert sample_df.ww['age'].ww.semantic_tags == {'age', 'numeric'}
+    assert sample_df['age'].dtype == 'float64'
+    # Reset global type system to original settings
+    ww.type_system.reset_defaults()
+
+
+def test_accessor_override_default_function(sample_df):
+    def new_double_func(series):
+        if pdtypes.is_integer_dtype(series.dtype):
+            return True
+        return False
+
+    # Update functions to cause 'age' to be recognized as Double instead fo Integer
+    ww.type_system.update_inference_function('Double', inference_function=new_double_func)
+    ww.type_system.update_inference_function('Integer', inference_function=None)
+    sample_df.ww.init()
+    assert sample_df.ww['age'].ww.logical_type == Double
+    assert sample_df['age'].dtype == 'float64'
+    # Reset global type system to original settings
+    ww.type_system.reset_defaults()


### PR DESCRIPTION
- Certain cases we were testing in DataTables weren't being tested in the Schema/Accessor approach, so this PR adds tests surrounding those cases.
- Closes #708