### PR TITLE
Use nullable Float64 pandas dtype for Double

### DIFF
--- a/dask-requirements.txt
+++ b/dask-requirements.txt
@@ -1,1 +1,1 @@
-dask[dataframe]>=2.30.0,<2012.12.0
+dask[dataframe]>=2021.02.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
 
     * Enhancements
         * Add validation control to WoodworkTableAccessor (:pr:`736`)
+        * Use nullable ``pd.Float64Dtype`` on ``Double`` logical type (:pr:`755`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)
@@ -27,6 +28,7 @@ Release Notes
 **Breaking Changes**
     * The ``ZIPCode`` logical type has been renamed to ``PostalCode``
     * The ``FullName`` logical type has been renamed to ``PersonFullName``
+    * The ``Double`` logical type now uses the nullable ``pd.Float64Dtype`` as its primary dtype instead of ``np.float64``
 
 **v0.1.0 March 22, 2021**
     * Enhancements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.15.4
-pandas>=1.1.1
+pandas>=1.2.0
 click>=7.1.2
 scikit-learn>=0.22

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -110,7 +110,7 @@ class Double(LogicalType):
             [1.2, 100.4, 3.5]
             [-15.34, 100, 58.3]
     """
-    primary_dtype = 'float64'
+    primary_dtype = 'Float64'
     standard_tags = {'numeric'}
 
 

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -152,7 +152,6 @@ def _make_categorical_for_mutual_info(schema, data, num_bins):
         column = schema.columns[col_name]
         if _is_col_numeric(column):
             # Float64 dtype is not compatible with qcut, so convert to float64
-            # --> should we convert it back after???? - check if later version of pandas changes
             data_col = data[col_name]
             if str(data_col.dtype) == 'Float64':
                 data_col = data_col.astype('float64')

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -151,8 +151,13 @@ def _make_categorical_for_mutual_info(schema, data, num_bins):
     for col_name in data.columns:
         column = schema.columns[col_name]
         if _is_col_numeric(column):
+            # Float64 dtype is not compatible with qcut, so convert to float64
+            # --> should we convert it back after????
+            data_col = data[col_name]
+            if str(data_col.dtype) == 'Float64':
+                data_col = data_col.astype('float64')
             # bin numeric features to make categories
-            data[col_name] = pd.qcut(data[col_name], num_bins, duplicates="drop")
+            data[col_name] = pd.qcut(data_col, num_bins, duplicates="drop")
         # Convert Datetimes to total seconds - an integer - and bin
         if _is_col_datetime(column):
             data[col_name] = pd.qcut(data[col_name].astype('int64'), num_bins, duplicates="drop")

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -152,7 +152,7 @@ def _make_categorical_for_mutual_info(schema, data, num_bins):
         column = schema.columns[col_name]
         if _is_col_numeric(column):
             # Float64 dtype is not compatible with qcut, so convert to float64
-            # --> should we convert it back after????
+            # --> should we convert it back after???? - check if later version of pandas changes
             data_col = data[col_name]
             if str(data_col.dtype) == 'Float64':
                 data_col = data_col.astype('float64')

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -234,7 +234,7 @@ def test_adds_category_standard_tag():
 
 
 def test_does_not_add_standard_tags():
-    series = pd.Series([1.1, 2, 3])
+    series = pd.Series([1.1, 2, 3], dtype='Float64')
     semantic_tags = 'custom_tag'
     series.ww.init(logical_type=Double,
                    semantic_tags=semantic_tags,

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -71,7 +71,7 @@ def test_accessor_replace_nans_for_mutual_info():
     assert isinstance(formatted_df, pd.DataFrame)
 
     assert formatted_df['ints'].equals(pd.Series([2, 3, 5, 2], dtype='Int64'))
-    assert formatted_df['floats'].equals(pd.Series([3.3, 2.3, 2.3, 1.3], dtype='float'))
+    assert formatted_df['floats'].equals(pd.Series([3.3, 2.3, 2.3, 1.3], dtype='Float64'))
     assert formatted_df['bools'].equals(pd.Series([True, True, True, False], dtype='category'))
     assert formatted_df['int_to_cat_nan'].equals(pd.Series([1, 1, 3, 1], dtype='category'))
     assert formatted_df['str'].equals(pd.Series(['test', 'test', 'test2', 'test'], dtype='category'))

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -398,7 +398,7 @@ def test_accessor_with_numeric_time_index(time_index_df):
     assert date_col['logical_type'] == Double
     assert date_col['semantic_tags'] == {'time_index', 'numeric'}
 
-# --> no longer valid to convert from strs to Float64
+# --> no longer valid to convert from strs to Float64 - check if later version of pandas changes this
     # schema_df = time_index_df.copy()
     # schema_df.ww.init(time_index='strs', logical_types={'strs': 'Double'})
     # date_col = schema_df.ww.columns['strs']
@@ -1137,6 +1137,7 @@ def test_get_invalid_schema_message_index_checks(sample_df):
     assert (_get_invalid_schema_message(different_underlying_index_df, schema) ==
             "Index mismatch between DataFrame and typing information")
 
+    # --> we shouldn't have to do the astype right? see if this is a bug or if a later pandas version fixes
     not_unique_df = schema_df.replace({3.0: 1.0}).astype({'id': 'Float64'})
     not_unique_df.index = not_unique_df['id']
     not_unique_df.index.name = None

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -398,13 +398,12 @@ def test_accessor_with_numeric_time_index(time_index_df):
     assert date_col['logical_type'] == Double
     assert date_col['semantic_tags'] == {'time_index', 'numeric'}
 
-# --> no longer valid to convert from strs to Float64 - check if later version of pandas changes this
-    # schema_df = time_index_df.copy()
-    # schema_df.ww.init(time_index='strs', logical_types={'strs': 'Double'})
-    # date_col = schema_df.ww.columns['strs']
-    # assert schema_df.ww.time_index == 'strs'
-    # assert date_col['logical_type'] == Double
-    # assert date_col['semantic_tags'] == {'time_index', 'numeric'}
+    schema_df = time_index_df.astype({'strs': 'string'})
+    schema_df.ww.init(time_index='strs', logical_types={'strs': 'Double'})
+    date_col = schema_df.ww.columns['strs']
+    assert schema_df.ww.time_index == 'strs'
+    assert date_col['logical_type'] == Double
+    assert date_col['semantic_tags'] == {'time_index', 'numeric'}
 
     error_msg = 'Time index column must contain datetime or numeric values'
     with pytest.raises(TypeError, match=error_msg):
@@ -1137,7 +1136,6 @@ def test_get_invalid_schema_message_index_checks(sample_df):
     assert (_get_invalid_schema_message(different_underlying_index_df, schema) ==
             "Index mismatch between DataFrame and typing information")
 
-    # --> we shouldn't have to do the astype right? see if this is a bug or if a later pandas version fixes
     not_unique_df = schema_df.replace({3.0: 1.0}).astype({'id': 'Float64'})
     not_unique_df.index = not_unique_df['id']
     not_unique_df.index.name = None

--- a/woodwork/tests/type_system/test_custom_types.py
+++ b/woodwork/tests/type_system/test_custom_types.py
@@ -23,7 +23,7 @@ def test_register_custom_logical_type(type_sys):
 
 def test_custom_type_with_accessor(sample_df):
     class AgesAbove20(LogicalType):
-        primary_dtype = 'float64'
+        primary_dtype = 'Float64'
         standard_tags = {'age', 'numeric'}
 
     def ages_func(series):
@@ -35,7 +35,7 @@ def test_custom_type_with_accessor(sample_df):
     sample_df.ww.init()
     assert sample_df.ww['age'].ww.logical_type == AgesAbove20
     assert sample_df.ww['age'].ww.semantic_tags == {'age', 'numeric'}
-    assert sample_df['age'].dtype == 'float64'
+    assert sample_df['age'].dtype == 'Float64'
     # Reset global type system to original settings
     ww.type_system.reset_defaults()
 
@@ -51,6 +51,6 @@ def test_accessor_override_default_function(sample_df):
     ww.type_system.update_inference_function('Integer', inference_function=None)
     sample_df.ww.init()
     assert sample_df.ww['age'].ww.logical_type == Double
-    assert sample_df['age'].dtype == 'float64'
+    assert sample_df['age'].dtype == 'Float64'
     # Reset global type system to original settings
     ww.type_system.reset_defaults()


### PR DESCRIPTION
- Changes the primary dtype for the `Double` logical type from `float64` to `Float64`
- updates pandas requirement to `1.2.0` and Dask requirement to `2021.02.0` beacause those are the releases where the Float64 was added
- Certain tests broke - need to investigate if those are pandas bugs and if so were they fixed in later releases?
  - can't convert from ['1', '2', '3'] to [1.0, 2.0, 3.0] when using `Float64` dtype
  - `pd.qcut` doesnt work on Float64
  - doing `df.replace` changes the dtype back to `float64`
- Closes #264 