### PR TITLE
Add validation control for the table accessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+        * Add validation control to WoodworkTableAccessor (:pr:`736`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -53,7 +53,7 @@ class Schema(object):
             use_standard_tags (bool, optional): If True, will add standard semantic tags to columns based
                 specified logical type for the column. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
-            validate (bool, optional): Whether parameter validateion should occur. Defaults to True. Warning:
+            validate (bool, optional): Whether parameter validation should occur. Defaults to True. Warning:
                 Should be set to False only when parameters and data are known to be valid.
                 Any errors resulting from skipping validation with invalid inputs may not be easily understood.
         """

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -26,7 +26,8 @@ class Schema(object):
                  table_metadata=None,
                  column_metadata=None,
                  use_standard_tags=True,
-                 column_descriptions=None):
+                 column_descriptions=None,
+                 validate=True):
         """Create Schema
 
         Args:
@@ -52,10 +53,14 @@ class Schema(object):
             use_standard_tags (bool, optional): If True, will add standard semantic tags to columns based
                 specified logical type for the column. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
+            validate (bool, optional): Whether parameter validateion should occur. Defaults to True. Warning:
+                Should only be False when confident that parameters valid since any resulting errors may
+                not be easily understood.
         """
-        # Check that inputs are valid
-        _validate_params(column_names, name, index, time_index, logical_types,
-                         table_metadata, column_metadata, semantic_tags, column_descriptions)
+        if validate:
+            # Check that inputs are valid
+            _validate_params(column_names, name, index, time_index, logical_types,
+                             table_metadata, column_metadata, semantic_tags, column_descriptions)
 
         self.name = name
         self.use_standard_tags = use_standard_tags
@@ -66,12 +71,13 @@ class Schema(object):
                                             semantic_tags,
                                             use_standard_tags,
                                             column_descriptions,
-                                            column_metadata)
+                                            column_metadata,
+                                            validate)
         if index is not None:
-            self.set_index(index)
+            self.set_index(index, validate=validate)
 
         if time_index is not None:
-            self.set_time_index(time_index)
+            self.set_time_index(time_index, validate=validate)
 
         self.metadata = table_metadata or {}
 
@@ -273,14 +279,16 @@ class Schema(object):
                         semantic_tags,
                         use_standard_tags,
                         column_descriptions,
-                        column_metadata):
+                        column_metadata,
+                        validate):
         """Create a dictionary with column names as keys and new column dictionaries holding
         each column's typing information as values."""
         columns = {}
         for name in column_names:
             semantic_tags_for_col = _convert_input_to_set((semantic_tags or {}).get(name),
-                                                          error_language=f'semantic_tags for {name}')
-            _validate_not_setting_index_tags(semantic_tags_for_col, name)
+                                                          error_language=f'semantic_tags for {name}', validate=validate)
+            if validate:
+                _validate_not_setting_index_tags(semantic_tags_for_col, name)
             description = (column_descriptions or {}).get(name)
             metadata_for_col = (column_metadata or {}).get(name)
 
@@ -289,10 +297,11 @@ class Schema(object):
                                              semantic_tags=semantic_tags_for_col,
                                              use_standard_tags=use_standard_tags,
                                              description=description,
-                                             metadata=metadata_for_col)
+                                             metadata=metadata_for_col,
+                                             validate=validate)
         return columns
 
-    def set_index(self, new_index):
+    def set_index(self, new_index, validate=True):
         """Sets the index. Handles setting a new index, updating the index, or removing the index.
 
         Args:
@@ -303,10 +312,11 @@ class Schema(object):
         if old_index is not None:
             self.remove_semantic_tags({old_index: 'index'})
         if new_index is not None:
-            _check_index(self.columns.keys(), new_index)
+            if validate:
+                _check_index(self.columns.keys(), new_index)
             self._set_index_tags(new_index)
 
-    def set_time_index(self, new_time_index):
+    def set_time_index(self, new_time_index, validate=True):
         """Set the time index. Adds the 'time_index' semantic tag to the column and
         clears the tag from any previously set index column
 
@@ -318,7 +328,8 @@ class Schema(object):
         if old_time_index is not None:
             self.remove_semantic_tags({old_time_index: 'time_index'})
         if new_time_index is not None:
