### PR TITLE
Set _get_column_dict parameter use_standard_types to False by default

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,7 @@ Release Notes
         * Update minimum scikit-learn version to 0.22 (:pr:`763`)
         * Drop support for Python version 3.6 (:pr:`768`)
         * Remove ``ColumnNameMismatchWarning`` (:pr:`777`)
+        * ``get_column_dict`` does not use standard tags by default (:pr:`782`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
     * Testing Changes

--- a/woodwork/schema.py
+++ b/woodwork/schema.py
@@ -51,7 +51,7 @@ class Schema(object):
             column_metadata (dict[str -> dict[str -> json serializable]], optional): Dictionary mapping column names
                 to that column's metadata dictionary.
             use_standard_tags (bool, optional): If True, will add standard semantic tags to columns based
-                specified logical type for the column. Defaults to True.
+                on the specified logical type for the column. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             validate (bool, optional): Whether parameter validation should occur. Defaults to True. Warning:
                 Should be set to False only when parameters and data are known to be valid.

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -23,7 +23,7 @@ def _get_column_dict(name,
         logical_type (str, LogicalType): The column's LogicalType.
         semantic_tags (str, list, set, optional): The semantic tag(s) specified for the column.
         use_standard_tags (boolean, optional): If True, will add standard semantic tags to the column based
-                specified logical type. Defaults to True.
+                on the specified logical type. Defaults to False.
         description (str, optional): User description of the column.
         metadata (dict[str -> json serializable], optional): Extra metadata provided by the user.
         validate (bool, optional): Whether to perform parameter validation. Defaults to True.

--- a/woodwork/schema_column.py
+++ b/woodwork/schema_column.py
@@ -13,7 +13,7 @@ from woodwork.utils import _convert_input_to_set
 def _get_column_dict(name,
                      logical_type,
                      semantic_tags=None,
-                     use_standard_tags=True,
+                     use_standard_tags=False,
                      description=None,
                      metadata=None,
                      validate=True):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -82,7 +82,7 @@ class WoodworkTableAccessor:
             column_metadata (dict[str -> dict[str -> json serializable]], optional): Dictionary mapping column names
                 to that column's metadata dictionary.
             use_standard_tags (bool, optional): If True, will add standard semantic tags to columns based
-                specified logical type for the column. Defaults to True.
+                on the specified logical type for the column. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             schema (Woodwork.Schema, optional): Typing information to use for the DataFrame instead of performing inference.
                 Any other arguments provided will be ignored. Note that any changes made to the schema object after

--- a/woodwork/tests/schema/test_schema_column.py
+++ b/woodwork/tests/schema/test_schema_column.py
@@ -90,16 +90,16 @@ def test_get_column_dict():
     assert set(column.keys()) == {'logical_type', 'semantic_tags', 'description', 'metadata'}
 
     assert column.get('logical_type') == Integer
-    assert column.get('semantic_tags') == {'numeric', 'test_tag'}
+    assert column.get('semantic_tags') == {'test_tag'}
 
     assert column.get('description') is None
     assert column.get('metadata') == {}
 
 
 def test_get_column_dict_standard_tags():
-    column = _get_column_dict('column', Integer, use_standard_tags=False)
+    column = _get_column_dict('column', Integer, use_standard_tags=True)
 
-    assert column.get('semantic_tags') == set()
+    assert column.get('semantic_tags') == {'numeric'}
 
 
 def test_get_column_dict_params():


### PR DESCRIPTION
Fixes #776 

`_get_column_dict` will have `use_standard_types=False` by default
`WoodworkColumnAccessor.__init__` will still have `use_standard_types=True` by default

swap two test cases based on this change 