### PR TITLE
Use pd.read_csv for readme and get started

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ conda install -c conda-forge woodwork
 Below is an example of using Woodwork. In this example, a sample dataset of order items is used to create a Woodwork `DataFrame`, specifying the `LogicalType` for four of the columns.
 
 ```python
+import pandas as pd
 import woodwork as ww
 
-df = ww.demo.load_retail(nrows=100, init_woodwork=False)
-df.ww.init(name='retail', index='order_product_id')
+df = pd.read_csv("https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv")
+df.ww.init(name='retail', make_index=True, index='order_product_id')
 df.ww.set_types(logical_types={
     'quantity': 'Integer',
     'customer_name': 'FullName',

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -68,6 +68,7 @@ Release Notes
         * Update Dask and Koalas guide to use accessor (:pr:`701`)
         * Update index notebook and install guide to use accessor (:pr:`715`)
         * Add section to documentation about schema validity (:pr:`729`)
+        * Update README.md and Get Started guide to use ``pd.read_csv`` (:pr:`730`)
     * Testing Changes
         * Add tests to Accessor/Schema that weren't previously covered (:pr:`712`, :pr:`716`)
         * Update release branch name in notes update check (:pr:`719`)

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -19,7 +19,7 @@
     "* Logical Type: defines how the data should be parsed or interpreted.\n",
     "* Semantic Tag(s): provides additional data about the meaning of the data or how it should be used.\n",
     "\n",
-    "Start learning how to use Woodwork by creating a dataframe that contains retail sales data."
+    "Start learning how to use Woodwork by reading in a dataframe that contains retail sales data."
    ]
   },
   {
@@ -28,9 +28,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import woodwork as ww\n",
+    "import pandas as pd\n",
     "\n",
-    "df = ww.demo.load_retail(nrows=100, init_woodwork=False)\n",
+    "df = pd.read_csv(\"https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv\")\n",
     "df.head(5)"
    ]
   },
@@ -55,7 +55,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.ww.init(name=\"retail\")\n",
+    "import woodwork as ww\n",
+    "\n",
+    "df.ww.init(name=\"retail\", make_index=True, index=\"order_product_id\")\n",
     "df.ww"
    ]
   },
@@ -63,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using just this simple call, Woodwork was able to infer the logical types present in the data by analyzing the DataFrame dtypes as well as the information contained in the columns. In addition, Woodwork also added semantic tags to some of the columns based on the logical types that were inferred.\n",
+    "Using just this simple call, Woodwork was able to infer the logical types present in the data by analyzing the DataFrame dtypes as well as the information contained in the columns. In addition, Woodwork also added semantic tags to some of the columns based on the logical types that were inferred. Because the original data did not contain an index column, Woodwork's `make_index` parameter was used to create a new index column in the DataFrame.\n",
     "\n",
     "All Woodwork methods and properties can be accessed through the `ww` namespace on the DataFrame. DataFrame methods called from the Woodwork namespace will be passed to the DataFrame, and whenever possible, Woodwork will be initialized on the returned object, assuming it is a Series or a DataFrame.\n",
     "\n",
@@ -363,8 +365,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "\n",
     "series = pd.Series([1, 2, 3], dtype='Int64')\n",
     "series.ww.init(logical_type='Integer')\n",
     "series.ww"
@@ -492,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Use pd.read_csv for readme and get started
- Closes #727 

Updates Getting Started guide and REAME.md to use `pd.read_csv` instead of `ww.demo.load_retail` to better illustrate we are starting directly from a pandas DataFrame.