-            _check_time_index(self.columns.keys(), new_time_index, self.logical_types.get(new_time_index))
+            if validate:
+                _check_time_index(self.columns.keys(), new_time_index, self.logical_types.get(new_time_index))
             self._set_time_index_tags(new_time_index)
 
     def rename(self, columns):

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -54,8 +54,8 @@ class Schema(object):
                 specified logical type for the column. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             validate (bool, optional): Whether parameter validateion should occur. Defaults to True. Warning:
-                Should only be False when confident that parameters valid since any resulting errors may
-                not be easily understood.
+                Should be set to False only when parameters and data are known to be valid.
+                Any errors resulting from skipping validation with invalid inputs may not be easily understood.
         """
         if validate:
             # Check that inputs are valid

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -65,7 +65,8 @@ def _validate_metadata(column_metadata):
 
 
 def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate):
-    semantic_tags = _convert_input_to_set(semantic_tags, error_language=f'semantic_tags for {name}', validate=validate)
+    semantic_tags = _convert_input_to_set(semantic_tags, error_language=f'semantic_tags for {name}',
+                                          validate=validate)
 
     if use_standard_tags:
         semantic_tags = semantic_tags.union(logical_type.standard_tags)

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -15,7 +15,8 @@ def _get_column_dict(name,
                      semantic_tags=None,
                      use_standard_tags=True,
                      description=None,
-                     metadata=None):
+                     metadata=None,
+                     validate=True):
     """Creates a dictionary that contains the typing information for a Schema column
     Args:
         name (str): The name of the column.
