### PR TITLE
Add WoodworkColumnAccessor.schema and handle schema copying better

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Store ``make_index`` value on WoodworkTableAccessor (:pr:`780`)
         * Add optional ``exclude`` parameter to WoodworkTableAccessor ``select`` method (:pr:`783`)
         * Add validation control to ``deserialize.read_woodwork_table`` and ``ww.read_csv`` (:pr:`788`)
+        * Add ``WoodworkColumnAccessor.schema`` and handle copying column schema (:pr:`799`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -63,6 +63,8 @@ class WoodworkColumnAccessor:
 
     @property
     def schema(self):
+        if self._schema is None:
+            _raise_init_error()
         return copy.deepcopy(self._schema)
 
     @property

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -62,6 +62,10 @@ class WoodworkColumnAccessor:
                                     metadata=metadata)
 
     @property
+    def schema(self):
+        return copy.deepcopy(self._schema)
+
+    @property
     def description(self):
         """The description of the series"""
         if self._schema is None:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -600,7 +600,7 @@ class WoodworkTableAccessor:
                                       TypingInfoMismatchWarning)
                     else:
                         copied_schema = self._schema._get_subset_schema(list(self._dataframe.columns))
-                        result.ww.init(schema=copied_schema)
+                        result.ww.init(schema=copied_schema, validate=False)
                         result.ww.make_index = self.make_index
                 else:
                     # Confirm that the schema is still valid on original DataFrame

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -190,7 +190,7 @@ class WoodworkTableAccessor:
             raise ColumnNotPresentError(key)
 
         series = self._dataframe[key]
-        column = self._schema.columns[key]
+        column = copy.deepcopy(self._schema.columns[key])
         column.semantic_tags -= {'index', 'time_index'}
 
         series.ww.init(logical_type=column.logical_type,

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -190,7 +190,7 @@ class WoodworkTableAccessor:
             raise ColumnNotPresentError(key)
 
         series = self._dataframe[key]
-        column = self.schema.columns[key]
+        column = self._schema.columns[key]
         column.semantic_tags -= {'index', 'time_index'}
 
         series.ww.init(logical_type=column.logical_type,
@@ -307,7 +307,7 @@ class WoodworkTableAccessor:
         """A dictionary containing physical types for each column"""
         if self._schema is None:
             _raise_init_error()
-        return {col_name: _get_valid_dtype(type(self._dataframe[col_name]), self.schema.logical_types[col_name]) for col_name in self._dataframe.columns}
+        return {col_name: _get_valid_dtype(type(self._dataframe[col_name]), self._schema.logical_types[col_name]) for col_name in self._dataframe.columns}
 
     @property
     def types(self):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -599,7 +599,7 @@ class WoodworkTableAccessor:
                         warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message, 'DataFrame'),
                                       TypingInfoMismatchWarning)
                     else:
-                        copied_schema = copy.deepcopy(self._schema)
+                        copied_schema = self.schema
                         result.ww.init(schema=copied_schema, validate=False)
                         result.ww.make_index = self.make_index
                 else:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -300,7 +300,7 @@ class WoodworkTableAccessor:
     def schema(self):
         """A copy of the Woodwork typing information for the DataFrame."""
         if self._schema:
-            return self._schema._get_subset_schema(list(self._dataframe.columns))
+            return copy.deepcopy(self._schema)
 
     @property
     def physical_types(self):
@@ -599,7 +599,7 @@ class WoodworkTableAccessor:
                         warnings.warn(TypingInfoMismatchWarning().get_warning_message(attr, invalid_schema_message, 'DataFrame'),
                                       TypingInfoMismatchWarning)
                     else:
-                        copied_schema = self._schema._get_subset_schema(list(self._dataframe.columns))
+                        copied_schema = copy.deepcopy(self._schema)
                         result.ww.init(schema=copied_schema, validate=False)
                         result.ww.make_index = self.make_index
                 else:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -629,7 +629,7 @@ class WoodworkTableAccessor:
 
         new_schema = self._schema._get_subset_schema(cols_to_include)
         new_df = self._dataframe[cols_to_include]
-        new_df.ww.init(schema=new_schema)
+        new_df.ww.init(schema=new_schema, validate=False)
 
         return new_df
 

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -486,7 +486,8 @@ class TableSchema(object):
                            use_standard_tags=self.use_standard_tags,
                            table_metadata=copy.deepcopy(self.metadata),
                            column_metadata=copy.deepcopy(new_column_metadata),
-                           column_descriptions=new_column_descriptions)
+                           column_descriptions=new_column_descriptions,
+                           validate=False)
 
 
 def _validate_params(column_names, name, index, time_index, logical_types,

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -351,7 +351,7 @@ class TableSchema(object):
         if len(columns) != len(set(columns.values())):
             raise ValueError('New columns names must be unique from one another.')
 
-        new_schema = self._get_subset_schema(list(self.columns.keys()))
+        new_schema = copy.deepcopy(self)
 
         cols_to_update = {}
         for old_name, new_name in columns.items():

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -386,7 +386,7 @@ def test_series_methods_on_accessor(sample_series):
 
     copied_series = sample_series.ww.copy()
     assert copied_series is not sample_series
-    assert copied_series.ww._schema == sample_series.ww._schema
+    assert copied_series.ww.schema == sample_series.ww.schema
     pd.testing.assert_series_equal(to_pandas(sample_series), to_pandas(copied_series))
 
 
@@ -395,7 +395,7 @@ def test_series_methods_on_accessor_without_standard_tags(sample_series):
 
     copied_series = sample_series.ww.copy()
     assert copied_series is not sample_series
-    assert copied_series.ww._schema == sample_series.ww._schema
+    assert copied_series.ww.schema == sample_series.ww.schema
     pd.testing.assert_series_equal(to_pandas(sample_series), to_pandas(copied_series))
 
 
@@ -710,3 +710,15 @@ def test_non_string_column_name(sample_series):
     assert sample_series.ww.name == 0
     assert sample_series.name == 0
     assert sample_series.ww.semantic_tags == {'category', 'test_tag'}
+
+
+def test_schema_property(sample_series):
+    sample_series.ww.init(logical_type='Categorical', semantic_tags='test_tag', metadata={'created_by': 'user1'})
+
+    assert sample_series.ww.schema is not sample_series.ww._schema
+    assert sample_series.ww.schema == sample_series.ww._schema
+
+    changed_schema = sample_series.ww.schema
+    changed_schema.metadata['new'] = 1
+
+    assert changed_schema != sample_series.ww._schema


### PR DESCRIPTION
- Adds a `schema` property to the Column accessor that uses `copy.deepcopy` because the Schema is simple enough to allow it (so I think we don't need a copy method)
- Avoids validating when re-initializing Woodwork after copying a Schema
- Closes #792 , closes #793 