### PR TITLE
Add deserialization validation control

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Add validation control to WoodworkTableAccessor (:pr:`736`)
         * Store ``make_index`` value on WoodworkTableAccessor (:pr:`780`)
         * Add optional ``exclude`` parameter to WoodworkTableAccessor ``select`` method (:pr:`783`)
+        * Add validation control to ``deserialize.read_woodwork_table`` and ``ww.read_csv`` (:pr:`788`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -136,7 +136,8 @@ def read_woodwork_table(path, profile_name=None, validate=False, **kwargs):
             profile_name (str, bool): The AWS profile specified to write to S3. Will default to None and search for AWS credentials.
                 Set to False to use an anonymous profile.
             validate (bool, optional): Whether parameter and data validation should occur when initializing Woodwork dataframe
-                during deserialization. Defaults to False.
+                during deserialization. Defaults to False. Note: If serialized data was modified outside of Woodwork and you
+                are unsure of the validity of the data or typing information, `validate` should be set to True.
             kwargs (keywords): Additional keyword arguments to pass as keyword arguments to the underlying deserialization method.
 
         Returns:

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -33,11 +33,12 @@ def read_table_typing_information(path):
     return typing_info
 
 
-def _typing_information_to_woodwork_table(table_typing_info, **kwargs):
+def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs):
     """Deserialize Woodwork table from table description.
 
     Args:
         table_typing_info (dict) : Woodwork typing information. Likely generated using :meth:`.serialize.typing_info_to_dict`
+        validate (bool): Whether parameter and data validation should occur during table initialization
         kwargs (keywords): Additional keyword arguments to pass as keywords arguments to the underlying deserialization method.
 
     Returns:
@@ -121,18 +122,21 @@ def _typing_information_to_woodwork_table(table_typing_info, **kwargs):
         use_standard_tags=table_typing_info.get('use_standard_tags'),
         table_metadata=table_typing_info.get('table_metadata'),
         column_metadata=column_metadata,
-        column_descriptions=column_descriptions)
+        column_descriptions=column_descriptions,
+        validate=validate)
 
     return dataframe
 
 
-def read_woodwork_table(path, profile_name=None, **kwargs):
+def read_woodwork_table(path, profile_name=None, validate=False, **kwargs):
     """Read Woodwork table from disk, S3 path, or URL.
 
         Args:
             path (str): Directory on disk, S3 path, or URL to read `woodwork_typing_info.json`.
             profile_name (str, bool): The AWS profile specified to write to S3. Will default to None and search for AWS credentials.
                 Set to False to use an anonymous profile.
+            validate (bool, optional): Whether parameter and data validation should occur when initializing Woodwork dataframe
+                during deserialization. Defaults to False.
             kwargs (keywords): Additional keyword arguments to pass as keyword arguments to the underlying deserialization method.
 
         Returns:
@@ -152,10 +156,10 @@ def read_woodwork_table(path, profile_name=None, **kwargs):
                 tar.extractall(path=tmpdir)
 
             table_typing_info = read_table_typing_information(tmpdir)
-            return _typing_information_to_woodwork_table(table_typing_info, **kwargs)
+            return _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
     else:
         table_typing_info = read_table_typing_information(path)
-        return _typing_information_to_woodwork_table(table_typing_info, **kwargs)
+        return _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
 
 
 def _check_schema_version(saved_version_str):

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -4,6 +4,7 @@ import os
 import boto3
 import pandas as pd
 import pytest
+from mock import patch
 
 import woodwork.deserialize as deserialize
 import woodwork.serialize as serialize
@@ -452,6 +453,15 @@ def test_deserialize_s3_csv(sample_df_pandas):
 
     pd.testing.assert_frame_equal(to_pandas(sample_df_pandas, index=sample_df_pandas.ww.index), to_pandas(deserialized_df, index=deserialized_df.ww.index))
     assert sample_df_pandas.ww.schema == deserialized_df.ww.schema
+
+
+@patch("woodwork.table_accessor._validate_accessor_params")
+def test_deserialize_validation_control(mock_validate_accessor_params):
+    assert not mock_validate_accessor_params.called
+    deserialize.read_woodwork_table(URL)
+    assert not mock_validate_accessor_params.called
+    deserialize.read_woodwork_table(URL, validate=True)
+    assert mock_validate_accessor_params.called
 
 
 def test_check_later_schema_version():

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -213,6 +213,18 @@ def test_read_csv_with_pandas_params(sample_df_pandas, tmpdir):
     pd.testing.assert_frame_equal(df_from_csv, schema_df.head(nrows))
 
 
+@patch("woodwork.table_accessor._validate_accessor_params")
+def test_read_csv_validation_control(mock_validate_accessor_params, sample_df_pandas, tmpdir):
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    sample_df_pandas.to_csv(filepath, index=False)
+
+    assert not mock_validate_accessor_params.called
+    ww.read_csv(filepath=filepath, validate=False)
+    assert not mock_validate_accessor_params.called
+    ww.read_csv(filepath=filepath)
+    assert mock_validate_accessor_params.called
+
+
 def test_is_numeric_datetime_series(time_index_df):
     assert _is_numeric_series(time_index_df['ints'], None)
     assert _is_numeric_series(time_index_df['ints'], Double)

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -66,6 +66,7 @@ def read_csv(filepath=None,
              semantic_tags=None,
              logical_types=None,
              use_standard_tags=True,
+             validate=True,
              **kwargs):
     """Read data from the specified CSV file and return a DataFrame with initialized Woodwork typing information.
 
@@ -88,6 +89,9 @@ def read_csv(filepath=None,
             for any columns not present in the dictionary.
         use_standard_tags (bool, optional): If True, will add standard semantic tags to columns based
             on the inferred or specified logical type for the column. Defaults to True.
+        validate (bool, optional): Whether parameter and data validation should occur. Defaults to True. Warning:
+                Should be set to False only when parameters and data are known to be valid.
+                Any errors resulting from skipping validation with invalid inputs may not be easily understood.
         **kwargs: Additional keyword arguments to pass to the underlying ``pandas.read_csv`` function. For more
             information on available keywords refer to the pandas documentation.
 
@@ -100,7 +104,8 @@ def read_csv(filepath=None,
                       time_index=time_index,
                       semantic_tags=semantic_tags,
                       logical_types=logical_types,
-                      use_standard_tags=use_standard_tags)
+                      use_standard_tags=use_standard_tags,
+                      validate=validate)
     return dataframe
 
 


### PR DESCRIPTION
- Add deserialization validation control
- Closes #739 

Adds validation control to `deserialize.read_woodwork_table`, which defaults to `False`. Also adds validation control to `ww.read_csv` which defaults to True.