### PR TITLE
Add exclude parameter to select method

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
 
     * Enhancements
         * Add validation control to WoodworkTableAccessor (:pr:`736`)
+        * Add optional ``exclude`` parameter to WoodworkTableAccessor ``select`` method (:pr:`783`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -393,25 +393,34 @@ class WoodworkTableAccessor:
             if updated_series is not series:
                 self._dataframe[col_name] = updated_series
 
-    def select(self, include):
+    def select(self, include=None, exclude=None):
         """Create a DataFrame with Woodwork typing information initialized
-        that includes only columns whose Logical Type and semantic tags are
-        specified in the list of types and tags to include.
+        that includes only columns whose Logical Type and semantic tags match
+        conditions specified in the list of types and tags to include or exclude.
+        Values for both ``include`` and ``exclude`` cannot be provided in a
+        single call.
 
         If no matching columns are found, an empty DataFrame will be returned.
 
         Args:
             include (str or LogicalType or list[str or LogicalType]): Logical
                 types, semantic tags to include in the DataFrame.
+            exclude (str or LogicalType or list[str or LogicalType]): Logical
+                types, semantic tags to exclude from the DataFrame.
 
         Returns:
-            DataFrame: The subset of the original DataFrame that contains just the
-            logical types and semantic tags in ``include``. Has Woodwork typing
-            information initialized.
+            DataFrame: The subset of the original DataFrame that matches the
+            conditions specified by ``include`` or ``exclude``. Has Woodwork
+            typing information initialized.
         """
         if self._schema is None:
             _raise_init_error()
-        cols_to_include = self._schema._filter_cols(include)
+        if include is not None and exclude is not None:
+            raise ValueError("Cannot specify values for both 'include' and 'exclude' in a single call.")
+        if include is None and exclude is None:
+            raise ValueError("Must specify values for either 'include' or 'exclude'.")
+
+        cols_to_include = self._schema._filter_cols(include, exclude)
         return self._get_subset_df_with_schema(cols_to_include)
 
     def add_semantic_tags(self, semantic_tags):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1334,8 +1334,9 @@ def test_select_ltypes_no_match_and_all(sample_df):
     assert len(schema_df.ww.select(['PostalCode', PhoneNumber]).columns) == 1
 
     all_types = ww.type_system.registered_types
-    df_all_types = schema_df.ww.select(all_types)
+    assert len(schema_df.ww.select(exclude=all_types).columns) == 0
 
+    df_all_types = schema_df.ww.select(all_types)
     pd.testing.assert_frame_equal(to_pandas(df_all_types), to_pandas(schema_df))
     assert df_all_types.ww.schema == schema_df.ww.schema
 
@@ -1388,6 +1389,22 @@ def test_select_ltypes_mixed(sample_df):
     df_mixed_ltypes = schema_df.ww.select(['PersonFullName', 'email_address', Double])
     assert len(df_mixed_ltypes.columns) == 3
     assert 'phone_number' not in df_mixed_ltypes.columns
+
+
+def test_select_ltypes_mixed_exclude(sample_df):
+    schema_df = sample_df.copy()
+    schema_df.ww.init(logical_types={'full_name': PersonFullName,
+                                     'email': EmailAddress,
+                                     'phone_number': PhoneNumber,
+                                     'age': Double,
+                                     'signup_date': Datetime,
+                                     })
+
+    df_mixed_ltypes = schema_df.ww.select(exclude=['PersonFullName', 'email_address', Double])
+    assert len(df_mixed_ltypes.columns) == 4
+    assert 'full_name' not in df_mixed_ltypes.columns
+    assert 'email_address' not in df_mixed_ltypes.columns
+    assert 'age' not in df_mixed_ltypes.columns
 
 
 def test_select_ltypes_table(sample_df):
@@ -1457,6 +1474,47 @@ def test_select_semantic_tags(sample_df):
     assert 'id' in df_common_tags.columns
     assert 'is_registered' in df_common_tags.columns
     assert 'age' in df_common_tags.columns
+
+
+def test_select_semantic_tags_exclude(sample_df):
+    schema_df = sample_df.copy()
+    schema_df.ww.init(semantic_tags={'full_name': 'tag1',
+                                     'email': ['tag2'],
+                                     'age': ['numeric', 'tag2'],
+                                     'phone_number': ['tag3', 'tag2'],
+                                     'is_registered': 'category',
+                                     },
+                      time_index='signup_date')
+
+    df_one_match = schema_df.ww.select(exclude='numeric')
+    assert len(df_one_match.columns) == 5
+    assert 'age' not in df_one_match.columns
+    assert 'id' not in df_one_match.columns
+
+    df_multiple_matches = schema_df.ww.select(exclude='tag2')
+    assert len(df_multiple_matches.columns) == 4
+    assert 'age' not in df_multiple_matches.columns
+    assert 'phone_number' not in df_multiple_matches.columns
+    assert 'email' not in df_multiple_matches.columns
+
+    df_multiple_tags = schema_df.ww.select(exclude=['numeric', 'time_index'])
+    assert len(df_multiple_tags.columns) == 4
+    assert 'id' not in df_multiple_tags.columns
+    assert 'age' not in df_multiple_tags.columns
+    assert 'signup_date' not in df_multiple_tags.columns
+
+    df_overlapping_tags = schema_df.ww.select(exclude=['numeric', 'tag2'])
+    assert len(df_overlapping_tags.columns) == 3
+    assert 'id' not in df_overlapping_tags.columns
+    assert 'age' not in df_overlapping_tags.columns
+    assert 'phone_number' not in df_overlapping_tags.columns
+    assert 'email' not in df_overlapping_tags.columns
+
+    df_common_tags = schema_df.ww.select(exclude=['category', 'numeric'])
+    assert len(df_common_tags.columns) == 4
+    assert 'id' not in df_common_tags.columns
+    assert 'is_registered' not in df_common_tags.columns
+    assert 'age' not in df_common_tags.columns
 
 
 def test_select_single_inputs(sample_df):
@@ -1605,6 +1663,23 @@ def test_select_instantiated_ltype():
     err_msg = "Invalid selector used in include: Datetime cannot be instantiated"
     with pytest.raises(TypeError, match=err_msg):
         df.ww.select(ymd_format)
+
+
+def test_select_include_and_exclude_error(sample_df):
+    sample_df.ww.init()
+    err_msg = "Cannot specify values for both 'include' and 'exclude' in a single call."
+    with pytest.raises(ValueError, match=err_msg):
+        sample_df.ww.select(include='Integer', exclude='Double')
+
+    with pytest.raises(ValueError, match=err_msg):
+        sample_df.ww.select(include=[], exclude=[])
+
+
+def test_select_no_selectors_error(sample_df):
+    sample_df.ww.init()
+    err_msg = "Must specify values for either 'include' or 'exclude'."
+    with pytest.raises(ValueError, match=err_msg):
+        sample_df.ww.select()
 
 
 def test_accessor_set_index(sample_df):

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -253,8 +253,14 @@ def test_filter_schema_cols_no_matches(sample_column_names, sample_inferred_logi
     filter_non_string = schema._filter_cols(include=1)
     assert filter_non_string == []
 
-    filter_exclude_all = schema._filter_cols(exclude=list(sample_inferred_logical_types.values()))
-    assert filter_exclude_all == []
+    filter_exclude_no_matches = schema._filter_cols(exclude='nothing')
+    assert set(filter_exclude_no_matches) == set(sample_column_names)
+
+    filter_exclude_empty_list = schema._filter_cols(exclude=[])
+    assert set(filter_exclude_empty_list) == set(sample_column_names)
+
+    filter_exclude_non_string = schema._filter_cols(exclude=1)
+    assert set(filter_exclude_non_string) == set(sample_column_names)
 
 
 def test_filter_schema_errors(sample_column_names, sample_inferred_logical_types):

--- a/woodwork/tests/schema/test_schema.py
+++ b/woodwork/tests/schema/test_schema.py
@@ -184,7 +184,7 @@ def test_schema_column_metadata(sample_column_names, sample_inferred_logical_typ
     assert schema.columns['id']['metadata'] == column_metadata
 
 
-def test_filter_schema_cols(sample_column_names, sample_inferred_logical_types):
+def test_filter_schema_cols_include(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types,
                     time_index='signup_date',
                     index='id',
@@ -211,6 +211,33 @@ def test_filter_schema_cols(sample_column_names, sample_inferred_logical_types):
         assert col in expected
 
 
+def test_filter_schema_cols_exclude(sample_column_names, sample_inferred_logical_types):
+    schema = Schema(sample_column_names, sample_inferred_logical_types,
+                    time_index='signup_date',
+                    index='id',
+                    name='df_name')
+
+    filtered = schema._filter_cols(exclude=Datetime)
+    assert 'signup_date' not in filtered
+
+    filtered = schema._filter_cols(exclude='email', col_names=True)
+    assert 'email' not in filtered
+
+    filtered_log_type_string = schema._filter_cols(exclude='NaturalLanguage')
+    filtered_log_type = schema._filter_cols(exclude=NaturalLanguage)
+    expected = {'id', 'age', 'signup_date', 'is_registered'}
+    assert filtered_log_type == filtered_log_type_string
+    assert set(filtered_log_type) == expected
+
+    filtered_semantic_tag = schema._filter_cols(exclude='numeric')
+    assert 'age' not in filtered_semantic_tag
+
+    filtered_multiple_overlap = schema._filter_cols(exclude=['NaturalLanguage', 'email'], col_names=True)
+    expected = ['id', 'age', 'signup_date', 'is_registered']
+    for col in filtered_multiple_overlap:
+        assert col in expected
+
+
 def test_filter_schema_cols_no_matches(sample_column_names, sample_inferred_logical_types):
     schema = Schema(sample_column_names, sample_inferred_logical_types,
                     time_index='signup_date',
@@ -225,6 +252,9 @@ def test_filter_schema_cols_no_matches(sample_column_names, sample_inferred_logi
 
     filter_non_string = schema._filter_cols(include=1)
     assert filter_non_string == []
+
+    filter_exclude_all = schema._filter_cols(exclude=list(sample_inferred_logical_types.values()))
+    assert filter_exclude_all == []
 
 
 def test_filter_schema_errors(sample_column_names, sample_inferred_logical_types):


### PR DESCRIPTION
- Add exclude parameter to WoodworkTableAccessor select method
- Closes #465 

Adds the ability to specify column types/tags to exclude when calling `df.ww.select`. Adds checks that one, but not both, of `include` and `exclude` is specified. Updated terminology in `select` to align with both options sharing much of the same code.

Note: Because of the large amount of shared code when using `include` or `exclude` some of the tests for `include` were not replicated for `exclude`. 