### PR TITLE
Add ColumnSchema object to Woodwork

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -22,6 +22,7 @@ Release Notes
         * ``get_column_dict`` does not use standard tags by default (:pr:`782`)
         * Make ``logical_type`` and ``name`` params to ``_get_column_dict`` optional (:pr:`786`)
         * Rename Schema object and files to match new table-column schema structure (:pr:`789`)
+        * Store column typing information in a ``ColumnSchema`` object instead of a dictionary (:pr:`791`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -36,6 +36,8 @@ Release Notes
     * The ``ZIPCode`` logical type has been renamed to ``PostalCode``
     * The ``FullName`` logical type has been renamed to ``PersonFullName``
     * The ``Schema`` object has been renamed to ``TableSchema``
+    * With the ``ColumnSchema`` object, typing information for a column can no longer be accessed
+      with ``df.ww.columns[col_name]['logical_type']``. Instead use ``df.ww.columns[col_name].logical_type``.
 
 **v0.1.0 March 22, 2021**
     * Enhancements

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -63,6 +63,7 @@ class WoodworkColumnAccessor:
                                     description=description,
                                     metadata=metadata)
 
+    # --> should be on ColumnSchema object???
     @property
     def description(self):
         """The description of the series"""
@@ -137,6 +138,7 @@ class WoodworkColumnAccessor:
             _raise_init_error()
         return self._schema.logical_type
 
+    # --> should be on column schema object??
     @property
     def metadata(self):
         """The metadata of the series"""

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -55,8 +55,7 @@ class WoodworkColumnAccessor:
         self._validate_logical_type(logical_type)
         self.use_standard_tags = use_standard_tags
 
