### PR TITLE
Add accessor test that uses numeric_time_index_df

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -64,7 +64,7 @@ Release Notes
         * Update Customizing Type Inference guide to use accessor (:pr:`696`)
         * Update Dask and Koalas guide to use accessor (:pr:`701`)
     * Testing Changes
-        * Add tests to Accessor/Schema that weren't previously covered (:pr:`712`)
+        * Add tests to Accessor/Schema that weren't previously covered (:pr:`712`, :pr:`716`)
 
     Thanks to the following people for contributing to this release:
     :user:`johnbridstrup`, :user:`jeff-hernandez`, :user:`tamargrey`, :user:`thehomebrewnerd`

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -425,6 +425,27 @@ def test_accessor_with_numeric_time_index(time_index_df):
     assert date_col['semantic_tags'] == {'numeric', 'time_index'}
 
 
+def test_numeric_time_index_dtypes(numeric_time_index_df):
+    numeric_time_index_df.ww.init(time_index='ints')
+    assert numeric_time_index_df.ww.time_index == 'ints'
+    assert numeric_time_index_df.ww.logical_types['ints'] == Integer
+    assert numeric_time_index_df.ww.semantic_tags['ints'] == {'time_index', 'numeric'}
+
+    numeric_time_index_df.ww.set_time_index('floats')
+    assert numeric_time_index_df.ww.time_index == 'floats'
+    assert numeric_time_index_df.ww.logical_types['floats'] == Double
+    assert numeric_time_index_df.ww.semantic_tags['floats'] == {'time_index', 'numeric'}
+
+    numeric_time_index_df.ww.set_time_index('with_null')
+    assert numeric_time_index_df.ww.time_index == 'with_null'
+    if ks and isinstance(numeric_time_index_df, ks.DataFrame):
+        ltype = Double
+    else:
+        ltype = Integer
+    assert numeric_time_index_df.ww.logical_types['with_null'] == ltype
+    assert numeric_time_index_df.ww.semantic_tags['with_null'] == {'time_index', 'numeric'}
+
+
 def test_accessor_init_with_invalid_string_time_index(sample_df):
     error_msg = 'Time index column must contain datetime or numeric values'
     with pytest.raises(TypeError, match=error_msg):


### PR DESCRIPTION
- Now we can remove the DataTables test that uses this fixture without having to also remove the fixture, plus we add a useful test to Accessor