### PR TITLE
Fixes for smart-open 5.0.0

### DIFF
--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -69,10 +69,10 @@
     "| Dependency        | Min Version | Notes                                  |\n",
     "|-------------------|-------------|----------------------------------------|\n",
     "| boto3             | 1.10.45     | Required to read/write to URLs and S3  |\n",
-    "| smart_open        | 1.8.4       | Required to read/write to URLs and S3  |\n",
+    "| smart_open        | 5.0.0       | Required to read/write to URLs and S3  |\n",
     "| pyarrow           | 2.0.0       | Required to serialize to parquet       |\n",
     "| dask[distributed] | 2.30.0      | Required to use with Dask DataFrames   |\n",
-    "| koalas            | 1.4.0       | Required to use with Koalas DataFrames |\n",
+    "| koalas            | 1.7.0       | Required to use with Koalas DataFrames |\n",
     "| pyspark           | 3.0.0       | Required to use with Koalas DataFrames |\n",
     "\n",
     "\n",
@@ -99,7 +99,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)
         * Rename ``ZIPCode`` logical type to ``PostalCode`` (:pr:`741`)
-        * Restrict smart-open version to <5.0.0 (:pr:`750`)
+        * Fix issue with smart-open version 5.0.0 (:pr:`750`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)
         * Rename ``ZIPCode`` logical type to ``PostalCode`` (:pr:`741`)
-        * Fix issue with smart-open version 5.0.0 (:pr:`750`)
+        * Fix issue with smart-open version 5.0.0 (:pr:`750`, :pr:`758`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
     * Testing Changes

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,5 @@ pytest-cov==2.10.1
 pytest-xdist==2.1.0
 boto3>=1.10.45
 moto[all]>=1.3.14
-smart-open>=1.8.4,<5.0.0
+smart-open>=5.0.0
 pyarrow>=2.0.0

--- a/woodwork/s3_utils.py
+++ b/woodwork/s3_utils.py
@@ -21,11 +21,12 @@ def get_transport_params(profile_name):
     Config = import_or_raise("botocore.config", BOTOCORE_ERR_MSG).Config
 
     if isinstance(profile_name, str):
-        transport_params = {'session': boto3.Session(profile_name=profile_name)}
+        session = boto3.Session(profile_name=profile_name)
+        transport_params = {'client': session.client('s3')}
     elif profile_name is False or boto3.Session().get_credentials() is None:
-        transport_params = {
-            'resource_kwargs': {'config': Config(signature_version=UNSIGNED)}
-        }
+        session = boto3.Session()
+        client = session.client('s3', config=Config(signature_version=UNSIGNED))
+        transport_params = {'client': client}
     else:
         transport_params = None
     return transport_params
@@ -48,7 +49,7 @@ BOTOCORE_ERR_MSG = (
 SMART_OPEN_ERR_MSG = (
     "The smart_open library is required to read and write from URLs and S3.\n"
     "Install via pip:\n"
-    "    pip install smart-open\n"
+    "    pip install 'smart-open>=5.0.0'\n"
     "Install via conda:\n"
-    "    conda install smart_open"
+    "    conda install 'smart-open>=5.0.0'"
 )


### PR DESCRIPTION
- Fixes for smart-open 5.0.0
- Closes #749 

Updates transport parameters to work with smart-open 5.0.0. Note, this version of smart-open implemented breaking changes, so these updates are not compatible with earlier versions of smart-open.