@@ -25,15 +26,16 @@ def _get_column_dict(name,
                 specified logical type. Defaults to True.
         description (str, optional): User description of the column.
         metadata (dict[str -> json serializable], optional): Extra metadata provided by the user.
+        validate (bool, optional): Whether to perform parameter validation. Defaults to True.
     """
-    _validate_logical_type(logical_type)
-    _validate_description(description)
-
     if metadata is None:
         metadata = {}
-    _validate_metadata(metadata)
+    if validate:
+        _validate_logical_type(logical_type)
+        _validate_description(description)
+        _validate_metadata(metadata)
 
-    semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name)
+    semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate)
 
     return {
         'logical_type': logical_type,
@@ -62,8 +64,8 @@ def _validate_metadata(column_metadata):
         raise TypeError("Column metadata must be a dictionary")
 
 
-def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name):
-    semantic_tags = _convert_input_to_set(semantic_tags, error_language=f'semantic_tags for {name}')
+def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate):
+    semantic_tags = _convert_input_to_set(semantic_tags, error_language=f'semantic_tags for {name}', validate=validate)
 
     if use_standard_tags:
         semantic_tags = semantic_tags.union(logical_type.standard_tags)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -52,6 +52,7 @@ class WoodworkTableAccessor:
              make_index=False,
              already_sorted=False,
              schema=None,
+             validate=True,
              **kwargs):
         """Initializes Woodwork typing information for a DataFrame.
 
@@ -88,8 +89,12 @@ class WoodworkTableAccessor:
                 Any other arguments provided will be ignored. Note that any changes made to the schema object after
                 initialization will propagate to the DataFrame. Similarly, to avoid unintended typing information changes,
                 the same schema object should not be shared between DataFrames.
+            validate (bool, optional): Whether parameter and data validation should occur. Defaults to True. Warning:
+                Should only be False when confident that parameters and data are valid since any resulting errors may
+                not be easily understood.
         """
-        _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
+        if validate:
+            _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
         if schema is not None:
             self._schema = schema
             extra_params = []
@@ -132,7 +137,9 @@ class WoodworkTableAccessor:
             self._schema = Schema(column_names=column_names,
                                   logical_types=parsed_logical_types,
                                   index=index,
-                                  time_index=time_index, **kwargs)
+                                  time_index=time_index,
+                                  validate=validate,
+                                  **kwargs)
 
             self._set_underlying_index()
             if self._schema.time_index is not None:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -90,8 +90,8 @@ class WoodworkTableAccessor:
                 initialization will propagate to the DataFrame. Similarly, to avoid unintended typing information changes,
                 the same schema object should not be shared between DataFrames.
             validate (bool, optional): Whether parameter and data validation should occur. Defaults to True. Warning:
-                Should only be False when confident that parameters and data are valid since any resulting errors may
-                not be easily understood.
+                Should be set to False only when parameters and data are known to be valid.
+                Any errors resulting from skipping validation with invalid inputs may not be easily understood.
         """
         if validate:
             _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -2225,3 +2225,26 @@ def test_numeric_column_names(sample_df):
     numeric_cols_df.ww.set_index(0)
     assert numeric_cols_df.ww.index == 0
     assert numeric_cols_df.ww.semantic_tags[0] == {'index'}
+
+
+def test_no_validation_valid_inputs(sample_df):
+    validated_df = sample_df.copy()
+    validated_df.ww.init(validate=True, index='id', logical_types={'age': 'Double'})
+
+    not_validated_df = sample_df.copy()
+    not_validated_df.ww.init(validate=False, index='id', logical_types={'age': 'Double'})
+
+    assert validated_df.ww == not_validated_df.ww
+    pd.testing.assert_frame_equal(to_pandas(validated_df), to_pandas(not_validated_df))
+
+
+def test_no_validation_invalid_inputs(sample_df):
+    validated_df = sample_df.copy()
+    error_message = 'Specified time index column `foo` not found in dataframe'
+    with pytest.raises(LookupError, match=error_message):
+        validated_df.ww.init(validate=True, index='id', time_index='foo')
+
+    not_validated_df = sample_df.copy()
+    error_message = 'foo'
+    with pytest.raises(KeyError, match=error_message):
+        not_validated_df.ww.init(validate=False, index='id', time_index='foo')

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -3,7 +3,6 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
-
 from mock import patch
 
 import woodwork as ww

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -57,6 +57,31 @@ def test_validate_metadata_errors():
         _validate_metadata(int)
 
 
+def test_no_validation_valid_input():
+    validated_column = _get_column_dict('ints', Integer, validate=True,
+                                        description='this is a description',
+                                        metadata={'user': 'person1'})
+    not_validated_column = _get_column_dict('ints', Integer, validate=False,
+                                            description='this is a description',
+                                            metadata={'user': 'person1'})
+
+    assert validated_column == not_validated_column
+
+
+def test_no_validation_invalid_input():
+    error = "logical_type logical_type is not a registered LogicalType."
+    with pytest.raises(TypeError, match=error):
+        _get_column_dict('ints', 'logical_type', validate=True,
+                         description='this is a description',
+                         metadata={'user': 'person1'})
+
+    error = "'str' object has no attribute 'standard_tags'"
+    with pytest.raises(AttributeError, match=error):
+        _get_column_dict('ints', 'logical_type', validate=False,
+                         description='this is a description',
+                         metadata={'user': 'person1'})
+
+
 def test_get_column_dict():
     column = _get_column_dict('column', Integer, semantic_tags='test_tag')
 

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+from mock import patch
 
 from woodwork.logical_types import (
     Boolean,
@@ -357,25 +358,30 @@ def test_schema_init_with_column_metadata(sample_column_names, sample_inferred_l
         assert column['metadata'] == (column_metadata.get(name) or {})
 
 
-def test_no_schema_validation_valid_input(sample_column_names, sample_inferred_logical_types):
-    column_metadata = {
-        'age': {'interesting_values': [33]},
-        'signup_date': {'description': 'date of account creation'}
-    }
-    validated_schema = Schema(sample_column_names, sample_inferred_logical_types,
-                              column_metadata=column_metadata, index='signup_date', validate=True)
+@patch("woodwork.schema._validate_not_setting_index_tags")
+@patch("woodwork.schema._check_time_index")
+@patch("woodwork.schema._check_index")
+@patch("woodwork.schema._validate_params")
+def test_validation_methods_called(mock_validate_params, mock_check_index,
+                                   mock_check_time_index, mock_validate_not_setting_index,
+                                   sample_column_names, sample_inferred_logical_types):
+    assert not mock_validate_params.called
+    assert not mock_check_index.called
+    assert not mock_check_time_index.called
+    assert not mock_validate_not_setting_index.called
+
     not_validated_schema = Schema(sample_column_names, sample_inferred_logical_types,
-                                  column_metadata=column_metadata, index='signup_date', validate=False)
+                                  index='id', time_index='signup_date', validate=False)
+    assert not mock_validate_params.called
+    assert not mock_check_index.called
+    assert not mock_check_time_index.called
+    assert not mock_validate_not_setting_index.called
+
+    validated_schema = Schema(sample_column_names, sample_inferred_logical_types,
+                              index='id', time_index='signup_date', validate=True)
+    assert mock_validate_params.called
+    assert mock_check_index.called
+    assert mock_check_time_index.called
+    assert mock_validate_not_setting_index.called
 
     assert validated_schema == not_validated_schema
-
-
-def test_no_schema_validation_invalid_input(sample_column_names, sample_inferred_logical_types):
-    error = 'semantic_tags for id must be a string, set or list'
-    with pytest.raises(TypeError, match=error):
-        Schema(sample_column_names, sample_inferred_logical_types,
-               semantic_tags={'id': 4}, validate=True)
-    error = "'int' object has no attribute 'union'"
-    with pytest.raises(AttributeError, match=error):
-        Schema(sample_column_names, sample_inferred_logical_types,
-               semantic_tags={'id': 4}, validate=False)

--- a/woodwork/tests/schema/test_schema_init.py
+++ b/woodwork/tests/schema/test_schema_init.py
@@ -355,3 +355,27 @@ def test_schema_init_with_column_metadata(sample_column_names, sample_inferred_l
     schema = Schema(sample_column_names, sample_inferred_logical_types, column_metadata=column_metadata)
     for name, column in schema.columns.items():
         assert column['metadata'] == (column_metadata.get(name) or {})
+
+
+def test_no_schema_validation_valid_input(sample_column_names, sample_inferred_logical_types):
+    column_metadata = {
+        'age': {'interesting_values': [33]},
+        'signup_date': {'description': 'date of account creation'}
+    }
+    validated_schema = Schema(sample_column_names, sample_inferred_logical_types,
+                              column_metadata=column_metadata, index='signup_date', validate=True)
+    not_validated_schema = Schema(sample_column_names, sample_inferred_logical_types,
+                                  column_metadata=column_metadata, index='signup_date', validate=False)
+
+    assert validated_schema == not_validated_schema
+
+
+def test_no_schema_validation_invalid_input(sample_column_names, sample_inferred_logical_types):
+    error = 'semantic_tags for id must be a string, set or list'
+    with pytest.raises(TypeError, match=error):
+        Schema(sample_column_names, sample_inferred_logical_types,
+               semantic_tags={'id': 4}, validate=True)
+    error = "'int' object has no attribute 'union'"
+    with pytest.raises(AttributeError, match=error):
+        Schema(sample_column_names, sample_inferred_logical_types,
+               semantic_tags={'id': 4}, validate=False)

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -62,13 +62,19 @@ def test_convert_input_to_set():
     with pytest.raises(TypeError, match=error_message):
         _convert_input_to_set(int)
 
+    assert _convert_input_to_set(int, validate=False) == int
+
     error_message = "test_text must be a string, set or list"
     with pytest.raises(TypeError, match=error_message):
         _convert_input_to_set({'index': {}, 'time_index': {}}, 'test_text')
 
+    assert _convert_input_to_set({'index': {}, 'time_index': {}}, 'test_text', validate=False) == {'index': {}, 'time_index': {}}
+
     error_message = "include parameter must contain only strings"
     with pytest.raises(TypeError, match=error_message):
         _convert_input_to_set(['index', 1], 'include parameter')
+
+    assert _convert_input_to_set(['index', 1], 'include parameter', validate=False) == {'index', 1}
 
     semantic_tags_from_single = _convert_input_to_set('index', 'include parameter')
     assert semantic_tags_from_single == {'index'}

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -5,7 +5,6 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
-
 from mock import patch
 
 import woodwork as ww

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -82,16 +82,16 @@ def test_convert_input_to_set():
 
 
 @patch("woodwork.utils._validate_string_tags")
-@patch("woodwork.utils._validate_tags_input")
-def test_validation_methods_called(mock_validate_input, mock_validate_strings):
-    assert not mock_validate_input.called
+@patch("woodwork.utils._validate_tags_input_type")
+def test_validation_methods_called(mock_validate_input_type, mock_validate_strings):
+    assert not mock_validate_input_type.called
     assert not mock_validate_strings.called
 
     _convert_input_to_set('test_tag', validate=False)
-    assert not mock_validate_input.called
+    assert not mock_validate_input_type.called
 
     _convert_input_to_set('test_tag', validate=True)
-    assert mock_validate_input.called
+    assert mock_validate_input_type.called
 
     _convert_input_to_set(['test_tag', 'tag2'], validate=False)
     assert not mock_validate_strings.called

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -34,7 +34,6 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags', validat
     if not semantic_tags:
         return set()
 
-# --> this and check below need to be their own functions in order to properly mock
     if validate and type(semantic_tags) not in [list, set, str]:
         raise TypeError(f"{error_language} must be a string, set or list")
 

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -35,7 +35,7 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags', validat
         return set()
 
     if validate:
-        _validate_tags_input(semantic_tags, error_language)
+        _validate_tags_input_type(semantic_tags, error_language)
 
     if isinstance(semantic_tags, str):
         return {semantic_tags}
@@ -49,7 +49,7 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags', validat
     return semantic_tags
 
 
-def _validate_tags_input(semantic_tags, error_language):
+def _validate_tags_input_type(semantic_tags, error_language):
     if type(semantic_tags) not in [list, set, str]:
         raise TypeError(f"{error_language} must be a string, set or list")
 

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -34,8 +34,8 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags', validat
     if not semantic_tags:
         return set()
 
-    if validate and type(semantic_tags) not in [list, set, str]:
-        raise TypeError(f"{error_language} must be a string, set or list")
+    if validate:
+        _validate_tags_input(semantic_tags, error_language)
 
     if isinstance(semantic_tags, str):
         return {semantic_tags}
@@ -43,10 +43,20 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags', validat
     if isinstance(semantic_tags, list):
         semantic_tags = set(semantic_tags)
 
-    if validate and not all([isinstance(tag, str) for tag in semantic_tags]):
-        raise TypeError(f"{error_language} must contain only strings")
+    if validate:
+        _validate_string_tags(semantic_tags, error_language)
 
     return semantic_tags
+
+
+def _validate_tags_input(semantic_tags, error_language):
+    if type(semantic_tags) not in [list, set, str]:
+        raise TypeError(f"{error_language} must be a string, set or list")
+
+
+def _validate_string_tags(semantic_tags, error_language):
+    if not all([isinstance(tag, str) for tag in semantic_tags]):
+        raise TypeError(f"{error_language} must contain only strings")
 
 
 def read_csv(filepath=None,

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -34,6 +34,7 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags', validat
     if not semantic_tags:
         return set()
 
+# --> this and check below need to be their own functions in order to properly mock
     if validate and type(semantic_tags) not in [list, set, str]:
         raise TypeError(f"{error_language} must be a string, set or list")
 

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -27,14 +27,14 @@ def camel_to_snake(s):
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s).lower()
 
 
-def _convert_input_to_set(semantic_tags, error_language='semantic_tags'):
+def _convert_input_to_set(semantic_tags, error_language='semantic_tags', validate=True):
     """Takes input as a single string, a list of strings, or a set of strings
         and returns a set with the supplied values. If no values are supplied,
         an empty set will be returned."""
     if not semantic_tags:
         return set()
 
-    if type(semantic_tags) not in [list, set, str]:
+    if validate and type(semantic_tags) not in [list, set, str]:
         raise TypeError(f"{error_language} must be a string, set or list")
 
     if isinstance(semantic_tags, str):
@@ -43,7 +43,7 @@ def _convert_input_to_set(semantic_tags, error_language='semantic_tags'):
     if isinstance(semantic_tags, list):
         semantic_tags = set(semantic_tags)
 
-    if not all([isinstance(tag, str) for tag in semantic_tags]):
+    if validate and not all([isinstance(tag, str) for tag in semantic_tags]):
         raise TypeError(f"{error_language} must contain only strings")
 
     return semantic_tags


### PR DESCRIPTION
- Adds a `validate` param to the WoodworkTableAccessor that disables all validation that occurs, passing `validate` down to the Schema class and `_get_column_schema`.

Note: Decided to open a PR after just the Table Accessor since it was touching a lot of areas of Woodwork already, and I want to make sure we give each component of the validation control changes enough review time. The Column Accessor validation control, removing validation from deserialization, and how we address this in documentation (if at all) can each be their own, separate PRs