### PR TITLE
Store make index on WoodworkTableAccessor

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
 
     * Enhancements
         * Add validation control to WoodworkTableAccessor (:pr:`736`)
-        * Store ``make_index`` value on WoodworkTableAccessor (:pr:`736`)
+        * Store ``make_index`` value on WoodworkTableAccessor (:pr:`780`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
 
     * Enhancements
         * Add validation control to WoodworkTableAccessor (:pr:`736`)
+        * Store ``make_index`` value on WoodworkTableAccessor (:pr:`736`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -94,6 +94,10 @@ class WoodworkTableAccessor:
         """
         if validate:
             _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
+
+        # --> Set the made_index value here
+        self.made_index = make_index
+
         if schema is not None:
             self._schema = schema
             extra_params = []
@@ -146,6 +150,10 @@ class WoodworkTableAccessor:
 
     def __eq__(self, other):
         if self._schema != other.ww._schema:
+            return False
+
+        # --> make sure to thest this in equality test
+        if self.made_index != other.ww.made_index:
             return False
 
         # Only check pandas DataFrames for equality
@@ -580,6 +588,9 @@ class WoodworkTableAccessor:
                     else:
                         copied_schema = self._schema._get_subset_schema(list(self._dataframe.columns))
                         result.ww.init(schema=copied_schema)
+                        print('og made', self.made_index)
+                        result.ww.made_index = self.made_index
+                        print('new made', result.ww.made_index)
                 else:
                     # Confirm that the Schema is still valid on original DataFrame
                     # Important for inplace operations

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -96,7 +96,7 @@ class WoodworkTableAccessor:
             _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
 
         # --> Set the made_index value here
-        self.made_index = make_index
+        self.make_index = make_index
 
         if schema is not None:
             self._schema = schema
@@ -153,7 +153,7 @@ class WoodworkTableAccessor:
             return False
 
         # --> make sure to thest this in equality test
-        if self.made_index != other.ww.made_index:
+        if self.make_index != other.ww.make_index:
             return False
 
         # Only check pandas DataFrames for equality
@@ -588,9 +588,7 @@ class WoodworkTableAccessor:
                     else:
                         copied_schema = self._schema._get_subset_schema(list(self._dataframe.columns))
                         result.ww.init(schema=copied_schema)
-                        print('og made', self.made_index)
-                        result.ww.made_index = self.made_index
-                        print('new made', result.ww.made_index)
+                        result.ww.make_index = self.make_index
                 else:
                     # Confirm that the Schema is still valid on original DataFrame
                     # Important for inplace operations

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -112,7 +112,11 @@ class WoodworkTableAccessor:
             if extra_params:
                 warnings.warn("A schema was provided and the following parameters were ignored: " + ", ".join(extra_params), ParametersIgnoredWarning)
 
+            # We need to store make_index on the Accessor when initializing with a Schema
+            # but we still should ignore any make_index value passed in here
+            self.make_index = False
         else:
+            self.make_index = make_index
             if make_index:
                 _make_index(self._dataframe, index)
 
@@ -143,9 +147,6 @@ class WoodworkTableAccessor:
             self._set_underlying_index()
             if self._schema.time_index is not None:
                 self._sort_columns(already_sorted)
-
-        # Record the value of
-        self.make_index = make_index
 
     def __eq__(self, other):
         if self.make_index != other.ww.make_index:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -94,7 +94,6 @@ class WoodworkTableAccessor:
         """
         if validate:
             _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
-
         if schema is not None:
             self._schema = schema
             extra_params = []
@@ -145,6 +144,7 @@ class WoodworkTableAccessor:
             if self._schema.time_index is not None:
                 self._sort_columns(already_sorted)
 
+        # Record the value of
         self.make_index = make_index
 
     def __eq__(self, other):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -95,9 +95,6 @@ class WoodworkTableAccessor:
         if validate:
             _validate_accessor_params(self._dataframe, index, make_index, time_index, logical_types, schema)
 
-        # --> Set the made_index value here
-        self.make_index = make_index
-
         if schema is not None:
             self._schema = schema
             extra_params = []
@@ -148,12 +145,13 @@ class WoodworkTableAccessor:
             if self._schema.time_index is not None:
                 self._sort_columns(already_sorted)
 
+        self.make_index = make_index
+
     def __eq__(self, other):
-        if self._schema != other.ww._schema:
+        if self.make_index != other.ww.make_index:
             return False
 
-        # --> make sure to thest this in equality test
-        if self.make_index != other.ww.make_index:
+        if self._schema != other.ww._schema:
             return False
 
         # Only check pandas DataFrames for equality

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -358,6 +358,19 @@ def test_accessor_equality(sample_df):
         assert schema_df.ww == iloc_df
 
 
+def test_accessor_equality_make_index(sample_df_pandas):
+    made_index_df = sample_df_pandas.copy()
+    made_index_df.insert(0, 'new_index', range(len(made_index_df)))
+    made_index_df.ww.init(index='new_index', make_index=False)
+
+    schema_df = sample_df_pandas.copy()
+    schema_df.ww.init(index='new_index', make_index=True)
+
+    pd.testing.assert_frame_equal(schema_df, made_index_df)
+
+    assert made_index_df.ww != schema_df
+
+
 def test_accessor_init_with_valid_string_time_index(time_index_df):
     time_index_df.ww.init(name='schema',
                           index='id',
@@ -813,7 +826,7 @@ def test_make_index(sample_df):
         schema_df = sample_df.copy()
         schema_df.ww.init(index='new_index', make_index=True)
 
-        assert schema_df.ww.made_index is True
+        assert schema_df.ww.make_index is True
 
         assert schema_df.ww.index == 'new_index'
         assert 'new_index' in schema_df.ww.columns
@@ -823,15 +836,15 @@ def test_make_index(sample_df):
         assert 'index' in schema_df.ww.columns['new_index']['semantic_tags']
 
         copied_df = schema_df.ww.copy()
-        assert copied_df.ww.made_index is True  # --> not sure the best way to store this across dfs
+        assert copied_df.ww.make_index is True  # --> not sure the best way to store this across dfs
 
         own_index_df = sample_df.copy()
         own_index_df.ww.init(index='id')
 
-        assert own_index_df.ww.made_index is False
+        assert own_index_df.ww.make_index is False
 
         copied_df = own_index_df.ww.copy()
-        assert copied_df.ww.made_index is False
+        assert copied_df.ww.make_index is False
 
 
 def test_underlying_index_set_no_index_on_init(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -836,7 +836,7 @@ def test_make_index(sample_df):
         assert 'index' in schema_df.ww.columns['new_index']['semantic_tags']
 
         copied_df = schema_df.ww.copy()
-        assert copied_df.ww.make_index is True  # --> not sure the best way to store this across dfs
+        assert copied_df.ww.make_index is True
 
         own_index_df = sample_df.copy()
         own_index_df.ww.init(index='id')

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -813,12 +813,25 @@ def test_make_index(sample_df):
         schema_df = sample_df.copy()
         schema_df.ww.init(index='new_index', make_index=True)
 
+        assert schema_df.ww.made_index is True
+
         assert schema_df.ww.index == 'new_index'
         assert 'new_index' in schema_df.ww.columns
         assert 'new_index' in schema_df.ww.columns
         assert to_pandas(schema_df)['new_index'].unique
         assert to_pandas(schema_df['new_index']).is_monotonic
         assert 'index' in schema_df.ww.columns['new_index']['semantic_tags']
+
+        copied_df = schema_df.ww.copy()
+        assert copied_df.ww.made_index is True  # --> not sure the best way to store this across dfs
+
+        own_index_df = sample_df.copy()
+        own_index_df.ww.init(index='id')
+
+        assert own_index_df.ww.made_index is False
+
+        copied_df = own_index_df.ww.copy()
+        assert copied_df.ww.made_index is False
 
 
 def test_underlying_index_set_no_index_on_init(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -368,7 +368,7 @@ def test_accessor_equality_make_index(sample_df_pandas):
 
     pd.testing.assert_frame_equal(schema_df, made_index_df)
 
-    assert made_index_df.ww != schema_df
+    assert made_index_df.ww != schema_df.ww
 
 
 def test_accessor_init_with_valid_string_time_index(time_index_df):


### PR DESCRIPTION
- adds a `WoodworkTableAccessor.make_index` attribute
- Also includes the `make_index` value in the equality check
- Closes #744 