### PR TITLE
Restrict smart-open version

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,11 +8,12 @@ Release Notes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)
         * Rename ``ZIPCode`` logical type to ``PostalCode`` (:pr:`741`)
+        * Restrict smart-open version to <5.0.0 (:pr:`750`)
     * Documentation Changes
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`, :user:`thehomebrewnerd`
+    :user:`jeff-hernandez`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 **Breaking Changes**
     * The ``ZIPCode`` logical type has been renamed to ``PostalCode``

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,5 @@ pytest-cov==2.10.1
 pytest-xdist==2.1.0
 boto3>=1.10.45
 moto[all]>=1.3.14
-smart-open>=1.8.4
+smart-open>=1.8.4,<5.0.0
 pyarrow>=2.0.0


### PR DESCRIPTION
Some serialization test fail with the new smart-open version 5.0.0. This PR restricts smart-open to <5.0.0 while this is being investigated in #749.