### PR TITLE
Rename ZIPCode to PostalCode

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -125,10 +125,10 @@ Logical Types
     NaturalLanguage
     Ordinal
     PhoneNumber
+    PostalCode
     SubRegionCode
     Timedelta
     URL
-    ZIPCode
 
 TypeSystem
 ==========

--- a/docs/source/guides/understanding_types_and_tags.ipynb
+++ b/docs/source/guides/understanding_types_and_tags.ipynb
@@ -104,8 +104,8 @@
     "    * `Categorical`\n",
     "    * `CountryCode`\n",
     "    * `Ordinal`\n",
+    "    * `PostalCode`\n",
     "    * `SubRegionCode`\n",
-    "    * `ZIPCode`\n",
     "\n",
     "There are also 2 tags that get added to index columns. If no index columns have been specified, these tags are not present:\n",
     "\n",
@@ -600,7 +600,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,14 +2,19 @@
 
 Release Notes
 -------------
-.. **Future Release**
+**Future Release**
     * Enhancements
     * Fixes
     * Changes
+        * Rename ``ZIPCode`` logical type to ``PostalCode`` (:pr:`741`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
+**Breaking Changes**
+    * The ``ZIPCode`` logical type has been renamed to ``PostalCode``
 
 **v0.1.0 March 22, 2021**
     * Enhancements

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -313,17 +313,16 @@ class URL(LogicalType):
     primary_dtype = 'string'
 
 
-class ZIPCode(LogicalType):
-    """Represents Logical Types that contain a series of postal codes used by
-    the US Postal Service for representing a group of addresses.
-    Has 'category' as a standard tag.
+class PostalCode(LogicalType):
+    """Represents Logical Types that contain a series of postal codes for
+    representing a group of addresses. Has 'category' as a standard tag.
 
     Examples:
         .. code-block:: python
 
             ["90210"
              "60018-0123",
-             "10021"]
+             "SW1A"]
     """
     primary_dtype = 'category'
     backup_dtype = 'string'

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -168,7 +168,7 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None, include_ind
     """Calculates mutual information between all pairs of columns in the DataFrame that
     support mutual information. Logical Types that support mutual information are as
     follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
-    SubRegionCode, and ZIPCode
+    SubRegionCode, and PostalCode
 
     Args:
         dataframe (pd.DataFrame): Data containing Woodwork typing information

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -168,7 +168,7 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None, include_ind
     """Calculates mutual information between all pairs of columns in the DataFrame that
     support mutual information. Logical Types that support mutual information are as
     follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
-    SubRegionCode, and PostalCode
+    PostalCode, and SubRegionCode
 
     Args:
         dataframe (pd.DataFrame): Data containing Woodwork typing information

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -681,7 +681,7 @@ class WoodworkTableAccessor:
         Calculates mutual information between all pairs of columns in the DataFrame that
         support mutual information. Logical Types that support mutual information are as
         follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
-        SubRegionCode, and PostalCode
+        PostalCode, and SubRegionCode
 
         Args:
             num_bins (int): Determines number of bins to use for converting
@@ -708,7 +708,7 @@ class WoodworkTableAccessor:
         """Calculates mutual information between all pairs of columns in the DataFrame that
         support mutual information. Logical Types that support mutual information are as
         follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
-        SubRegionCode, and PostalCode
+        PostalCode, and SubRegionCode
 
         Args:
             num_bins (int): Determines number of bins to use for converting

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -681,7 +681,7 @@ class WoodworkTableAccessor:
         Calculates mutual information between all pairs of columns in the DataFrame that
         support mutual information. Logical Types that support mutual information are as
         follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
-        SubRegionCode, and ZIPCode
+        SubRegionCode, and PostalCode
 
         Args:
             num_bins (int): Determines number of bins to use for converting
