### PR TITLE
Move spark config to a visible cell

### DIFF
--- a/docs/source/guides/using_woodwork_with_dask_and_koalas.ipynb
+++ b/docs/source/guides/using_woodwork_with_dask_and_koalas.ipynb
@@ -140,16 +140,13 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    ".. ipython:: python\n",
-    "    :suppress:\n",
-    "    \n",
-    "    import pyspark.sql as sql\n",
-    "    spark = sql.SparkSession.builder.master('local[2]').config(\"spark.driver.extraJavaOptions\", \"-Dio.netty.tryReflectionSetAccessible=True\").config(\"spark.sql.shuffle.partitions\", \"2\").config(\"spark.driver.bindAddress\", \"127.0.0.1\").getOrCreate() "
+    "import pyspark.sql as sql\n",
+    "spark = sql.SparkSession.builder.master('local[2]').config(\"spark.driver.extraJavaOptions\", \"-Dio.netty.tryReflectionSetAccessible=True\").config(\"spark.sql.shuffle.partitions\", \"2\").config(\"spark.driver.bindAddress\", \"127.0.0.1\").getOrCreate() "
    ]
   },
   {
@@ -343,7 +340,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/guides/using_woodwork_with_dask_and_koalas.ipynb
+++ b/docs/source/guides/using_woodwork_with_dask_and_koalas.ipynb
@@ -145,6 +145,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Thew two lines below only need to be executed if you do not have Spark properly configured.\n",
+    "# However if you are running into config errors, this resource may be useful:\n",
+    "# https://stackoverflow.com/questions/52133731/how-to-solve-cant-assign-requested-address-service-sparkdriver-failed-after\n",
     "import pyspark.sql as sql\n",
     "spark = sql.SparkSession.builder.master('local[2]').config(\"spark.driver.extraJavaOptions\", \"-Dio.netty.tryReflectionSetAccessible=True\").config(\"spark.sql.shuffle.partitions\", \"2\").config(\"spark.driver.bindAddress\", \"127.0.0.1\").getOrCreate() "
    ]

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,6 +26,7 @@ Release Notes
         * Store column typing information in a ``ColumnSchema`` object instead of a dictionary (:pr:`791`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
+        * Move spark config to a visible cell (:pr:`801`)
     * Testing Changes
         * Add unit tests against minimum dependencies for python 3.6 on PRs and main (:pr:`743`, :pr:`753`, :pr:`763`)
         * Update spark config for test fixtures and docs build (:pr:`787`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,10 +26,10 @@ Release Notes
         * Store column typing information in a ``ColumnSchema`` object instead of a dictionary (:pr:`791`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
-        * Move spark config to a visible cell (:pr:`801`)
+        * Update spark config for docs build (:pr:`787`, :pr:`801`)
     * Testing Changes
         * Add unit tests against minimum dependencies for python 3.6 on PRs and main (:pr:`743`, :pr:`753`, :pr:`763`)
-        * Update spark config for test fixtures and docs build (:pr:`787`)
+        * Update spark config for test fixtures (:pr:`787`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -41,6 +41,7 @@ ks = import_or_none('databricks.koalas')
 
 
 # temp comment
+# a second comment
 
 class WoodworkTableAccessor:
     def __init__(self, dataframe):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -40,6 +40,8 @@ dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
 
 
+# temp comment
+
 class WoodworkTableAccessor:
     def __init__(self, dataframe):
         self._dataframe = dataframe

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -40,9 +40,6 @@ dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
 
 
-# temp comment
-# a second comment
-
 class WoodworkTableAccessor:
     def __init__(self, dataframe):
         self._dataframe = dataframe


### PR DESCRIPTION
- Seeing the docs build fail on the `copy-schema` PR, so hoping to recreate that here and find a fix.
- The fix involves making the spark config visible, and this isn't ideal, but it seems like it's not getting executed in a raw rst cell in the same way it does in a regular cell.