### PR TITLE
Add use_standard_tags to WoodworkColumnAccessor equality check

### DIFF
--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -163,6 +163,8 @@ class WoodworkColumnAccessor:
         return self._schema.semantic_tags
 
     def __eq__(self, other):
+        if self.use_standard_tags != other.use_standard_tags:
+            return False
         if self._schema != other._schema:
             return False
         if isinstance(self._series, pd.Series):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -661,6 +661,25 @@ def test_accessor_equality(sample_series, sample_datetime_series):
         assert str_col.ww == changed_series.ww
 
 
+def test_accessor_equality_standard_tags(sample_series):
+    # Different standard tags values - using logical types with standard tags
+    no_standard_tags_series = sample_series.copy()
+    standard_tags_series = sample_series.copy()
+
+    no_standard_tags_series.ww.init(use_standard_tags=False)
+    standard_tags_series.ww.init(use_standard_tags=True)
+
+    assert no_standard_tags_series.ww.use_standard_tags != standard_tags_series.ww.use_standard_tags
+    assert no_standard_tags_series.ww != standard_tags_series.ww
+
+    # Different standard tags values - no logical types that have standard tags
+    no_standard_tags_series = init_series(sample_series.copy(), logical_type='NaturalLanguage', use_standard_tags=False)
+    standard_tags_series = init_series(sample_series.copy(), logical_type='NaturalLanguage', use_standard_tags=True)
+
+    assert no_standard_tags_series.ww.use_standard_tags != standard_tags_series.ww.use_standard_tags
+    assert no_standard_tags_series.ww != standard_tags_series.ww
+
+
 def test_accessor_metadata(sample_series):
     column_metadata = {'metadata_field': [1, 2, 3], 'created_by': 'user0'}
 


### PR DESCRIPTION
- Decided to keep `use_standard_tags` on the Accessor to avoid storing that value in multiple places in the TableSchema
- Closes #794 