### PR TITLE
Remove ColumnNameMismatch warning

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,7 @@ Release Notes
         * Fix issue with smart-open version 5.0.0 (:pr:`750`, :pr:`758`)
         * Update minimum scikit-learn version to 0.22 (:pr:`763`)
         * Drop support for Python version 3.6 (:pr:`768`)
+        * Remove ``ColumnNameMismatchWarning`` (:pr:`777`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
     * Testing Changes

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -1,8 +1,3 @@
-class ColumnNameMismatchWarning(UserWarning):
-    def get_warning_message(self, lose_col, keep_col):
-        return f'Name mismatch between {lose_col} and {keep_col}. Series name is now {keep_col}'
-
-
 class DuplicateTagsWarning(UserWarning):
     def get_warning_message(self, duplicate_tags, name):
         return f"Semantic tag(s) '{', '.join(duplicate_tags)}' already present on column '{name}'"

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -10,7 +10,6 @@ from woodwork.accessor_utils import (
     init_series
 )
 from woodwork.exceptions import (
-    ColumnNameMismatchWarning,
     ColumnNotPresentError,
     ParametersIgnoredWarning,
     StandardTagsChangedWarning,
@@ -198,10 +197,6 @@ class WoodworkTableAccessor:
             raise KeyError('Cannot reassign index. Change column name and then use df.ww.set_index to reassign index.')
         if self.time_index == col_name:
             raise KeyError('Cannot reassign time index. Change column name and then use df.ww.set_time_index to reassign time index.')
-
-        if column.name is not None and column.name != col_name:
-            warnings.warn(ColumnNameMismatchWarning().get_warning_message(column.name, col_name),
-                          ColumnNameMismatchWarning)
 
         if column.ww._schema is None:
             column = init_series(column, use_standard_tags=self.use_standard_tags)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -8,7 +8,6 @@ from mock import patch
 import woodwork as ww
 from woodwork.accessor_utils import init_series
 from woodwork.exceptions import (
-    ColumnNameMismatchWarning,
     ColumnNotPresentError,
     ParametersIgnoredWarning,
     StandardTagsChangedWarning,
@@ -1912,10 +1911,8 @@ def test_setitem_different_name(sample_df):
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series = ks.Series(new_series)
 
-    warning = 'Name mismatch between wrong and id. Series name is now id'
-    with pytest.warns(ColumnNameMismatchWarning, match=warning):
-        df.ww['id'] = new_series
-
+    # Assign series with name `wrong` to existing column with name `id`
+    df.ww['id'] = new_series
     assert df.ww['id'].name == 'id'
     assert 'id' in df.ww.columns
     assert 'wrong' not in df.ww.columns
@@ -1925,10 +1922,8 @@ def test_setitem_different_name(sample_df):
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series2 = ks.Series(new_series2)
 
-    warning = 'Name mismatch between wrong2 and new_col. Series name is now new_col'
-    with pytest.warns(ColumnNameMismatchWarning, match=warning):
-        df.ww['new_col'] = new_series2
-
+    # Assign series with name `wrong2` to new column with name `new_col`
+    df.ww['new_col'] = new_series2
     assert df.ww['new_col'].name == 'new_col'
     assert 'new_col' in df.ww.columns
     assert 'wrong2' not in df.ww.columns


### PR DESCRIPTION
- Remove ColumnNameMismatch warning
- Closes #757 

Previously Woodwork would raise a warning if assigning a named series to a dataframe column of a different name through the Woodwork accessor. Since the user is explicitly supplying the name they want during the column assignment, this warning is not necessary and can be removed.