### PR TITLE
Small fixes to documentation

### DIFF
--- a/docs/source/guides/understanding_types_and_tags.ipynb
+++ b/docs/source/guides/understanding_types_and_tags.ipynb
@@ -528,6 +528,7 @@
     "### Defining a Valid Schema\n",
     "\n",
     "Given a DataFrame and its Woodwork typing information, the schema will be considered valid if:\n",
+    "\n",
     "- All of the columns present in the schema are present on the DataFrame and vice versa \n",
     "- The physical type used by each column's Logical Type matches the corresponding series' `dtype`\n",
     "- If an index is present, the index column is unique [pandas only]\n",

--- a/docs/source/index.ipynb
+++ b/docs/source/index.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "### Woodwork is a library that helps with data typing of 2-dimensional tabular data structures.\n",
     "\n",
-    "It provides a special namespace on your DataFrame,`ww`, which contains the physical, logical, and semantic data types.\n",
+    "It provides a special namespace on your DataFrame, `ww`,cle which contains the physical, logical, and semantic data types.\n",
     "It can be used with [Featuretools](https://www.featuretools.com), [EvalML](https://evalml.featurelabs.com/en/latest/), and general machine learning applications where logical and semantic typing information is important.\n",
     "\n",
     "Woodwork provides simple interfaces for adding and updating logical and semantic typing information, as well as selecting data columns based on the types.\n",

--- a/docs/source/index.ipynb
+++ b/docs/source/index.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "### Woodwork is a library that helps with data typing of 2-dimensional tabular data structures.\n",
     "\n",
-    "It provides a special namespace on your DataFrame, `ww`,cle which contains the physical, logical, and semantic data types.\n",
+    "It provides a special namespace on your DataFrame, `ww`, which contains the physical, logical, and semantic data types.\n",
     "It can be used with [Featuretools](https://www.featuretools.com), [EvalML](https://evalml.featurelabs.com/en/latest/), and general machine learning applications where logical and semantic typing information is important.\n",
     "\n",
     "Woodwork provides simple interfaces for adding and updating logical and semantic typing information, as well as selecting data columns based on the types.\n",

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -69,6 +69,7 @@ Release Notes
         * Update index notebook and install guide to use accessor (:pr:`715`)
         * Add section to documentation about schema validity (:pr:`729`)
         * Update README.md and Get Started guide to use ``pd.read_csv`` (:pr:`730`)
+        * Make small fixes to documentation formatting (:pr:`731`)
     * Testing Changes
         * Add tests to Accessor/Schema that weren't previously covered (:pr:`712`, :pr:`716`)
         * Update release branch name in notes update check (:pr:`719`)


### PR DESCRIPTION
- The bullet list in the types and tags doc wasn't formatting correctly, and we were missing a space in the index notebook