@@ -708,7 +708,7 @@ class WoodworkTableAccessor:
         """Calculates mutual information between all pairs of columns in the DataFrame that
         support mutual information. Logical Types that support mutual information are as
         follows:  Boolean, Categorical, CountryCode, Datetime, Double, Integer, Ordinal,
-        SubRegionCode, and ZIPCode
+        SubRegionCode, and PostalCode
 
         Args:
             num_bins (int): Determines number of bins to use for converting

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -21,8 +21,8 @@ from woodwork.logical_types import (
     LatLong,
     NaturalLanguage,
     Ordinal,
-    SubRegionCode,
-    ZIPCode
+    PostalCode,
+    SubRegionCode
 )
 from woodwork.tests.testing_utils import (
     is_property,
@@ -226,7 +226,7 @@ def test_adds_numeric_standard_tag():
 def test_adds_category_standard_tag():
     semantic_tags = 'custom_tag'
 
-    logical_types = [Categorical, CountryCode, Ordinal(order=(1, 2, 3)), SubRegionCode, ZIPCode]
+    logical_types = [Categorical, CountryCode, Ordinal(order=(1, 2, 3)), PostalCode, SubRegionCode]
     for logical_type in logical_types:
         series = pd.Series([1, 2, 3], dtype='category')
         series.ww.init(logical_type=logical_type, semantic_tags=semantic_tags)

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -17,9 +17,9 @@ from woodwork.logical_types import (
     NaturalLanguage,
     Ordinal,
     PhoneNumber,
+    PostalCode,
     SubRegionCode,
-    Timedelta,
-    ZIPCode
+    Timedelta
 )
 from woodwork.statistics_utils import (
     _get_describe_dict,
@@ -222,8 +222,8 @@ def test_describe_accessor_method(describe_df):
     categorical_ltypes = [Categorical,
                           CountryCode,
                           Ordinal(order=('yellow', 'red', 'blue')),
-                          SubRegionCode,
-                          ZIPCode]
+                          PostalCode,
+                          SubRegionCode]
     boolean_ltypes = [Boolean]
     datetime_ltypes = [Datetime]
     formatted_datetime_ltypes = [Datetime(datetime_format='%Y~%m~%d')]

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -30,8 +30,8 @@ from woodwork.logical_types import (
     NaturalLanguage,
     Ordinal,
     PhoneNumber,
-    SubRegionCode,
-    ZIPCode
+    PostalCode,
+    SubRegionCode
 )
 from woodwork.schema import Schema
 from woodwork.table_accessor import (
@@ -624,8 +624,8 @@ def test_sets_category_dtype_on_init():
         Categorical,
         CountryCode,
         Ordinal(order=['a', 'b', 'c']),
-        SubRegionCode,
-        ZIPCode,
+        PostalCode,
+        SubRegionCode
     ]
 
     for series in series_list:
@@ -1330,8 +1330,8 @@ def test_select_ltypes_no_match_and_all(sample_df):
                                      'signup_date': Datetime,
                                      })
 
-    assert len(schema_df.ww.select(ZIPCode).columns) == 0
-    assert len(schema_df.ww.select(['ZIPCode', PhoneNumber]).columns) == 1
+    assert len(schema_df.ww.select(PostalCode).columns) == 0
+    assert len(schema_df.ww.select(['PostalCode', PhoneNumber]).columns) == 1
 
     all_types = ww.type_system.registered_types
     df_all_types = schema_df.ww.select(all_types)
@@ -1556,7 +1556,7 @@ def test_select_semantic_tags_no_match(sample_df):
     df_multiple_unused = schema_df.ww.select(['doesnt_exist', 'boolean', 'category', PhoneNumber])
     assert len(df_multiple_unused.columns) == 2
 
-    df_unused_ltype = schema_df.ww.select(['date_of_birth', 'doesnt_exist', ZIPCode, Integer])
+    df_unused_ltype = schema_df.ww.select(['date_of_birth', 'doesnt_exist', PostalCode, Integer])
     assert len(df_unused_ltype.columns) == 3
 
 

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -15,8 +15,8 @@ from woodwork.logical_types import (
     Double,
     Integer,
     Ordinal,
-    SubRegionCode,
-    ZIPCode
+    PostalCode,
+    SubRegionCode
 )
 from woodwork.type_sys.utils import (
     _get_specified_ltype_params,
@@ -47,7 +47,7 @@ ks = import_or_none('databricks.koalas')
 
 def test_camel_to_snake():
     test_items = {
-        'ZIPCode': 'zip_code',
+        'PostalCode': 'postal_code',
         'SubRegionCode': 'sub_region_code',
         'NaturalLanguage': 'natural_language',
         'Categorical': 'categorical',
@@ -109,8 +109,8 @@ def test_list_logical_types_customized_type_system():
     df = list_logical_types()
     assert len(all_ltypes) == len(df)
     # Check that URL is unregistered
-    assert df.loc[18, 'is_default_type']
-    assert not df.loc[18, 'is_registered']
+    assert df.loc[19, 'is_default_type']
+    assert not df.loc[19, 'is_registered']
 
     # Check that new registered type is present and shows as registered
     assert 'CustomRegistered' in df['name'].values
@@ -413,8 +413,8 @@ def test_get_valid_mi_types():
         Double,
         Integer,
         Ordinal,
+        PostalCode,
         SubRegionCode,
-        ZIPCode,
     ]
 
     assert valid_types == expected_types

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -24,9 +24,9 @@ from woodwork.logical_types import (
     NaturalLanguage,
     Ordinal,
     PhoneNumber,
+    PostalCode,
     SubRegionCode,
-    Timedelta,
-    ZIPCode
+    Timedelta
 )
 from woodwork.utils import import_or_none
 
@@ -48,18 +48,18 @@ DEFAULT_INFERENCE_FUNCTIONS = {
     NaturalLanguage: None,
     Ordinal: None,
     PhoneNumber: None,
+    PostalCode: None,
     SubRegionCode: None,
     Timedelta: timedelta_func,
-    URL: None,
-    ZIPCode: None
+    URL: None
 }
 
 # (ParentType, ChildType)
 DEFAULT_RELATIONSHIPS = [
     (Categorical, CountryCode),
     (Categorical, Ordinal),
+    (Categorical, PostalCode),
     (Categorical, SubRegionCode),
-    (Categorical, ZIPCode),
     (NaturalLanguage, EmailAddress),
     (NaturalLanguage, Filepath),
     (NaturalLanguage, FullName),


### PR DESCRIPTION
- Rename ZIPCode to PostalCode
- Closes #164 

Renames ZIPCode logical type to PostalCode. Also had to update one test because the renaming changed the order or output from the `ww.list_logical_types()` function.