-        self._schema = ColumnSchema(name=self._series.name,
-                                    logical_type=logical_type,
+        self._schema = ColumnSchema(logical_type=logical_type,
                                     semantic_tags=semantic_tags,
                                     use_standard_tags=self.use_standard_tags,
                                     description=description,

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -55,7 +55,6 @@ class WoodworkColumnAccessor:
         self._validate_logical_type(logical_type)
         self.use_standard_tags = use_standard_tags
 
-# --> add a schema property below this that returns a copy of the schema
         self._schema = ColumnSchema(name=self._series.name,
                                     logical_type=logical_type,
                                     semantic_tags=semantic_tags,
@@ -63,7 +62,6 @@ class WoodworkColumnAccessor:
                                     description=description,
                                     metadata=metadata)
 
-    # --> should be on ColumnSchema object???
     @property
     def description(self):
         """The description of the series"""
@@ -138,7 +136,6 @@ class WoodworkColumnAccessor:
             _raise_init_error()
         return self._schema.logical_type
 
-    # --> should be on column schema object??
     @property
     def metadata(self):
         """The metadata of the series"""
@@ -201,7 +198,6 @@ class WoodworkColumnAccessor:
                 if _is_series(result):
                     valid_dtype = _get_valid_dtype(type(result), self._schema.logical_type)
                     if str(result.dtype) == valid_dtype:
-                        # --> add a way of initializing with a schema??
                         result.ww.init(logical_type=self._schema.logical_type,
                                        semantic_tags=copy.deepcopy(self._schema.semantic_tags),
                                        description=self._schema.description,

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -5,8 +5,8 @@ import pandas as pd
 
 from woodwork.accessor_utils import _get_valid_dtype, _is_series, init_series
 from woodwork.column_schema import (
+    ColumnSchema,
     _add_semantic_tags,
-    _get_column_dict,
     _remove_semantic_tags,
     _reset_semantic_tags,
     _set_semantic_tags,
@@ -55,26 +55,27 @@ class WoodworkColumnAccessor:
         self._validate_logical_type(logical_type)
         self.use_standard_tags = use_standard_tags
 
-        self._schema = _get_column_dict(name=self._series.name,
-                                        logical_type=logical_type,
-                                        semantic_tags=semantic_tags,
-                                        use_standard_tags=self.use_standard_tags,
-                                        description=description,
-                                        metadata=metadata)
+# --> add a schema property below this that returns a copy of the schema
+        self._schema = ColumnSchema(name=self._series.name,
+                                    logical_type=logical_type,
+                                    semantic_tags=semantic_tags,
+                                    use_standard_tags=self.use_standard_tags,
+                                    description=description,
+                                    metadata=metadata)
 
     @property
     def description(self):
         """The description of the series"""
         if self._schema is None:
             _raise_init_error()
-        return self._schema['description']
+        return self._schema.description
 
     @description.setter
     def description(self, description):
         if self._schema is None:
             _raise_init_error()
         _validate_description(description)
-        self._schema['description'] = description
+        self._schema.description = description
 
     @property
     def iloc(self):
@@ -134,28 +135,28 @@ class WoodworkColumnAccessor:
         """The logical type of the series"""
         if self._schema is None:
             _raise_init_error()
-        return self._schema['logical_type']
+        return self._schema.logical_type
 
     @property
     def metadata(self):
         """The metadata of the series"""
         if self._schema is None:
             _raise_init_error()
-        return self._schema['metadata']
+        return self._schema.metadata
 
     @metadata.setter
     def metadata(self, metadata):
         if self._schema is None:
             _raise_init_error()
         _validate_metadata(metadata)
-        self._schema['metadata'] = metadata
+        self._schema.metadata = metadata
 
     @property
     def semantic_tags(self):
         """The semantic tags assigned to the series"""
         if self._schema is None:
             _raise_init_error()
-        return self._schema['semantic_tags']
+        return self._schema.semantic_tags
 
     def __eq__(self, other):
         if self._schema != other._schema:
@@ -196,10 +197,14 @@ class WoodworkColumnAccessor:
 
                 # Try to initialize Woodwork with the existing schema
                 if _is_series(result):
-                    valid_dtype = _get_valid_dtype(type(result), self._schema['logical_type'])
+                    valid_dtype = _get_valid_dtype(type(result), self._schema.logical_type)
                     if str(result.dtype) == valid_dtype:
-                        schema = copy.deepcopy(self._schema)
-                        result.ww.init(**schema, use_standard_tags=self.use_standard_tags)
+                        # --> add a way of initializing with a schema??
+                        result.ww.init(logical_type=self._schema.logical_type,
+                                       semantic_tags=copy.deepcopy(self._schema.semantic_tags),
+                                       description=self._schema.description,
+                                       metadata=copy.deepcopy(self._schema.metadata),
+                                       use_standard_tags=self.use_standard_tags)
                     else:
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \
                             f'{valid_dtype}, and returned dtype, {result.dtype}'
@@ -239,9 +244,9 @@ class WoodworkColumnAccessor:
         """
         if self._schema is None:
             _raise_init_error()
-        self._schema['semantic_tags'] = _add_semantic_tags(semantic_tags,
-                                                           self.semantic_tags,
-                                                           self._series.name)
+        self._schema.semantic_tags = _add_semantic_tags(semantic_tags,
+                                                        self.semantic_tags,
+                                                        self._series.name)
 
     def remove_semantic_tags(self, semantic_tags):
         """Removes specified semantic tags from the current tags.
@@ -251,11 +256,11 @@ class WoodworkColumnAccessor:
         """
         if self._schema is None:
             _raise_init_error()
-        self._schema['semantic_tags'] = _remove_semantic_tags(semantic_tags,
-                                                              self.semantic_tags,
-                                                              self._series.name,
-                                                              self.logical_type.standard_tags,
-                                                              self.use_standard_tags)
+        self._schema.semantic_tags = _remove_semantic_tags(semantic_tags,
+                                                           self.semantic_tags,
+                                                           self._series.name,
+                                                           self.logical_type.standard_tags,
+                                                           self.use_standard_tags)
 
     def reset_semantic_tags(self):
         """Reset the semantic tags to the default values. The default values
@@ -267,8 +272,8 @@ class WoodworkColumnAccessor:
         """
         if self._schema is None:
             _raise_init_error()
-        self._schema['semantic_tags'] = _reset_semantic_tags(self.logical_type.standard_tags,
-                                                             self.use_standard_tags)
+        self._schema.semantic_tags = _reset_semantic_tags(self.logical_type.standard_tags,
+                                                          self.use_standard_tags)
 
     def set_logical_type(self, logical_type):
         """Update the logical type for the series, clearing any previously set semantic tags,
@@ -303,9 +308,9 @@ class WoodworkColumnAccessor:
         """
         if self._schema is None:
             _raise_init_error()
-        self._schema['semantic_tags'] = _set_semantic_tags(semantic_tags,
-                                                           self.logical_type.standard_tags,
-                                                           self.use_standard_tags)
+        self._schema.semantic_tags = _set_semantic_tags(semantic_tags,
+                                                        self.logical_type.standard_tags,
+                                                        self.use_standard_tags)
 
 
 def _raise_init_error():

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -15,7 +15,7 @@ class ColumnSchema(object):
                  name=None,
                  logical_type=None,
                  semantic_tags=None,
-                 use_standard_tags=False,  # --> should this be stored?? - if it is we need to include in equality
+                 use_standard_tags=False,
                  description=None,
                  metadata=None,
                  validate=True):
@@ -43,7 +43,6 @@ class ColumnSchema(object):
         self.description = description
         self.logical_type = logical_type
 
-        # --> make a method and use self.locial_type inside
         semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate)
         self.semantic_tags = semantic_tags
 
@@ -58,8 +57,6 @@ class ColumnSchema(object):
             return False
 
         return True
-
-# --> probably will need a way to copy the object deeply for the accessors!
 
 
 def _validate_logical_type(logical_type):

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -10,6 +10,7 @@ from woodwork.type_sys.utils import _get_ltype_class
 from woodwork.utils import _convert_input_to_set
 
 
+# --> just keeping this so tests run - remove when we've removed all uses of _get_column_dict
 def _get_column_dict(name=None,
                      logical_type=None,
                      semantic_tags=None,
@@ -17,33 +18,59 @@ def _get_column_dict(name=None,
                      description=None,
                      metadata=None,
                      validate=True):
-    """Creates a dictionary that contains the typing information for a column schema
-    Args:
-        name (str, optional): The name of the column.
-        logical_type (str, LogicalType, optional): The column's LogicalType.
-        semantic_tags (str, list, set, optional): The semantic tag(s) specified for the column.
-        use_standard_tags (boolean, optional): If True, will add standard semantic tags to the column based
-                on the specified logical type if a logical type is defined for the column. Defaults to False.
-        description (str, optional): User description of the column.
-        metadata (dict[str -> json serializable], optional): Extra metadata provided by the user.
-        validate (bool, optional): Whether to perform parameter validation. Defaults to True.
-    """
-    if metadata is None:
-        metadata = {}
-    if validate:
-        if logical_type is not None:
-            _validate_logical_type(logical_type)
-        _validate_description(description)
-        _validate_metadata(metadata)
+    pass
 
-    semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate)
 
-    return {
-        'logical_type': logical_type,
-        'semantic_tags': semantic_tags,
-        'description': description,
-        'metadata': metadata
-    }
+class ColumnSchema(object):
+    def __init__(self,
+                 name=None,
+                 logical_type=None,
+                 semantic_tags=None,
+                 use_standard_tags=False,  # --> should this be stored?? - if it is we need to include in equality
+                 description=None,
+                 metadata=None,
+                 validate=True):
+        """Create ColumnSchema
+
+        Args:
+            name (str, optional): The name of the column.
+            logical_type (str, LogicalType, optional): The column's LogicalType.
+            semantic_tags (str, list, set, optional): The semantic tag(s) specified for the column.
+            use_standard_tags (boolean, optional): If True, will add standard semantic tags to the column based
+                    on the specified logical type if a logical type is defined for the column. Defaults to False.
+            description (str, optional): User description of the column.
+            metadata (dict[str -> json serializable], optional): Extra metadata provided by the user.
+            validate (bool, optional): Whether to perform parameter validation. Defaults to True.
+        """
+        if metadata is None:
+            metadata = {}
+        self.metadata = metadata
+
+        if validate:
+            if logical_type is not None:
+                _validate_logical_type(logical_type)
+            _validate_description(description)
+            _validate_metadata(metadata)
+        self.description = description
+        self.logical_type = logical_type
+
+        # --> make a method and use self.locial_type inside
+        semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate)
+        self.semantic_tags = semantic_tags
+
+    def __eq__(self, other):
+        if self.logical_type != other.logical_type:
+            return False
+        if self.semantic_tags != other.semantic_tags:
+            return False
+        if self.description != other.description:
+            return False
+        if self.metadata != other.metadata:
+            return False
+
+        return True
+
+# --> probably will need a way to copy the object deeply for the accessors!
 
 
 def _validate_logical_type(logical_type):
@@ -81,20 +108,20 @@ def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, valid
     return semantic_tags
 
 
-def _is_col_numeric(col_dict):
-    return 'numeric' in col_dict['logical_type'].standard_tags
+def _is_col_numeric(col):
+    return 'numeric' in col.logical_type.standard_tags
 
 
-def _is_col_categorical(col_dict):
-    return 'category' in col_dict['logical_type'].standard_tags
+def _is_col_categorical(col):
+    return 'category' in col.logical_type.standard_tags
 
 
-def _is_col_datetime(col_dict):
-    return _get_ltype_class(col_dict['logical_type']) == Datetime
+def _is_col_datetime(col):
+    return _get_ltype_class(col.logical_type) == Datetime
 
 
-def _is_col_boolean(col_dict):
-    return _get_ltype_class(col_dict['logical_type']) == Boolean
+def _is_col_boolean(col):
+    return _get_ltype_class(col.logical_type) == Boolean
 
 
 def _add_semantic_tags(new_tags, current_tags, name):

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -10,17 +10,6 @@ from woodwork.type_sys.utils import _get_ltype_class
 from woodwork.utils import _convert_input_to_set
 
 
-# --> just keeping this so tests run - remove when we've removed all uses of _get_column_dict
-def _get_column_dict(name=None,
-                     logical_type=None,
-                     semantic_tags=None,
-                     use_standard_tags=False,
-                     description=None,
-                     metadata=None,
-                     validate=True):
-    pass
-
-
 class ColumnSchema(object):
     def __init__(self,
                  name=None,

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -12,7 +12,6 @@ from woodwork.utils import _convert_input_to_set
 
 class ColumnSchema(object):
     def __init__(self,
-                 name=None,
                  logical_type=None,
                  semantic_tags=None,
                  use_standard_tags=False,
@@ -43,7 +42,7 @@ class ColumnSchema(object):
         self.description = description
         self.logical_type = logical_type
 
-        semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate)
+        semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, validate)
         self.semantic_tags = semantic_tags
 
     def __eq__(self, other):
@@ -78,12 +77,8 @@ def _validate_metadata(column_metadata):
         raise TypeError("Column metadata must be a dictionary")
 
 
-def _get_column_tags(semantic_tags, logical_type, use_standard_tags, name, validate):
-    error_language = f'semantic_tags for {name}'
-    if logical_type is None:
-        error_language = 'semantic_tags'
-
-    semantic_tags = _convert_input_to_set(semantic_tags, error_language=error_language,
+def _get_column_tags(semantic_tags, logical_type, use_standard_tags, validate):
+    semantic_tags = _convert_input_to_set(semantic_tags, error_language='semantic_tags',
                                           validate=validate)
 
     if use_standard_tags:

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -4,9 +4,10 @@ class DuplicateTagsWarning(UserWarning):
 
 
 class StandardTagsChangedWarning(UserWarning):
-    def get_warning_message(self, use_standard_tags, col_name):
+    def get_warning_message(self, use_standard_tags, col_name=None):
         changed = 'added to' if use_standard_tags else 'removed from'
-        return f'Standard tags have been {changed} "{col_name}"'
+        name = ("\"" + col_name + "\"") if col_name is not None else 'your column'
+        return f'Standard tags have been {changed} {name}'
 
 
 class UpgradeSchemaWarning(UserWarning):

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -42,12 +42,16 @@ def _process_selection(selection, original_data):
         elif _is_dataframe(original_data):
             # Selecting a single column from a DataFrame
             schema = original_data.ww.schema.columns[selection.name]
-            schema['semantic_tags'] = schema['semantic_tags'] - {'index'} - {'time_index'}
+            schema.semantic_tags = schema.semantic_tags - {'index'} - {'time_index'}
         else:
             # Selecting a new Series from an existing Series
-            schema = copy.deepcopy(original_data.ww._schema)
+            schema = original_data.ww._schema
         if schema:
-            selection.ww.init(**schema, use_standard_tags=original_data.ww.use_standard_tags)
+            selection.ww.init(logical_type=schema.logical_type,
+                              semantic_tags=copy.deepcopy(schema.semantic_tags),
+                              description=schema.description,
+                              metadata=copy.deepcopy(schema.metadata),
+                              use_standard_tags=original_data.ww.use_standard_tags)
     elif _is_dataframe(selection):
         # Selecting a new DataFrame from an existing DataFrame
         schema = original_data.ww.schema

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -37,15 +37,15 @@ def typing_info_to_dict(dataframe):
         {'name': col_name,
          'ordinal': ordered_columns.get_loc(col_name),
          'logical_type': {
-             'parameters': _get_specified_ltype_params(col['logical_type']),
-             'type': str(_get_ltype_class(col['logical_type']))
+             'parameters': _get_specified_ltype_params(col.logical_type),
+             'type': str(_get_ltype_class(col.logical_type))
          },
          'physical_type': {
              'type': str(dataframe[col_name].dtype)
          },
-         'semantic_tags': sorted(list(col['semantic_tags'])),
-         'description': col['description'],
-         'metadata': col['metadata']
+         'semantic_tags': sorted(list(col.semantic_tags)),
+         'description': col.description,
+         'metadata': col.metadata
          }
         for col_name, col in dataframe.ww.columns.items()
     ]
@@ -168,7 +168,7 @@ def write_dataframe(dataframe, path, format='csv', **kwargs):
         # Latlong columns in pandas and Dask DataFrames contain tuples, which raises
         # an error in parquet format.
         dataframe = dataframe.ww.copy()
-        latlong_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col['logical_type']) == ww.logical_types.LatLong]
+        latlong_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col.logical_type) == ww.logical_types.LatLong]
         dataframe[latlong_columns] = dataframe[latlong_columns].astype(str)
 
         dataframe.to_parquet(file, **kwargs)

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -52,17 +52,17 @@ def _get_describe_dict(dataframe, include=None):
 
         # Any LatLong columns will be using lists, which we must convert
         # back to tuples so we can calculate the mode, which requires hashable values
-        latlong_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col['logical_type']) == LatLong]
+        latlong_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col.logical_type) == LatLong]
         df[latlong_columns] = df[latlong_columns].applymap(lambda latlong: tuple(latlong) if latlong else latlong)
     else:
         df = dataframe
 
     for column_name, column in cols_to_include:
-        if 'index' in column['semantic_tags']:
+        if 'index' in column.semantic_tags:
             continue
         values = {}
-        logical_type = column['logical_type']
-        semantic_tags = column['semantic_tags']
+        logical_type = column.logical_type
+        semantic_tags = column.semantic_tags
         series = df[column_name]
 
         # Calculate Aggregation Stats
@@ -125,7 +125,7 @@ def _replace_nans_for_mutual_info(schema, data):
 
         if _is_col_numeric(column) or _is_col_datetime(column):
             mean = series.mean()
-            if isinstance(mean, float) and not _get_ltype_class(column['logical_type']) == Double:
+            if isinstance(mean, float) and not _get_ltype_class(column.logical_type) == Double:
                 data[column_name] = series.astype('float')
             data[column_name] = series.fillna(mean)
         elif _is_col_categorical(column) or _is_col_boolean(column):
@@ -190,7 +190,7 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None, include_ind
         (perfect dependency).
         """
     valid_types = get_valid_mi_types()
-    valid_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col['logical_type']) in valid_types]
+    valid_columns = [col_name for col_name, col in dataframe.ww.columns.items() if _get_ltype_class(col.logical_type) in valid_types]
 
     if not include_index and dataframe.ww.index is not None:
         valid_columns.remove(dataframe.ww.index)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -192,7 +192,7 @@ class WoodworkTableAccessor:
         series = self._dataframe[key]
         column = self.schema.columns[key]
         column.semantic_tags -= {'index', 'time_index'}
-        # --> need a way to copy a ColumnSchema deeply
+
         series.ww.init(logical_type=column.logical_type,
                        semantic_tags=copy.deepcopy(column.semantic_tags),
                        description=column.description,
@@ -651,7 +651,6 @@ class WoodworkTableAccessor:
 
         # Initialize Woodwork typing info for series
         col_schema = self._schema.columns[column_name]
-        # --> need a way of copying a column schema
         series.ww.init(logical_type=col_schema.logical_type,
                        semantic_tags=copy.deepcopy(col_schema.semantic_tags),
                        description=col_schema.description,

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -215,14 +215,11 @@ class WoodworkTableAccessor:
         if column.ww._schema is None:
             column = init_series(column, use_standard_tags=self.use_standard_tags)
         elif self.use_standard_tags and not column.ww.use_standard_tags:
-            # --> need to update so that we can set like this :/ maybe add a property and a setter??
-            column.ww.semantic_tags |= column.ww.logical_type.standard_tags
+            column.ww.add_semantic_tags(column.ww.logical_type.standard_tags)
             message = StandardTagsChangedWarning().get_warning_message(self.use_standard_tags, col_name)
             warnings.warn(message, StandardTagsChangedWarning)
         elif not self.use_standard_tags and column.ww.use_standard_tags:
-            column.ww.semantic_tags -= column.ww.logical_type.standard_tags
-            message = StandardTagsChangedWarning().get_warning_message(self.use_standard_tags, col_name)
-            warnings.warn(message, StandardTagsChangedWarning)
+            column.ww.remove_semantic_tags(column.ww.logical_type.standard_tags)
 
         self._dataframe[col_name] = column
         self._schema.columns[col_name] = column.ww._schema

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -291,8 +291,7 @@ class TableSchema(object):
             description = (column_descriptions or {}).get(name)
             metadata_for_col = (column_metadata or {}).get(name)
 
-            columns[name] = ColumnSchema(name,
-                                         logical_types.get(name),
+            columns[name] = ColumnSchema(logical_type=logical_types.get(name),
                                          semantic_tags=semantic_tags_for_col,
                                          use_standard_tags=use_standard_tags,
                                          description=description,

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -5,8 +5,8 @@ import pandas as pd
 
 import woodwork as ww
 from woodwork.column_schema import (
+    ColumnSchema,
     _add_semantic_tags,
-    _get_column_dict,
     _remove_semantic_tags,
     _reset_semantic_tags,
     _set_semantic_tags
@@ -115,9 +115,8 @@ class TableSchema(object):
     def _get_typing_info(self):
         """Creates a DataFrame that contains the typing information for a TableSchema."""
         typing_info = {}
-        for col_name, col_dict in self.columns.items():
-
-            types = [col_dict['logical_type'], str(list(col_dict['semantic_tags']))]
+        for col_name, col in self.columns.items():
+            types = [col.logical_type, str(list(col.semantic_tags))]
             typing_info[col_name] = types
 
         columns = ['Logical Type', 'Semantic Tag(s)']
@@ -132,18 +131,18 @@ class TableSchema(object):
     @property
     def logical_types(self):
         """A dictionary containing logical types for each column"""
-        return {col_name: col['logical_type'] for col_name, col in self.columns.items()}
+        return {col_name: col.logical_type for col_name, col in self.columns.items()}
 
     @property
     def semantic_tags(self):
         """A dictionary containing semantic tags for each column"""
-        return {col_name: col['semantic_tags'] for col_name, col in self.columns.items()}
+        return {col_name: col.semantic_tags for col_name, col in self.columns.items()}
 
     @property
     def index(self):
         """The index column for the table"""
         for col_name, column in self.columns.items():
-            if 'index' in column['semantic_tags']:
+            if 'index' in column.semantic_tags:
                 return col_name
         return None
 
@@ -151,7 +150,7 @@ class TableSchema(object):
     def time_index(self):
         """The time index column for the table"""
         for col_name, column in self.columns.items():
-            if 'time_index' in column['semantic_tags']:
+            if 'time_index' in column.semantic_tags:
                 return col_name
         return None
 
@@ -180,7 +179,7 @@ class TableSchema(object):
             # Update Logical Type for the TableSchema, getting new semantic tags
             new_logical_type = logical_types.get(col_name)
             if new_logical_type is not None:
-                self.columns[col_name]['logical_type'] = new_logical_type
+                self.columns[col_name].logical_type = new_logical_type
 
             # Get new semantic tags, removing existing tags
             new_semantic_tags = semantic_tags.get(col_name)
@@ -193,7 +192,7 @@ class TableSchema(object):
                 _validate_not_setting_index_tags(new_semantic_tags, col_name)
 
             # Update the tags for the TableSchema
-            self.columns[col_name]['semantic_tags'] = new_semantic_tags
+            self.columns[col_name].semantic_tags = new_semantic_tags
 
             if retain_index_tags and 'index' in original_tags:
                 self._set_index_tags(col_name)
@@ -213,7 +212,7 @@ class TableSchema(object):
             tags_to_add = _convert_input_to_set(tags_to_add)
             _validate_not_setting_index_tags(tags_to_add, col_name)
             new_semantic_tags = _add_semantic_tags(tags_to_add, self.semantic_tags[col_name], col_name)
-            self.columns[col_name]['semantic_tags'] = new_semantic_tags
+            self.columns[col_name].semantic_tags = new_semantic_tags
 
     def remove_semantic_tags(self, semantic_tags):
         """Remove the semantic tags for any column names in the provided semantic_tags
@@ -240,7 +239,7 @@ class TableSchema(object):
                 standard_tags_removed = tags_to_remove.intersection(standard_tags)
                 standard_tags_to_reinsert = standard_tags.difference(standard_tags_removed)
                 new_semantic_tags = new_semantic_tags.union(standard_tags_to_reinsert)
-            self.columns[col_name]['semantic_tags'] = new_semantic_tags
+            self.columns[col_name].semantic_tags = new_semantic_tags
 
     def reset_semantic_tags(self, columns=None, retain_index_tags=False):
         """Reset the semantic tags for the specified columns to the default values.
@@ -266,7 +265,7 @@ class TableSchema(object):
         for col_name in columns:
             original_tags = self.semantic_tags[col_name]
             new_semantic_tags = _reset_semantic_tags(self.logical_types[col_name].standard_tags, self.use_standard_tags)
-            self.columns[col_name]['semantic_tags'] = new_semantic_tags
+            self.columns[col_name].semantic_tags = new_semantic_tags
 
             if retain_index_tags and 'index' in original_tags:
                 self._set_index_tags(col_name)
@@ -292,13 +291,13 @@ class TableSchema(object):
             description = (column_descriptions or {}).get(name)
             metadata_for_col = (column_metadata or {}).get(name)
 
-            columns[name] = _get_column_dict(name,
-                                             logical_types.get(name),
-                                             semantic_tags=semantic_tags_for_col,
-                                             use_standard_tags=use_standard_tags,
-                                             description=description,
-                                             metadata=metadata_for_col,
-                                             validate=validate)
+            columns[name] = ColumnSchema(name,
+                                         logical_types.get(name),
+                                         semantic_tags=semantic_tags_for_col,
+                                         use_standard_tags=use_standard_tags,
+                                         description=description,
+                                         metadata=metadata_for_col,
+                                         validate=validate)
         return columns
 
     def set_index(self, new_index, validate=True):
@@ -366,16 +365,16 @@ class TableSchema(object):
     def _set_index_tags(self, index):
         """Updates the semantic tags of the index by removing any standard tags
         before adding the 'index' tag."""
-        column_dict = self.columns[index]
+        column = self.columns[index]
 
-        standard_tags = column_dict['logical_type'].standard_tags
-        new_tags = column_dict['semantic_tags'].difference(standard_tags)
+        standard_tags = column.logical_type.standard_tags
+        new_tags = column.semantic_tags.difference(standard_tags)
         new_tags.add('index')
 
-        self.columns[index]['semantic_tags'] = new_tags
+        self.columns[index].semantic_tags = new_tags
 
     def _set_time_index_tags(self, time_index):
-        self.columns[time_index]['semantic_tags'].add('time_index')
+        self.columns[time_index].semantic_tags.add('time_index')
 
     def _filter_cols(self, include=None, exclude=None, col_names=False):
         """Return list of columns filtered with any of: semantic tags, LogicalTypes, column names
@@ -405,10 +404,10 @@ class TableSchema(object):
             selectors = exclude
 
         ltypes_used = set()
-        ltypes_in_schema = {_get_ltype_class(col['logical_type']) for col in self.columns.values()}
+        ltypes_in_schema = {_get_ltype_class(col.logical_type) for col in self.columns.values()}
 
         tags_used = set()
-        tags_in_schema = {tag for col in self.columns.values() for tag in col['semantic_tags']}
+        tags_in_schema = {tag for col in self.columns.values() for tag in col.semantic_tags}
 
         col_name_matches = set()
 
@@ -442,8 +441,8 @@ class TableSchema(object):
 
         cols_to_return = set()
         for col_name, col in self.columns.items():
-            is_match = (_get_ltype_class(col['logical_type']) in ltypes_used or
-                        col['semantic_tags'].intersection(tags_used) or
+            is_match = (_get_ltype_class(col.logical_type) in ltypes_used or
+                        col.semantic_tags.intersection(tags_used) or
                         col_name in col_name_matches)
             if include is not None and is_match:
                 cols_to_return.add(col_name)
@@ -467,10 +466,10 @@ class TableSchema(object):
         for col_name in subset_cols:
             col = col = self.columns[col_name]
 
-            new_logical_types[col_name] = col['logical_type']
-            new_semantic_tags[col_name] = col['semantic_tags']
-            new_column_descriptions[col_name] = col['description']
-            new_column_metadata[col_name] = col['metadata']
+            new_logical_types[col_name] = col.logical_type
+            new_semantic_tags[col_name] = col.semantic_tags
+            new_column_descriptions[col_name] = col.description
+            new_column_metadata[col_name] = col.metadata
 
         new_index = self.index if self.index in subset_cols else None
         new_time_index = self.time_index if self.time_index in subset_cols else None

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -6,6 +6,7 @@ import pytest
 
 from woodwork.accessor_utils import init_series
 from woodwork.column_accessor import WoodworkColumnAccessor
+from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
     DuplicateTagsWarning,
     StandardTagsChangedWarning,
@@ -38,7 +39,7 @@ ks = import_or_none('databricks.koalas')
 def test_accessor_init(sample_series):
     assert sample_series.ww._schema is None
     sample_series.ww.init()
-    assert isinstance(sample_series.ww._schema, dict)
+    assert isinstance(sample_series.ww._schema, ColumnSchema)
     assert sample_series.ww.logical_type == Categorical
     assert sample_series.ww.semantic_tags == {'category'}
 
@@ -428,11 +429,13 @@ def test_series_methods_on_accessor_inplace(sample_series):
     # TODO: Try to find a supported inplace method for Dask, if one exists
     if dd and isinstance(sample_series, dd.Series):
         pytest.xfail('Dask does not support pop.')
-    sample_series.ww.init()
+    comparison_series = sample_series.copy()
 
-    original_schema = sample_series.ww._schema.copy()
+    sample_series.ww.init()
+    comparison_series.ww.init()
+
     val = sample_series.ww.pop(0)
-    assert sample_series.ww._schema == original_schema
+    assert sample_series.ww._schema == comparison_series.ww._schema
     assert len(sample_series) == 3
     assert val == 'a'
 

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -134,15 +134,15 @@ def test_logical_type_errors(sample_series):
 
 
 def test_semantic_tag_errors(sample_series):
-    error_message = "semantic_tags for sample_series must be a string, set or list"
+    error_message = "semantic_tags must be a string, set or list"
     with pytest.raises(TypeError, match=error_message):
         sample_series.ww.init(semantic_tags=int)
 
-    error_message = "semantic_tags for sample_series must be a string, set or list"
+    error_message = "semantic_tags must be a string, set or list"
     with pytest.raises(TypeError, match=error_message):
         sample_series.ww.init(semantic_tags={'index': {}, 'time_index': {}})
 
-    error_message = "semantic_tags for sample_series must contain only strings"
+    error_message = "semantic_tags must contain only strings"
     with pytest.raises(TypeError, match=error_message):
         sample_series.ww.init(semantic_tags=['index', 1])
 

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -258,6 +258,6 @@ def test_iloc_table_does_not_propagate_changes_to_data(sample_df):
     assert sliced.ww.metadata == {}
     assert sliced.ww.metadata is not sample_df.ww.metadata
 
-    sample_df.ww.columns['email']['metadata']['new_key'] = 'new_value'
-    assert sliced.ww.columns['email']['metadata'] == {}
-    assert sliced.ww.columns['email']['metadata'] is not sample_df.ww.columns['email']['metadata']
+    sample_df.ww.columns['email'].metadata['new_key'] = 'new_value'
+    assert sliced.ww.columns['email'].metadata == {}
+    assert sliced.ww.columns['email'].metadata is not sample_df.ww.columns['email'].metadata

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -2138,7 +2138,7 @@ def test_setitem_overwrite_column(sample_df):
     df.ww.init(use_standard_tags=False)
 
     original_col = df['full_name']
-    new_series = pd.Series([0, 1, 2], dtype='float', name='full_name')
+    new_series = pd.Series([0, 1, 2], dtype='float')
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series = ks.Series(new_series)
 
@@ -2148,7 +2148,7 @@ def test_setitem_overwrite_column(sample_df):
         semantic_tags='test_tag',
     )
 
-    match = 'Standard tags have been removed from "full_name"'
+    match = 'Standard tags have been removed from your column'
     with pytest.warns(StandardTagsChangedWarning, match=match):
         df.ww['full_name'] = new_series
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -2138,7 +2138,7 @@ def test_setitem_overwrite_column(sample_df):
     df.ww.init(use_standard_tags=False)
 
     original_col = df['full_name']
-    new_series = pd.Series([0, 1, 2], dtype='float')
+    new_series = pd.Series([0, 1, 2], dtype='float', name='full_name')
     if ks and isinstance(sample_df, ks.DataFrame):
         new_series = ks.Series(new_series)
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -127,7 +127,7 @@ def test_accessor_physical_types_property(sample_df):
     assert isinstance(sample_df.ww.physical_types, dict)
     assert set(sample_df.ww.physical_types.keys()) == set(sample_df.columns)
     for k, v in sample_df.ww.physical_types.items():
-        logical_type = sample_df.ww.columns[k]['logical_type']
+        logical_type = sample_df.ww.columns[k].logical_type
         if ks and isinstance(sample_df, ks.DataFrame) and logical_type.backup_dtype is not None:
             assert v == logical_type.backup_dtype
         else:
@@ -379,7 +379,7 @@ def test_accessor_init_with_valid_string_time_index(time_index_df):
     assert time_index_df.ww.name == 'schema'
     assert time_index_df.ww.index == 'id'
     assert time_index_df.ww.time_index == 'times'
-    assert time_index_df.ww.columns[time_index_df.ww.time_index]['logical_type'] == Datetime
+    assert time_index_df.ww.columns[time_index_df.ww.time_index].logical_type == Datetime
 
 
 def test_accessor_init_with_numeric_datetime_time_index(time_index_df):
@@ -400,23 +400,23 @@ def test_accessor_with_numeric_time_index(time_index_df):
     schema_df.ww.init(time_index='ints')
     date_col = schema_df.ww.columns['ints']
     assert schema_df.ww.time_index == 'ints'
-    assert date_col['logical_type'] == Integer
-    assert date_col['semantic_tags'] == {'time_index', 'numeric'}
+    assert date_col.logical_type == Integer
+    assert date_col.semantic_tags == {'time_index', 'numeric'}
 
     # Specify logical type for time index on init
     schema_df = time_index_df.copy()
     schema_df.ww.init(time_index='ints', logical_types={'ints': 'Double'})
     date_col = schema_df.ww.columns['ints']
     assert schema_df.ww.time_index == 'ints'
-    assert date_col['logical_type'] == Double
-    assert date_col['semantic_tags'] == {'time_index', 'numeric'}
+    assert date_col.logical_type == Double
+    assert date_col.semantic_tags == {'time_index', 'numeric'}
 
     schema_df = time_index_df.copy()
     schema_df.ww.init(time_index='strs', logical_types={'strs': 'Double'})
     date_col = schema_df.ww.columns['strs']
     assert schema_df.ww.time_index == 'strs'
-    assert date_col['logical_type'] == Double
-    assert date_col['semantic_tags'] == {'time_index', 'numeric'}
+    assert date_col.logical_type == Double
+    assert date_col.semantic_tags == {'time_index', 'numeric'}
 
     error_msg = 'Time index column must contain datetime or numeric values'
     with pytest.raises(TypeError, match=error_msg):
@@ -434,8 +434,8 @@ def test_accessor_with_numeric_time_index(time_index_df):
     schema_df.ww.set_time_index('ints')
     date_col = schema_df.ww.columns['ints']
     assert schema_df.ww.time_index == 'ints'
-    assert date_col['logical_type'] == Double
-    assert date_col['semantic_tags'] == {'numeric', 'time_index'}
+    assert date_col.logical_type == Double
+    assert date_col.semantic_tags == {'numeric', 'time_index'}
 
 
 def test_numeric_time_index_dtypes(numeric_time_index_df):
@@ -473,8 +473,8 @@ def test_accessor_init_with_string_logical_types(sample_df):
     schema_df = sample_df.copy()
     schema_df.ww.init(name='schema',
                       logical_types=logical_types)
-    assert schema_df.ww.columns['full_name']['logical_type'] == NaturalLanguage
-    assert schema_df.ww.columns['age']['logical_type'] == Double
+    assert schema_df.ww.columns['full_name'].logical_type == NaturalLanguage
+    assert schema_df.ww.columns['age'].logical_type == Double
 
     logical_types = {
         'full_name': 'NaturalLanguage',
@@ -486,8 +486,8 @@ def test_accessor_init_with_string_logical_types(sample_df):
                       logical_types=logical_types,
                       time_index='signup_date'
                       )
-    assert schema_df.ww.columns['full_name']['logical_type'] == NaturalLanguage
-    assert schema_df.ww.columns['age']['logical_type'] == Integer
+    assert schema_df.ww.columns['full_name'].logical_type == NaturalLanguage
+    assert schema_df.ww.columns['age'].logical_type == Integer
     assert schema_df.ww.time_index == 'signup_date'
 
 
@@ -649,7 +649,7 @@ def test_sets_category_dtype_on_init():
             }
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
-            assert df.ww.columns[column_name]['logical_type'] == logical_type
+            assert df.ww.columns[column_name].logical_type == logical_type
             assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -660,7 +660,7 @@ def test_sets_object_dtype_on_init(latlong_df):
         }
         df = latlong_df.loc[:, [column_name]]
         df.ww.init(logical_types=ltypes)
-        assert df.ww.columns[column_name]['logical_type'] == LatLong
+        assert df.ww.columns[column_name].logical_type == LatLong
         assert df[column_name].dtype == LatLong.primary_dtype
         df_pandas = to_pandas(df[column_name])
         expected_val = (3, 4)
@@ -695,7 +695,7 @@ def test_sets_string_dtype_on_init():
             }
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
-            assert df.ww.columns[column_name]['logical_type'] == logical_type
+            assert df.ww.columns[column_name].logical_type == logical_type
             assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -716,7 +716,7 @@ def test_sets_boolean_dtype_on_init():
         }
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
-        assert df.ww.columns[column_name]['logical_type'] == logical_type
+        assert df.ww.columns[column_name].logical_type == logical_type
         assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -738,7 +738,7 @@ def test_sets_int64_dtype_on_init():
             }
             df = pd.DataFrame(series)
             df.ww.init(logical_types=ltypes)
-            assert df.ww.columns[column_name]['logical_type'] == logical_type
+            assert df.ww.columns[column_name].logical_type == logical_type
             assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -758,7 +758,7 @@ def test_sets_float64_dtype_on_init():
         }
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
-        assert df.ww.columns[column_name]['logical_type'] == logical_type
+        assert df.ww.columns[column_name].logical_type == logical_type
         assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -780,7 +780,7 @@ def test_sets_datetime64_dtype_on_init():
         }
         df = pd.DataFrame(series)
         df.ww.init(logical_types=ltypes)
-        assert df.ww.columns[column_name]['logical_type'] == logical_type
+        assert df.ww.columns[column_name].logical_type == logical_type
         assert df[column_name].dtype == logical_type.primary_dtype
 
 
@@ -833,7 +833,7 @@ def test_make_index(sample_df):
         assert 'new_index' in schema_df.ww.columns
         assert to_pandas(schema_df)['new_index'].unique
         assert to_pandas(schema_df['new_index']).is_monotonic
-        assert 'index' in schema_df.ww.columns['new_index']['semantic_tags']
+        assert 'index' in schema_df.ww.columns['new_index'].semantic_tags
 
         copied_df = schema_df.ww.copy()
         assert copied_df.ww.make_index is True
@@ -1008,7 +1008,7 @@ def test_accessor_already_sorted(sample_unsorted_df):
                       time_index='signup_date')
 
     assert schema_df.ww.time_index == 'signup_date'
-    assert schema_df.ww.columns[schema_df.ww.time_index]['logical_type'] == Datetime
+    assert schema_df.ww.columns[schema_df.ww.time_index].logical_type == Datetime
 
     sorted_df = to_pandas(sample_unsorted_df).sort_values(['signup_date', 'id']).set_index('id', drop=False)
     sorted_df.index.name = None
@@ -1022,7 +1022,7 @@ def test_accessor_already_sorted(sample_unsorted_df):
                       already_sorted=True)
 
     assert schema_df.ww.time_index == 'signup_date'
-    assert schema_df.ww.columns[schema_df.ww.time_index]['logical_type'] == Datetime
+    assert schema_df.ww.columns[schema_df.ww.time_index].logical_type == Datetime
 
     unsorted_df = to_pandas(sample_unsorted_df.set_index('id', drop=False))
     unsorted_df.index.name = None
@@ -1221,9 +1221,9 @@ def test_dataframe_methods_on_accessor_new_schema_object(sample_df):
     assert copied_df.ww.semantic_tags['email'] == set()
     assert sample_df.ww.semantic_tags['email'] == {'new_tag'}
 
-    copied_df.ww.columns['id']['metadata']['important_keys'].append(4)
-    assert copied_df.ww.columns['id']['metadata'] == {'important_keys': [1, 2, 3, 4]}
-    assert sample_df.ww.columns['id']['metadata'] == {'important_keys': [1, 2, 3]}
+    copied_df.ww.columns['id'].metadata['important_keys'].append(4)
+    assert copied_df.ww.columns['id'].metadata == {'important_keys': [1, 2, 3, 4]}
+    assert sample_df.ww.columns['id'].metadata == {'important_keys': [1, 2, 3]}
 
 
 def test_dataframe_methods_on_accessor_inplace(sample_df):
@@ -1924,12 +1924,12 @@ def test_accessor_rename(sample_df):
 
     # confirm that metadata and descriptions are there
     assert new_df.ww.metadata == table_metadata
-    assert new_df.ww.columns['id']['description'] == id_description
+    assert new_df.ww.columns['id'].description == id_description
 
     old_col = sample_df.ww.columns['age']
     new_col = new_df.ww.columns['birthday']
-    assert old_col['logical_type'] == new_col['logical_type']
-    assert old_col['semantic_tags'] == new_col['semantic_tags']
+    assert old_col.logical_type == new_col.logical_type
+    assert old_col.semantic_tags == new_col.semantic_tags
 
     new_df = sample_df.ww.rename({'age': 'full_name', 'full_name': 'age'})
 

--- a/woodwork/tests/demo_tests/test_retail.py
+++ b/woodwork/tests/demo_tests/test_retail.py
@@ -54,7 +54,7 @@ def test_load_retail():
     }
 
     for col_name, column in df.ww.columns.items():
-        assert column['logical_type'] == expected_logical_types[col_name]
+        assert column.logical_type == expected_logical_types[col_name]
 
     assert df.ww.index == 'order_product_id'
     assert df.ww.time_index == 'order_date'

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -5,7 +5,7 @@ from mock import patch
 
 import woodwork as ww
 from woodwork.column_schema import (
-    _get_column_dict,
+    ColumnSchema,
     _is_col_boolean,
     _is_col_categorical,
     _is_col_datetime,
@@ -39,7 +39,7 @@ def test_validate_logical_type_errors():
 
     error_msg = 'Must use an Ordinal instance with order values defined'
     with pytest.raises(TypeError, match=error_msg):
-        _get_column_dict('column', Ordinal)
+        ColumnSchema('column', Ordinal)
 
 
 def test_validate_description_errors():
@@ -59,20 +59,21 @@ def test_validate_metadata_errors():
 @patch("woodwork.column_schema._validate_logical_type")
 def test_validation_methods_called(mock_validate_logical_type, mock_validate_description, mock_validate_metadata,
                                    sample_column_names, sample_inferred_logical_types):
+    # --> need to add an equality method
     assert not mock_validate_logical_type.called
     assert not mock_validate_description.called
     assert not mock_validate_metadata.called
 
-    not_validated_column = _get_column_dict('not_validated', logical_type=Integer,
-                                            description='this is a description', metadata={'user': 'person1'},
-                                            validate=False)
-    assert not mock_validate_logical_type.called
-    assert not mock_validate_description.called
-    assert not mock_validate_metadata.called
-
-    validated_column = _get_column_dict('not_validated', logical_type=Integer,
+    not_validated_column = ColumnSchema('not_validated', logical_type=Integer,
                                         description='this is a description', metadata={'user': 'person1'},
-                                        validate=True)
+                                        validate=False)
+    assert not mock_validate_logical_type.called
+    assert not mock_validate_description.called
+    assert not mock_validate_metadata.called
+
+    validated_column = ColumnSchema('not_validated', logical_type=Integer,
+                                    description='this is a description', metadata={'user': 'person1'},
+                                    validate=True)
     assert mock_validate_logical_type.called
     assert mock_validate_description.called
     assert mock_validate_metadata.called
@@ -81,121 +82,117 @@ def test_validation_methods_called(mock_validate_logical_type, mock_validate_des
 
 
 def test_get_column_dict():
-    column = _get_column_dict('column', Integer, semantic_tags='test_tag')
+    column = ColumnSchema('column', Integer, semantic_tags='test_tag')
 
-    assert set(column.keys()) == {'logical_type', 'semantic_tags', 'description', 'metadata'}
+    assert column.logical_type == Integer
+    assert column.semantic_tags == {'test_tag'}
 
-    assert column.get('logical_type') == Integer
-    assert column.get('semantic_tags') == {'test_tag'}
-
-    assert column.get('description') is None
-    assert column.get('metadata') == {}
+    assert column.description is None
+    assert column.metadata == {}
 
 
 def test_get_column_dict_standard_tags():
-    column = _get_column_dict('column', Integer, use_standard_tags=True)
+    column = ColumnSchema('column', Integer, use_standard_tags=True)
 
-    assert column.get('semantic_tags') == {'numeric'}
+    assert column.semantic_tags == {'numeric'}
 
 
 def test_get_column_dict_params():
-    column = _get_column_dict('column', Integer, description='this is a column!', metadata={'created_by': 'user1'})
+    column = ColumnSchema('column', Integer, description='this is a column!', metadata={'created_by': 'user1'})
 
-    assert column.get('description') == 'this is a column!'
-    assert column.get('metadata') == {'created_by': 'user1'}
+    assert column.description == 'this is a column!'
+    assert column.metadata == {'created_by': 'user1'}
 
 
 def test_get_column_dict_null_params():
-    empty_col = {
-        'logical_type': None,
-        'semantic_tags': set(),
-        'description': None,
-        'metadata': {}
-    }
-    assert _get_column_dict() == empty_col
+    empty_col = ColumnSchema()
+    assert empty_col.logical_type is None
+    assert empty_col.description is None
+    assert empty_col.semantic_tags == set()
+    assert empty_col.metadata == {}
 
-    just_tags = _get_column_dict(semantic_tags={'numeric', 'time_index'})
-    assert just_tags.get('logical_type') is None
-    assert just_tags.get('semantic_tags') == {'numeric', 'time_index'}
+    just_tags = ColumnSchema(semantic_tags={'numeric', 'time_index'})
+    assert just_tags.logical_type is None
+    assert just_tags.semantic_tags == {'numeric', 'time_index'}
 
-    just_ltype = _get_column_dict(logical_type=Integer)
-    assert just_ltype.get('logical_type') == Integer
-    assert just_ltype.get('semantic_tags') == set()
+    just_ltype = ColumnSchema(logical_type=Integer)
+    assert just_ltype.logical_type == Integer
+    assert just_ltype.semantic_tags == set()
 
     error = "Cannot use standard tags when logical_type is None"
     with pytest.raises(ValueError, match=error):
-        _get_column_dict(semantic_tags='categorical', use_standard_tags=True)
+        ColumnSchema(semantic_tags='categorical', use_standard_tags=True)
 
     error = "semantic_tags must be a string, set or list"
     with pytest.raises(TypeError, match=error):
-        _get_column_dict(semantic_tags=1)
+        ColumnSchema(semantic_tags=1)
 
 
 def test_is_col_numeric():
-    int_column = _get_column_dict('ints', Integer)
+    int_column = ColumnSchema('ints', Integer)
     assert _is_col_numeric(int_column)
 
-    double_column = _get_column_dict('floats', Double)
+    double_column = ColumnSchema('floats', Double)
     assert _is_col_numeric(double_column)
 
-    nl_column = _get_column_dict('text', NaturalLanguage)
+    nl_column = ColumnSchema('text', NaturalLanguage)
     assert not _is_col_numeric(nl_column)
 
-    manually_added = _get_column_dict('text', NaturalLanguage, semantic_tags='numeric')
+    manually_added = ColumnSchema('text', NaturalLanguage, semantic_tags='numeric')
     assert not _is_col_numeric(manually_added)
 
-    no_standard_tags = _get_column_dict('ints', Integer, use_standard_tags=False)
+    no_standard_tags = ColumnSchema('ints', Integer, use_standard_tags=False)
     assert _is_col_numeric(no_standard_tags)
 
-    instantiated_column = _get_column_dict('ints', Integer())
+    instantiated_column = ColumnSchema('ints', Integer())
     assert _is_col_numeric(instantiated_column)
 
 
 def test_is_col_categorical():
-    categorical_column = _get_column_dict('cats', Categorical)
+    categorical_column = ColumnSchema('cats', Categorical)
     assert _is_col_categorical(categorical_column)
 
-    ordinal_column = _get_column_dict('ordinal', Ordinal(order=['a', 'b']))
+    ordinal_column = ColumnSchema('ordinal', Ordinal(order=['a', 'b']))
     assert _is_col_categorical(ordinal_column)
 
-    nl_column = _get_column_dict('text', NaturalLanguage)
+    nl_column = ColumnSchema('text', NaturalLanguage)
     assert not _is_col_categorical(nl_column)
 
-    manually_added = _get_column_dict('text', NaturalLanguage, semantic_tags='category')
+    manually_added = ColumnSchema('text', NaturalLanguage, semantic_tags='category')
     assert not _is_col_categorical(manually_added)
 
-    no_standard_tags = _get_column_dict('cats', Categorical, use_standard_tags=False)
+    no_standard_tags = ColumnSchema('cats', Categorical, use_standard_tags=False)
     assert _is_col_categorical(no_standard_tags)
 
 
 def test_is_col_boolean():
-    boolean_column = _get_column_dict('bools', Boolean)
+    boolean_column = ColumnSchema('bools', Boolean)
     assert _is_col_boolean(boolean_column)
 
-    instantiated_column = _get_column_dict('bools', Boolean())
+    instantiated_column = ColumnSchema('bools', Boolean())
     assert _is_col_boolean(instantiated_column)
 
-    ordinal_column = _get_column_dict('ordinal', Ordinal(order=['a', 'b']))
+    ordinal_column = ColumnSchema('ordinal', Ordinal(order=['a', 'b']))
     assert not _is_col_boolean(ordinal_column)
 
-    nl_column = _get_column_dict('text', NaturalLanguage)
+    nl_column = ColumnSchema('text', NaturalLanguage)
     assert not _is_col_boolean(nl_column)
 
 
 def test_is_col_datetime():
-    datetime_column = _get_column_dict('dates', Datetime)
+    datetime_column = ColumnSchema('dates', Datetime)
     assert _is_col_datetime(datetime_column)
 
-    formatted_datetime_column = _get_column_dict('dates', Datetime(datetime_format='%Y-%m%d'))
+    formatted_datetime_column = ColumnSchema('dates', Datetime(datetime_format='%Y-%m%d'))
     assert _is_col_datetime(formatted_datetime_column)
 
-    instantiated_datetime_column = _get_column_dict('dates', Datetime())
+    instantiated_datetime_column = ColumnSchema('dates', Datetime())
     assert _is_col_datetime(instantiated_datetime_column)
 
-    nl_column = _get_column_dict('text', NaturalLanguage)
+    nl_column = ColumnSchema('text', NaturalLanguage)
     assert not _is_col_datetime(nl_column)
 
-    double_column = _get_column_dict('floats', Double)
+    double_column = ColumnSchema('floats', Double)
     assert not _is_col_datetime(double_column)
 
 

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -39,7 +39,7 @@ def test_validate_logical_type_errors():
 
     error_msg = 'Must use an Ordinal instance with order values defined'
     with pytest.raises(TypeError, match=error_msg):
-        ColumnSchema('column', Ordinal)
+        ColumnSchema(Ordinal)
 
 
 def test_validate_description_errors():
@@ -63,14 +63,14 @@ def test_validation_methods_called(mock_validate_logical_type, mock_validate_des
     assert not mock_validate_description.called
     assert not mock_validate_metadata.called
 
-    not_validated_column = ColumnSchema('not_validated', logical_type=Integer,
+    not_validated_column = ColumnSchema(logical_type=Integer,
                                         description='this is a description', metadata={'user': 'person1'},
                                         validate=False)
     assert not mock_validate_logical_type.called
     assert not mock_validate_description.called
     assert not mock_validate_metadata.called
 
-    validated_column = ColumnSchema('not_validated', logical_type=Integer,
+    validated_column = ColumnSchema(logical_type=Integer,
                                     description='this is a description', metadata={'user': 'person1'},
                                     validate=True)
     assert mock_validate_logical_type.called
@@ -81,7 +81,7 @@ def test_validation_methods_called(mock_validate_logical_type, mock_validate_des
 
 
 def test_column_schema():
-    column = ColumnSchema('column', Integer, semantic_tags='test_tag')
+    column = ColumnSchema(logical_type=Integer, semantic_tags='test_tag')
 
     assert column.logical_type == Integer
     assert column.semantic_tags == {'test_tag'}
@@ -91,13 +91,13 @@ def test_column_schema():
 
 
 def test_column_schema_standard_tags():
-    column = ColumnSchema('column', Integer, use_standard_tags=True)
+    column = ColumnSchema(logical_type=Integer, use_standard_tags=True)
 
     assert column.semantic_tags == {'numeric'}
 
 
 def test_column_schema_params():
-    column = ColumnSchema('column', Integer, description='this is a column!', metadata={'created_by': 'user1'})
+    column = ColumnSchema(logical_type=Integer, description='this is a column!', metadata={'created_by': 'user1'})
 
     assert column.description == 'this is a column!'
     assert column.metadata == {'created_by': 'user1'}
@@ -128,70 +128,70 @@ def test_column_schema_null_params():
 
 
 def test_is_col_numeric():
-    int_column = ColumnSchema('ints', Integer)
+    int_column = ColumnSchema(logical_type=Integer)
     assert _is_col_numeric(int_column)
 
-    double_column = ColumnSchema('floats', Double)
+    double_column = ColumnSchema(logical_type=Double)
     assert _is_col_numeric(double_column)
 
-    nl_column = ColumnSchema('text', NaturalLanguage)
+    nl_column = ColumnSchema(logical_type=NaturalLanguage)
     assert not _is_col_numeric(nl_column)
 
-    manually_added = ColumnSchema('text', NaturalLanguage, semantic_tags='numeric')
+    manually_added = ColumnSchema(logical_type=NaturalLanguage, semantic_tags='numeric')
     assert not _is_col_numeric(manually_added)
 
-    no_standard_tags = ColumnSchema('ints', Integer, use_standard_tags=False)
+    no_standard_tags = ColumnSchema(logical_type=Integer, use_standard_tags=False)
     assert _is_col_numeric(no_standard_tags)
 
-    instantiated_column = ColumnSchema('ints', Integer())
+    instantiated_column = ColumnSchema(logical_type=Integer())
     assert _is_col_numeric(instantiated_column)
 
 
 def test_is_col_categorical():
-    categorical_column = ColumnSchema('cats', Categorical)
+    categorical_column = ColumnSchema(logical_type=Categorical)
     assert _is_col_categorical(categorical_column)
 
-    ordinal_column = ColumnSchema('ordinal', Ordinal(order=['a', 'b']))
+    ordinal_column = ColumnSchema(logical_type=Ordinal(order=['a', 'b']))
     assert _is_col_categorical(ordinal_column)
 
-    nl_column = ColumnSchema('text', NaturalLanguage)
+    nl_column = ColumnSchema(logical_type=NaturalLanguage)
     assert not _is_col_categorical(nl_column)
 
-    manually_added = ColumnSchema('text', NaturalLanguage, semantic_tags='category')
+    manually_added = ColumnSchema(logical_type=NaturalLanguage, semantic_tags='category')
     assert not _is_col_categorical(manually_added)
 
-    no_standard_tags = ColumnSchema('cats', Categorical, use_standard_tags=False)
+    no_standard_tags = ColumnSchema(logical_type=Categorical, use_standard_tags=False)
     assert _is_col_categorical(no_standard_tags)
 
 
 def test_is_col_boolean():
-    boolean_column = ColumnSchema('bools', Boolean)
+    boolean_column = ColumnSchema(logical_type=Boolean)
     assert _is_col_boolean(boolean_column)
 
-    instantiated_column = ColumnSchema('bools', Boolean())
+    instantiated_column = ColumnSchema(logical_type=Boolean())
     assert _is_col_boolean(instantiated_column)
 
-    ordinal_column = ColumnSchema('ordinal', Ordinal(order=['a', 'b']))
+    ordinal_column = ColumnSchema(logical_type=Ordinal(order=['a', 'b']))
     assert not _is_col_boolean(ordinal_column)
 
-    nl_column = ColumnSchema('text', NaturalLanguage)
+    nl_column = ColumnSchema(logical_type=NaturalLanguage)
     assert not _is_col_boolean(nl_column)
 
 
 def test_is_col_datetime():
-    datetime_column = ColumnSchema('dates', Datetime)
+    datetime_column = ColumnSchema(logical_type=Datetime)
     assert _is_col_datetime(datetime_column)
 
-    formatted_datetime_column = ColumnSchema('dates', Datetime(datetime_format='%Y-%m%d'))
+    formatted_datetime_column = ColumnSchema(logical_type=Datetime(datetime_format='%Y-%m%d'))
     assert _is_col_datetime(formatted_datetime_column)
 
-    instantiated_datetime_column = ColumnSchema('dates', Datetime())
+    instantiated_datetime_column = ColumnSchema(logical_type=Datetime())
     assert _is_col_datetime(instantiated_datetime_column)
 
-    nl_column = ColumnSchema('text', NaturalLanguage)
+    nl_column = ColumnSchema(logical_type=NaturalLanguage)
     assert not _is_col_datetime(nl_column)
 
-    double_column = ColumnSchema('floats', Double)
+    double_column = ColumnSchema(logical_type=Double)
     assert not _is_col_datetime(double_column)
 
 

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -59,7 +59,6 @@ def test_validate_metadata_errors():
 @patch("woodwork.column_schema._validate_logical_type")
 def test_validation_methods_called(mock_validate_logical_type, mock_validate_description, mock_validate_metadata,
                                    sample_column_names, sample_inferred_logical_types):
-    # --> need to add an equality method
     assert not mock_validate_logical_type.called
     assert not mock_validate_description.called
     assert not mock_validate_metadata.called

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -80,7 +80,7 @@ def test_validation_methods_called(mock_validate_logical_type, mock_validate_des
     assert validated_column == not_validated_column
 
 
-def test_get_column_dict():
+def test_column_schema():
     column = ColumnSchema('column', Integer, semantic_tags='test_tag')
 
     assert column.logical_type == Integer
@@ -90,20 +90,20 @@ def test_get_column_dict():
     assert column.metadata == {}
 
 
-def test_get_column_dict_standard_tags():
+def test_column_schema_standard_tags():
     column = ColumnSchema('column', Integer, use_standard_tags=True)
 
     assert column.semantic_tags == {'numeric'}
 
 
-def test_get_column_dict_params():
+def test_column_schema_params():
     column = ColumnSchema('column', Integer, description='this is a column!', metadata={'created_by': 'user1'})
 
     assert column.description == 'this is a column!'
     assert column.metadata == {'created_by': 'user1'}
 
 
-def test_get_column_dict_null_params():
+def test_column_schema_null_params():
     empty_col = ColumnSchema()
     assert empty_col.logical_type is None
     assert empty_col.description is None

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -26,7 +26,7 @@ def test_schema_logical_types(sample_column_names, sample_inferred_logical_types
     assert isinstance(schema.logical_types, dict)
     assert set(schema.logical_types.keys()) == set(sample_column_names)
     for k, v in schema.logical_types.items():
-        assert v == schema.columns[k]['logical_type']
+        assert v == schema.columns[k].logical_type
 
 
 def test_schema_semantic_tags(sample_column_names, sample_inferred_logical_types):
@@ -40,7 +40,7 @@ def test_schema_semantic_tags(sample_column_names, sample_inferred_logical_types
     assert set(schema.semantic_tags.keys()) == set(sample_column_names)
     for k, v in schema.semantic_tags.items():
         assert isinstance(v, set)
-        assert v == schema.columns[k]['semantic_tags']
+        assert v == schema.columns[k].semantic_tags
 
 
 def test_schema_types(sample_column_names, sample_inferred_logical_types):
@@ -178,10 +178,10 @@ def test_column_schema_metadata(sample_column_names, sample_inferred_logical_typ
     column_metadata = {'metadata_field': [1, 2, 3], 'created_by': 'user0'}
 
     schema = TableSchema(sample_column_names, sample_inferred_logical_types)
-    assert schema.columns['id']['metadata'] == {}
+    assert schema.columns['id'].metadata == {}
 
     schema = TableSchema(sample_column_names, sample_inferred_logical_types, column_metadata={'id': column_metadata})
-    assert schema.columns['id']['metadata'] == column_metadata
+    assert schema.columns['id'].metadata == column_metadata
 
 
 def test_filter_schema_cols_include(sample_column_names, sample_inferred_logical_types):
@@ -898,12 +898,12 @@ def test_schema_rename(sample_column_names, sample_inferred_logical_types):
 
     # confirm that metadata and descriptions are there
     assert renamed_schema.metadata == table_metadata
-    assert schema.columns['id']['description'] == id_description
+    assert schema.columns['id'].description == id_description
 
     old_col = schema.columns['age']
     new_col = renamed_schema.columns['birthday']
-    assert old_col['logical_type'] == new_col['logical_type']
-    assert old_col['semantic_tags'] == new_col['semantic_tags']
+    assert old_col.logical_type == new_col.logical_type
+    assert old_col.semantic_tags == new_col.semantic_tags
 
     swapped_schema = schema.rename({'age': 'full_name', 'full_name': 'age'})
     swapped_back_schema = swapped_schema.rename({'age': 'full_name', 'full_name': 'age'})

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -190,7 +190,7 @@ def test_schema_init_with_name_and_indices(sample_column_names, sample_inferred_
     assert schema.name == 'schema'
     assert schema.index == 'id'
     assert schema.time_index == 'signup_date'
-    assert schema.columns[schema.time_index]['logical_type'] == Datetime
+    assert schema.columns[schema.time_index].logical_type == Datetime
 
 
 def test_schema_with_numeric_time_index(sample_column_names, sample_inferred_logical_types):
@@ -199,16 +199,16 @@ def test_schema_with_numeric_time_index(sample_column_names, sample_inferred_log
                          time_index='signup_date')
     date_col = schema.columns['signup_date']
     assert schema.time_index == 'signup_date'
-    assert date_col['logical_type'] == Integer
-    assert date_col['semantic_tags'] == {'time_index', 'numeric'}
+    assert date_col.logical_type == Integer
+    assert date_col.semantic_tags == {'time_index', 'numeric'}
 
     # Specify logical type for time index on init
     schema = TableSchema(sample_column_names, logical_types={**sample_inferred_logical_types, **{'signup_date': Double}},
                          time_index='signup_date')
     date_col = schema.columns['signup_date']
     assert schema.time_index == 'signup_date'
-    assert date_col['logical_type'] == Double
-    assert date_col['semantic_tags'] == {'time_index', 'numeric'}
+    assert date_col.logical_type == Double
+    assert date_col.semantic_tags == {'time_index', 'numeric'}
 
 
 def test_schema_init_with_logical_type_classes(sample_column_names, sample_inferred_logical_types):
@@ -258,7 +258,7 @@ def test_schema_init_with_semantic_tags(sample_column_names, sample_inferred_log
                          semantic_tags=semantic_tags,
                          use_standard_tags=False)
 
-    id_semantic_tags = schema.columns['id']['semantic_tags']
+    id_semantic_tags = schema.columns['id'].semantic_tags
     assert isinstance(id_semantic_tags, set)
     assert len(id_semantic_tags) == 1
     assert 'custom_tag' in id_semantic_tags
@@ -295,11 +295,11 @@ def test_semantic_tags_during_init(sample_column_names, sample_inferred_logical_
         'age': {'numeric', 'age'}
     }
     schema = TableSchema(sample_column_names, sample_inferred_logical_types, semantic_tags=semantic_tags)
-    assert schema.columns['full_name']['semantic_tags'] == expected_types['full_name']
-    assert schema.columns['email']['semantic_tags'] == expected_types['email']
-    assert schema.columns['phone_number']['semantic_tags'] == expected_types['phone_number']
-    assert schema.columns['signup_date']['semantic_tags'] == expected_types['signup_date']
-    assert schema.columns['age']['semantic_tags'] == expected_types['age']
+    assert schema.columns['full_name'].semantic_tags == expected_types['full_name']
+    assert schema.columns['email'].semantic_tags == expected_types['email']
+    assert schema.columns['phone_number'].semantic_tags == expected_types['phone_number']
+    assert schema.columns['signup_date'].semantic_tags == expected_types['signup_date']
+    assert schema.columns['age'].semantic_tags == expected_types['age']
 
 
 def test_semantic_tag_errors(sample_column_names, sample_inferred_logical_types):
@@ -318,10 +318,10 @@ def test_semantic_tag_errors(sample_column_names, sample_inferred_logical_types)
 
 def test_index_replacing_standard_tags(sample_column_names, sample_inferred_logical_types):
     schema = TableSchema(sample_column_names, sample_inferred_logical_types)
-    assert schema.columns['id']['semantic_tags'] == {'numeric'}
+    assert schema.columns['id'].semantic_tags == {'numeric'}
 
     schema = TableSchema(sample_column_names, sample_inferred_logical_types, index='id')
-    assert schema.columns['id']['semantic_tags'] == {'index'}
+    assert schema.columns['id'].semantic_tags == {'index'}
 
 
 def test_schema_init_with_col_descriptions(sample_column_names, sample_inferred_logical_types):
@@ -331,7 +331,7 @@ def test_schema_init_with_col_descriptions(sample_column_names, sample_inferred_
     }
     schema = TableSchema(sample_column_names, sample_inferred_logical_types, column_descriptions=descriptions)
     for name, column in schema.columns.items():
-        assert column['description'] == descriptions.get(name)
+        assert column.description == descriptions.get(name)
 
 
 def test_schema_col_descriptions_errors(sample_column_names, sample_inferred_logical_types):
@@ -355,7 +355,7 @@ def test_schema_init_with_column_metadata(sample_column_names, sample_inferred_l
     }
     schema = TableSchema(sample_column_names, sample_inferred_logical_types, column_metadata=column_metadata)
     for name, column in schema.columns.items():
-        assert column['metadata'] == (column_metadata.get(name) or {})
+        assert column.metadata == (column_metadata.get(name) or {})
 
 
 @patch("woodwork.table_schema._validate_not_setting_index_tags")

--- a/woodwork/tests/testing_utils/table_utils.py
+++ b/woodwork/tests/testing_utils/table_utils.py
@@ -11,8 +11,8 @@ def validate_subset_schema(subset_schema, schema):
     for subset_col_name, subset_col in subset_schema.columns.items():
         assert subset_col_name in schema.columns
         col = schema.columns[subset_col_name]
-        assert subset_col['logical_type'] == col['logical_type']
-        assert subset_col['semantic_tags'] == col['semantic_tags']
+        assert subset_col.logical_type == col.logical_type
+        assert subset_col.semantic_tags == col.semantic_tags
 
 
 def mi_between_cols(col1, col2, df):


### PR DESCRIPTION
- Creates a ColumnSchema object that's used by the `WoodworkColumnAccessor` and the `TableSchema` to store typing information at the column level
- Closes #770 