### PR TITLE
Update release notes test to use correct branch name

### DIFF
--- a/.github/workflows/release_notes_updated.yml
+++ b/.github/workflows/release_notes_updated.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           from re import compile
           main = '^main$'
-          release = '^release_v\d+\_\d+\_\d+$'
+          release = '^release_v\d+\.\d+\.\d+$'
           dep_update = '^dep-update-[a-f0-9]{7}$'
           regex = main, release, dep_update
           patterns = list(map(compile, regex))

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,14 +2,16 @@
 
 Release Notes
 -------------
-.. **Future Release**
+**Future Release**
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Update release branch name in notes update check (:pr:`719`)
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`gsheni`
 
 **v0.0.11 March 15, 2021**
     * Changes


### PR DESCRIPTION
- To be consistent across Featuretools, and Woodwork, the release branch name should be the same
  - https://github.com/alteryx/woodwork/blob/main/.github/workflows/release_notes_updated.yml#L18
  - https://github.com/alteryx/featuretools/blob/main/.github/workflows/release_notes_updated.yml#L18