### PR TITLE
Store use_standard_tags only on ColumnSchema

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -61,6 +61,7 @@ WoodworkColumnAccessor
     WoodworkColumnAccessor.semantic_tags
     WoodworkColumnAccessor.set_logical_type
     WoodworkColumnAccessor.set_semantic_tags
+    WoodworkColumnAccessor.use_standard_tags
 
 TableSchema
 ===========

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -38,6 +38,7 @@ WoodworkTableAccessor
     WoodworkTableAccessor.to_parquet
     WoodworkTableAccessor.to_pickle
     WoodworkTableAccessor.types
+    WoodworkTableAccessor.use_standard_tags
     WoodworkTableAccessor.value_counts
 
 WoodworkColumnAccessor
@@ -81,6 +82,7 @@ TableSchema
     TableSchema.set_types
     TableSchema.time_index
     TableSchema.types
+    TableSchema.use_standard_tags
 
 Serialization
 =============

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ Release Notes
         * Rename Schema object and files to match new table-column schema structure (:pr:`789`)
         * Store column typing information in a ``ColumnSchema`` object instead of a dictionary (:pr:`791`)
         * ``TableSchema`` does not use standard tags by default (:pr:`806`)
+        * Store ``use_standard_tags`` on the ``ColumnSchema`` instead of the ``TableSchema`` (:pr:`809`)
     * Documentation Changes
         * Update Pygments version requirement (:pr:`751`)
         * Update spark config for docs build (:pr:`787`, :pr:`801`, :pr:`810`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -53,11 +53,10 @@ class WoodworkColumnAccessor:
         logical_type = _get_column_logical_type(self._series, logical_type, self._series.name)
 
         self._validate_logical_type(logical_type)
-        self.use_standard_tags = use_standard_tags
 
         self._schema = ColumnSchema(logical_type=logical_type,
                                     semantic_tags=semantic_tags,
-                                    use_standard_tags=self.use_standard_tags,
+                                    use_standard_tags=use_standard_tags,
                                     description=description,
                                     metadata=metadata)
 
@@ -165,6 +164,8 @@ class WoodworkColumnAccessor:
     def __eq__(self, other):
         if self._schema != other._schema:
             return False
+        if self._series.name != other._series.name:
+            return False
         if isinstance(self._series, pd.Series):
             return self._series.equals(other._series)
         return True
@@ -207,7 +208,7 @@ class WoodworkColumnAccessor:
                                        semantic_tags=copy.deepcopy(self._schema.semantic_tags),
                                        description=self._schema.description,
                                        metadata=copy.deepcopy(self._schema.metadata),
-                                       use_standard_tags=self.use_standard_tags)
+                                       use_standard_tags=self._schema.use_standard_tags)
                     else:
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \
                             f'{valid_dtype}, and returned dtype, {result.dtype}'
@@ -263,7 +264,7 @@ class WoodworkColumnAccessor:
                                                            self.semantic_tags,
                                                            self._series.name,
                                                            self.logical_type.standard_tags,
-                                                           self.use_standard_tags)
+                                                           self._schema.use_standard_tags)
 
     def reset_semantic_tags(self):
         """Reset the semantic tags to the default values. The default values
@@ -276,7 +277,7 @@ class WoodworkColumnAccessor:
         if self._schema is None:
             _raise_init_error()
         self._schema.semantic_tags = _reset_semantic_tags(self.logical_type.standard_tags,
-                                                          self.use_standard_tags)
+                                                          self._schema.use_standard_tags)
 
     def set_logical_type(self, logical_type):
         """Update the logical type for the series, clearing any previously set semantic tags,
@@ -297,7 +298,7 @@ class WoodworkColumnAccessor:
         return init_series(new_series,
                            logical_type=logical_type,
                            semantic_tags=None,
-                           use_standard_tags=self.use_standard_tags,
+                           use_standard_tags=self._schema.use_standard_tags,
                            description=self.description,
                            metadata=copy.deepcopy(self.metadata))
 
@@ -313,7 +314,7 @@ class WoodworkColumnAccessor:
             _raise_init_error()
         self._schema.semantic_tags = _set_semantic_tags(semantic_tags,
                                                         self.logical_type.standard_tags,
-                                                        self.use_standard_tags)
+                                                        self._schema.use_standard_tags)
 
 
 def _raise_init_error():

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -161,6 +161,12 @@ class WoodworkColumnAccessor:
             _raise_init_error()
         return self._schema.semantic_tags
 
+    @property
+    def use_standard_tags(self):
+        if self._schema is None:
+            _raise_init_error()
+        return self._schema.use_standard_tags
+
     def __eq__(self, other):
         if self._schema != other._schema:
             return False
@@ -172,12 +178,9 @@ class WoodworkColumnAccessor:
 
     def __getattr__(self, attr):
         # If the method is present on the Accessor, uses that method.
-        # If the method is present on TableSchema, uses that method.
         # If the method is present on Series, uses that method.
         if self._schema is None:
             _raise_init_error()
-        if hasattr(self._schema, attr):
-            return self._make_schema_call(attr)
         if hasattr(self._series, attr):
             return self._make_series_call(attr)
         else:
@@ -191,17 +194,6 @@ class WoodworkColumnAccessor:
         msg += u"(Logical Type = {}) ".format(self.logical_type)
         msg += u"(Semantic Tags = {})>".format(self.semantic_tags)
         return msg
-
-    def _make_schema_call(self, attr):
-        """Forwards the requested attribute onto the schema object.
-        Results are that of the Woodwork.ColumnSchema class."""
-        schema_attr = getattr(self._schema, attr)
-
-        if callable(schema_attr):
-            def wrapper(*args, **kwargs):
-                return schema_attr(*args, **kwargs)
-            return wrapper
-        return schema_attr
 
     def _make_series_call(self, attr):
         """Forwards the requested attribute onto the series object. Intercepts return value,

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -193,7 +193,6 @@ class WoodworkColumnAccessor:
         return msg
 
     def _make_schema_call(self, attr):
-        # --> consider adding to accessor utils
         """Forwards the requested attribute onto the schema object.
         Results are that of the Woodwork.ColumnSchema class."""
         schema_attr = getattr(self._schema, attr)

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -42,10 +42,14 @@ class ColumnSchema(object):
         self.description = description
         self.logical_type = logical_type
 
+        self.use_standard_tags = use_standard_tags
+
         semantic_tags = _get_column_tags(semantic_tags, logical_type, use_standard_tags, validate)
         self.semantic_tags = semantic_tags
 
     def __eq__(self, other):
+        if self.use_standard_tags != other.use_standard_tags:
+            return False
         if self.logical_type != other.logical_type:
             return False
         if self.semantic_tags != other.semantic_tags:

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -95,6 +95,7 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
     semantic_tags = {}
     column_descriptions = {}
     column_metadata = {}
+    use_standard_tags = {}
     for col in table_typing_info['column_typing_info']:
         col_name = col['name']
 
@@ -112,6 +113,7 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
         semantic_tags[col_name] = tags
         column_descriptions[col_name] = col['description']
         column_metadata[col_name] = col['metadata']
+        use_standard_tags[col_name] = col['use_standard_tags']
 
     dataframe.ww.init(
         name=table_typing_info.get('name'),
@@ -119,7 +121,7 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
         time_index=table_typing_info.get('time_index'),
         logical_types=logical_types,
         semantic_tags=semantic_tags,
-        use_standard_tags=table_typing_info.get('use_standard_tags'),
+        use_standard_tags=use_standard_tags,
         table_metadata=table_typing_info.get('table_metadata'),
         column_metadata=column_metadata,
         column_descriptions=column_descriptions,

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -51,7 +51,7 @@ def _process_selection(selection, original_data):
                               semantic_tags=copy.deepcopy(schema.semantic_tags),
                               description=schema.description,
                               metadata=copy.deepcopy(schema.metadata),
-                              use_standard_tags=original_data.ww.use_standard_tags)
+                              use_standard_tags=schema.use_standard_tags)
     elif _is_dataframe(selection):
         # Selecting a new DataFrame from an existing DataFrame
         schema = original_data.ww.schema

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -17,7 +17,7 @@ from woodwork.utils import _is_s3, _is_url, import_or_none
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
 
-SCHEMA_VERSION = '7.0.0'
+SCHEMA_VERSION = '8.0.0'
 FORMATS = ['csv', 'pickle', 'parquet']
 
 
@@ -36,6 +36,7 @@ def typing_info_to_dict(dataframe):
     column_typing_info = [
         {'name': col_name,
          'ordinal': ordered_columns.get_loc(col_name),
+         'use_standard_tags': col.use_standard_tags,
          'logical_type': {
              'parameters': _get_specified_ltype_params(col.logical_type),
              'type': str(_get_ltype_class(col.logical_type))
@@ -45,7 +46,7 @@ def typing_info_to_dict(dataframe):
          },
          'semantic_tags': sorted(list(col.semantic_tags)),
          'description': col.description,
-         'metadata': col.metadata
+         'metadata': col.metadata,
          }
         for col_name, col in dataframe.ww.columns.items()
     ]
@@ -62,7 +63,6 @@ def typing_info_to_dict(dataframe):
         'name': dataframe.ww.name,
         'index': dataframe.ww.index,
         'time_index': dataframe.ww.time_index,
-        'use_standard_tags': dataframe.ww.use_standard_tags,
         'column_typing_info': column_typing_info,
         'loading_info': {
             'table_type': table_type

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -83,8 +83,11 @@ class WoodworkTableAccessor:
             table_metadata (dict[str -> json serializable], optional): Dictionary containing extra metadata for Woodwork.
             column_metadata (dict[str -> dict[str -> json serializable]], optional): Dictionary mapping column names
                 to that column's metadata dictionary.
-            use_standard_tags (bool, optional): If True, will add standard semantic tags to columns based
-                on the specified logical type for the column. Defaults to True.
+            use_standard_tags (bool, dict[str -> bool], optional): Determines whether standard semantic tags will be
+                added to columns based on the specified logical type for the column. 
+                If a single boolean is supplied, will apply the same use_standard_tags value to all columns.
+                A dictionary can be used to specify ``use_standard_tags`` values for individual columns.
+                Unspecified columns will use the default value. Defaults to True. 
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             schema (Woodwork.TableSchema, optional): Typing information to use for the DataFrame instead of performing inference.
                 Any other arguments provided will be ignored. Note that any changes made to the schema object after

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -84,10 +84,10 @@ class WoodworkTableAccessor:
             column_metadata (dict[str -> dict[str -> json serializable]], optional): Dictionary mapping column names
                 to that column's metadata dictionary.
             use_standard_tags (bool, dict[str -> bool], optional): Determines whether standard semantic tags will be
-                added to columns based on the specified logical type for the column. 
+                added to columns based on the specified logical type for the column.
                 If a single boolean is supplied, will apply the same use_standard_tags value to all columns.
                 A dictionary can be used to specify ``use_standard_tags`` values for individual columns.
-                Unspecified columns will use the default value. Defaults to True. 
+                Unspecified columns will use the default value. Defaults to True.
             column_descriptions (dict[str -> str], optional): Dictionary mapping column names to column descriptions.
             schema (Woodwork.TableSchema, optional): Typing information to use for the DataFrame instead of performing inference.
                 Any other arguments provided will be ignored. Note that any changes made to the schema object after
@@ -142,6 +142,7 @@ class WoodworkTableAccessor:
                     self._dataframe[name] = updated_series
 
             column_names = list(self._dataframe.columns)
+            # --> we need to pass in the full dict for use_standard_tags so that we use the correct default
             self._schema = TableSchema(column_names=column_names,
                                        logical_types=parsed_logical_types,
                                        index=index,

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -350,6 +350,13 @@ class WoodworkTableAccessor:
             _raise_init_error()
         return self._schema.time_index
 
+    @property
+    def use_standard_tags(self):
+        """Whether standard tags are used for each column in the table"""
+        if self._schema is None:
+            _raise_init_error()
+        return self._schema.use_standard_tags
+
     def set_index(self, new_index):
         """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
         and clears the tag from any previously set index column.

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -352,7 +352,7 @@ class WoodworkTableAccessor:
 
     @property
     def use_standard_tags(self):
-        """Whether standard tags are used for each column in the table"""
+        """A dictionary containing the use_standard_tags setting for each column in the table"""
         if self._schema is None:
             _raise_init_error()
         return self._schema.use_standard_tags

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -163,7 +163,6 @@ class TableSchema(object):
 
     @property
     def use_standard_tags(self):
-        # --> test this, add to api ref and accessor
         return {col_name: col.use_standard_tags for col_name, col in self.columns.items()}
 
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -163,7 +163,7 @@ class TableSchema(object):
 
     @property
     def use_standard_tags(self):
-        # --> test this
+        # --> test this, add to api ref and accessor
         return {col_name: col.use_standard_tags for col_name, col in self.columns.items()}
 
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -16,7 +16,6 @@ from woodwork.exceptions import (
 from woodwork.logical_types import (
     Categorical,
     CountryCode,
-    Datetime,
     Double,
     Integer,
     LatLong,
@@ -592,60 +591,28 @@ def test_latlong_formatting_with_init_series(latlongs):
         assert expected_series.ww._schema == new_series.ww._schema
 
 
-def test_accessor_equality(sample_series, sample_datetime_series):
+def test_accessor_equality(sample_series):
     # Check different parameters
     str_col = sample_series.copy()
     str_col.ww.init(logical_type='Categorical')
+
     str_col_2 = sample_series.copy()
     str_col_2.ww.init(logical_type=Categorical)
+
     str_col_diff_tags = sample_series.copy()
     str_col_diff_tags.ww.init(logical_type=Categorical, semantic_tags={'test'})
-    if ks and isinstance(sample_datetime_series, ks.Series):
-        diff_name_col = sample_datetime_series.astype('string')
-    else:
-        diff_name_col = sample_datetime_series.astype('category')
+
+    diff_name_col = sample_series.copy()
+    diff_name_col.name = 'different_name'
     diff_name_col.ww.init(logical_type=Categorical)
+
     diff_dtype_col = sample_series.astype('string')
     diff_dtype_col.ww.init(logical_type=NaturalLanguage)
-    diff_description_col = sample_series.copy()
-    diff_description_col.ww.init(logical_type='Categorical', description='description')
-    diff_metadata_col = sample_series.copy()
-    diff_metadata_col.ww.init(logical_type='Categorical', metadata={'interesting_values': ['a', 'b']})
 
     assert str_col.ww == str_col_2.ww
     assert str_col.ww != str_col_diff_tags.ww
-    if isinstance(str_col, pd.Series) and isinstance(diff_name_col, pd.Series):
-        # Name is from series, series equality checked only with Pandas input
-        assert str_col.ww != diff_name_col.ww
+    assert str_col.ww != diff_name_col.ww
     assert str_col.ww != diff_dtype_col.ww
-    assert str_col.ww != diff_description_col.ww
-    assert str_col.ww != diff_metadata_col.ww
-
-    # Check columns with same logical types but different parameters
-    ordinal_ltype_1 = Ordinal(order=['a', 'b', 'c'])
-    ordinal_ltype_2 = Ordinal(order=['b', 'a', 'c'])
-    ordinal_col_1 = sample_series.copy()
-    ordinal_col_2 = sample_series.copy()
-    ordinal_col_1.ww.init(logical_type=ordinal_ltype_1)
-    ordinal_col_2.ww.init(logical_type=ordinal_ltype_2)
-
-    assert str_col.ww != ordinal_col_1.ww
-    assert ordinal_col_1.ww != ordinal_col_2.ww
-    assert ordinal_col_1.ww == ordinal_col_1.ww
-
-    datetime_ltype_instantiated = Datetime(datetime_format='%Y-%m%d')
-    datetime_col_format = sample_datetime_series.astype('datetime64[ns]')
-    datetime_col_param = sample_datetime_series.astype('datetime64[ns]')
-    datetime_col_instantiated = sample_datetime_series.astype('datetime64[ns]')
-    datetime_col = sample_datetime_series.astype('datetime64[ns]')
-    datetime_col_format.ww.init(logical_type=datetime_ltype_instantiated)
-    datetime_col_param.ww.init(logical_type=Datetime(datetime_format=None))
-    datetime_col_instantiated.ww.init(logical_type=Datetime())
-    datetime_col.ww.init(logical_type=Datetime)
-
-    assert datetime_col.ww != datetime_col_instantiated.ww
-    assert datetime_col_instantiated.ww != datetime_col_format.ww
-    assert datetime_col_instantiated.ww == datetime_col_param.ww
 
     # Check different underlying series
     str_col = sample_series.astype('string')

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -19,7 +19,7 @@ ks = import_or_none('databricks.koalas')
 BUCKET_NAME = "test-bucket"
 WRITE_KEY_NAME = "test-key"
 TEST_S3_URL = "s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)
-TEST_FILE = "test_serialization_woodwork_table_schema_7.0.0.tar"
+TEST_FILE = "test_serialization_woodwork_table_schema_8.0.0.tar"
 S3_URL = "s3://woodwork-static/" + TEST_FILE
 URL = "https://woodwork-static.s3.amazonaws.com/" + TEST_FILE
 TEST_KEY = "test_access_key_es"
@@ -63,13 +63,13 @@ def test_to_dictionary(sample_df):
     string_val = 'string'
     bool_val = 'boolean'
 
-    expected = {'schema_version': '7.0.0',
+    expected = {'schema_version': '8.0.0',
                 'name': 'test_data',
                 'index': 'id',
                 'time_index': None,
-                'use_standard_tags': True,
                 'column_typing_info': [{'name': 'id',
                                         'ordinal': 0,
+                                        'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'Integer'},
                                         'physical_type': {'type': int_val},
                                         'semantic_tags': ['index', 'tag1'],
@@ -77,6 +77,7 @@ def test_to_dictionary(sample_df):
                                         'metadata':{'is_sorted': True}},
                                        {'name': 'full_name',
                                         'ordinal': 1,
+                                        'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
                                         'physical_type': {'type': string_val},
                                         'semantic_tags': [],
@@ -84,6 +85,7 @@ def test_to_dictionary(sample_df):
                                         'metadata':{}},
                                        {'name': 'email',
                                         'ordinal': 2,
+                                        'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
                                         'physical_type': {'type': string_val},
                                         'semantic_tags': [],
@@ -91,6 +93,7 @@ def test_to_dictionary(sample_df):
                                         'metadata':{}},
                                        {'name': 'phone_number',
                                         'ordinal': 3,
+                                        'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
                                         'physical_type': {'type': string_val},
                                         'semantic_tags': [],
@@ -98,6 +101,7 @@ def test_to_dictionary(sample_df):
                                         'metadata': {}},
                                        {'name': 'age',
                                         'ordinal': 4,
+                                        'use_standard_tags': True,
                                         'logical_type': {'parameters': {'order': [25, 33, 57]}, 'type': 'Ordinal'},
                                         'physical_type': {'type': cat_val},
                                         'semantic_tags': ['category'],
@@ -105,6 +109,7 @@ def test_to_dictionary(sample_df):
                                         'metadata':{'interesting_values': [33, 57]}},
                                        {'name': 'signup_date',
                                         'ordinal': 5,
+                                        'use_standard_tags': True,
                                         'logical_type': {'parameters': {},
                                                          'type': 'Datetime'},
                                         'physical_type': {'type': 'datetime64[ns]'},
@@ -113,6 +118,7 @@ def test_to_dictionary(sample_df):
                                         'metadata':{}},
                                        {'name': 'is_registered',
                                         'ordinal': 6,
+                                        'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'Boolean'},
                                         'physical_type': {'type': bool_val},
                                         'semantic_tags': [],

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1973,7 +1973,7 @@ def test_accessor_schema_properties(sample_df):
     sample_df.ww.init(index='id',
                       time_index='signup_date')
 
-    schema_properties = ['logical_types', 'semantic_tags', 'index', 'time_index']
+    schema_properties = ['logical_types', 'semantic_tags', 'index', 'time_index', 'use_standard_tags']
     for schema_property in schema_properties:
         prop_from_accessor = getattr(sample_df.ww, schema_property)
         prop_from_schema = getattr(sample_df.ww.schema, schema_property)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -10,7 +10,6 @@ from woodwork.accessor_utils import init_series
 from woodwork.exceptions import (
     ColumnNotPresentError,
     ParametersIgnoredWarning,
-    StandardTagsChangedWarning,
     TypeConversionError,
     TypingInfoMismatchWarning
 )
@@ -39,6 +38,7 @@ from woodwork.table_accessor import (
     _check_logical_types,
     _check_time_index,
     _check_unique_column_names,
+    _check_use_standard_tags,
     _get_invalid_schema_message
 )
 from woodwork.table_schema import TableSchema
@@ -106,6 +106,12 @@ def test_check_unique_column_names_errors(sample_df):
         duplicate_cols_df.insert(0, 'age', [18, 21, 65, 43], allow_duplicates=True)
     with pytest.raises(IndexError, match='Dataframe cannot contain duplicate columns names'):
         _check_unique_column_names(duplicate_cols_df)
+
+
+def test_check_use_standard_tags_errors():
+    error_message = 'use_standard_tags must be a dictionary or a boolean'
+    with pytest.raises(TypeError, match=error_message):
+        _check_use_standard_tags(1)
 
 
 def test_accessor_init(sample_df):
@@ -2044,7 +2050,8 @@ def test_setitem_new_column(sample_df):
     assert 'test_col2' in df.columns
     assert 'test_col2' in df.ww._schema.columns.keys()
     assert df.ww['test_col2'].ww.logical_type == Integer
-    assert df.ww['test_col2'].ww.semantic_tags == set()
+    assert df.ww['test_col2'].ww.use_standard_tags is True
+    assert df.ww['test_col2'].ww.semantic_tags == {'numeric'}
     assert df.ww['test_col2'].name == 'test_col2'
     assert df.ww['test_col2'].dtype == dtype
 
@@ -2062,6 +2069,7 @@ def test_setitem_new_column(sample_df):
     df.ww['test_col3'] = new_series
     assert 'test_col3' in df.ww.columns
     assert df.ww['test_col3'].ww.logical_type == Double
+    assert df.ww['test_col3'].ww.use_standard_tags is False
     assert df.ww['test_col3'].ww.semantic_tags == {'test_tag'}
     assert df.ww['test_col3'].name == 'test_col3'
     assert df.ww['test_col3'].dtype == 'float'
@@ -2081,6 +2089,7 @@ def test_setitem_new_column(sample_df):
     df.ww['test_col'] = new_series
     assert 'test_col' in df.ww.columns
     assert df.ww['test_col'].ww.logical_type == Categorical
+    assert df.ww['test_col'].ww.use_standard_tags is True
     assert df.ww['test_col'].ww.semantic_tags == {'category'}
     assert df.ww['test_col'].name == 'test_col'
     assert df.ww['test_col'].dtype == dtype
@@ -2123,14 +2132,13 @@ def test_setitem_overwrite_column(sample_df):
         semantic_tags='test_tag',
     )
 
-    match = 'Standard tags have been added to "full_name"'
-    with pytest.warns(StandardTagsChangedWarning, match=match):
-        df.ww['full_name'] = new_series
+    df.ww['full_name'] = new_series
 
     assert 'full_name' in df.columns
     assert 'full_name' in df.ww._schema.columns.keys()
     assert df.ww['full_name'].ww.logical_type == Double
-    assert df.ww['full_name'].ww.semantic_tags == {'test_tag', 'numeric'}
+    assert df.ww['full_name'].ww.use_standard_tags is False
+    assert df.ww['full_name'].ww.semantic_tags == {'test_tag'}
     assert df.ww['full_name'].dtype == 'float'
     assert original_col is not df.ww['full_name']
 
@@ -2148,14 +2156,13 @@ def test_setitem_overwrite_column(sample_df):
         semantic_tags='test_tag',
     )
 
-    match = 'Standard tags have been removed from your column'
-    with pytest.warns(StandardTagsChangedWarning, match=match):
-        df.ww['full_name'] = new_series
+    df.ww['full_name'] = new_series
 
     assert 'full_name' in df.columns
     assert 'full_name' in df.ww._schema.columns.keys()
     assert df.ww['full_name'].ww.logical_type == Double
-    assert df.ww['full_name'].ww.semantic_tags == {'test_tag'}
+    assert df.ww['full_name'].ww.use_standard_tags is True
+    assert df.ww['full_name'].ww.semantic_tags == {'test_tag', 'numeric'}
     assert df.ww['full_name'].dtype == 'float'
     assert original_col is not df.ww['full_name']
 

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -200,3 +200,37 @@ def test_reset_semantic_tags_returns_new_object():
     reset_tags = _reset_semantic_tags(standard_tags, use_standard_tags=True)
     assert reset_tags is not standard_tags
     assert reset_tags == standard_tags
+
+
+def test_schema_equality():
+    col = ColumnSchema(logical_type=Categorical)
+    diff_description_col = ColumnSchema(logical_type=Categorical, description='description')
+    diff_metadata_col = ColumnSchema(logical_type=Categorical, metadata={'interesting_values': ['a', 'b']})
+    use_standard_tags_col = ColumnSchema(logical_type=Categorical, use_standard_tags=True)
+    diff_tags_col = ColumnSchema(logical_type=Categorical, semantic_tags={'new_tag'})
+
+    assert col != diff_description_col
+    assert col != diff_metadata_col
+    assert col != use_standard_tags_col
+    assert col != diff_tags_col
+
+    # Check columns with same logical types but different parameters
+    ordinal_ltype_1 = Ordinal(order=['a', 'b', 'c'])
+    ordinal_ltype_2 = Ordinal(order=['b', 'a', 'c'])
+    ordinal_col_1 = ColumnSchema(logical_type=ordinal_ltype_1)
+    ordinal_col_2 = ColumnSchema(logical_type=ordinal_ltype_2)
+
+    assert col != ordinal_col_1
+    assert ordinal_col_1 != ordinal_col_2
+    assert ordinal_col_1 == ordinal_col_1
+
+    datetime_ltype_instantiated = Datetime(datetime_format='%Y-%m%d')
+
+    datetime_col_format = ColumnSchema(logical_type=datetime_ltype_instantiated)
+    datetime_col_param = ColumnSchema(logical_type=Datetime(datetime_format=None))
+    datetime_col_instantiated = ColumnSchema(logical_type=Datetime())
+    datetime_col = ColumnSchema(logical_type=Datetime)
+
+    assert datetime_col != datetime_col_instantiated
+    assert datetime_col_instantiated != datetime_col_format
+    assert datetime_col_instantiated == datetime_col_param

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -333,7 +333,6 @@ def test_filter_schema_non_string_cols():
 
 
 def test_get_subset_schema(sample_column_names, sample_inferred_logical_types):
-    # --> maybe test with weird use_standard_tags values??
     schema = TableSchema(sample_column_names, sample_inferred_logical_types)
     new_schema = schema._get_subset_schema(sample_column_names[1:4])
     for col in new_schema.columns:

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -333,6 +333,7 @@ def test_filter_schema_non_string_cols():
 
 
 def test_get_subset_schema(sample_column_names, sample_inferred_logical_types):
+    # --> maybe test with weird use_standard_tags values??
     schema = TableSchema(sample_column_names, sample_inferred_logical_types)
     new_schema = schema._get_subset_schema(sample_column_names[1:4])
     for col in new_schema.columns:

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -430,7 +430,7 @@ def test_use_standard_tags_from_bool(sample_column_names, sample_inferred_logica
 
 
 def test_use_standard_tags_from_dict(sample_column_names, sample_inferred_logical_types):
-    default_schema = TableSchema(sample_column_names, sample_inferred_logical_types)
+    default_schema = TableSchema(sample_column_names, sample_inferred_logical_types, use_standard_tags={col_name: False for col_name in sample_column_names})
     assert default_schema.use_standard_tags == {col_name: False for col_name in sample_column_names}
 
     use_standard_tags = {'id': True,

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -413,3 +413,49 @@ def test_validation_methods_called(mock_validate_params, mock_check_index,
     assert mock_validate_not_setting_index.called
 
     assert validated_schema == not_validated_schema
+
+
+def test_use_standard_tags_from_bool(sample_column_names, sample_inferred_logical_types):
+    standard_tags_schema = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                       use_standard_tags=True)
+    assert set(standard_tags_schema.columns.keys()) == set(standard_tags_schema.use_standard_tags.keys())
+    assert all([*standard_tags_schema.use_standard_tags.values()])
+    assert standard_tags_schema.semantic_tags['id'] == {'numeric'}
+
+    no_standard_tags_schema = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                          use_standard_tags=False)
+    assert set(no_standard_tags_schema.columns.keys()) == set(no_standard_tags_schema.use_standard_tags.keys())
+    assert not any([*no_standard_tags_schema.use_standard_tags.values()])
+    assert no_standard_tags_schema.semantic_tags['id'] == set()
+
+
+def test_use_standard_tags_from_dict(sample_column_names, sample_inferred_logical_types):
+    default_schema = TableSchema(sample_column_names, sample_inferred_logical_types)
+    assert default_schema.use_standard_tags == {col_name: False for col_name in sample_column_names}
+
+    use_standard_tags = {'id': True,
+                         'full_name': False,
+                         'email': True,
+                         'phone_number': True,
+                         'age': False,
+                         'signup_date': True,
+                         'is_registered': False}
+    full_dict_schema = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                   use_standard_tags=use_standard_tags)
+    assert full_dict_schema.use_standard_tags == use_standard_tags
+
+    partial_dict_schema = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                      use_standard_tags={'id': True,
+                                                         'email': True,
+                                                         'phone_number': True,
+                                                         'signup_date': True})
+    assert full_dict_schema.use_standard_tags == partial_dict_schema.use_standard_tags
+    assert full_dict_schema == partial_dict_schema
+
+    partial_dict_default_schema = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                              use_standard_tags={'id': False,
+                                                                 'email': False,
+                                                                 'phone_number': False,
+                                                                 'signup_date': False})
+    assert default_schema.use_standard_tags == partial_dict_default_schema.use_standard_tags
+    assert default_schema == partial_dict_default_schema

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -430,7 +430,8 @@ def test_use_standard_tags_from_bool(sample_column_names, sample_inferred_logica
 
 
 def test_use_standard_tags_from_dict(sample_column_names, sample_inferred_logical_types):
-    default_schema = TableSchema(sample_column_names, sample_inferred_logical_types, use_standard_tags={col_name: False for col_name in sample_column_names})
+    default_schema = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                 use_standard_tags={col_name: False for col_name in sample_column_names})
     assert default_schema.use_standard_tags == {col_name: False for col_name in sample_column_names}
 
     use_standard_tags = {'id': True,

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -21,6 +21,7 @@ from woodwork.table_schema import (
     _check_semantic_tags,
     _check_table_metadata,
     _check_time_index,
+    _check_use_standard_tags,
     _validate_params
 )
 
@@ -36,7 +37,8 @@ def test_validate_params_errors(sample_column_names):
                          table_metadata=None,
                          column_metadata=None,
                          semantic_tags=None,
-                         column_descriptions=None)
+                         column_descriptions=None,
+                         use_standard_tags=False)
 
 
 def test_check_index_errors(sample_column_names):
@@ -160,6 +162,20 @@ def test_check_column_description_errors(sample_column_names):
     err_msg = re.escape("column_descriptions contains columns that do not exist: ['invalid_col']")
     with pytest.raises(LookupError, match=err_msg):
         _check_column_descriptions(sample_column_names, column_descriptions=column_descriptions)
+
+
+def test_check_use_standard_tags_errors(sample_column_names):
+    error_message = 'use_standard_tags must be a dictionary or a boolean'
+    with pytest.raises(TypeError, match=error_message):
+        _check_use_standard_tags(sample_column_names, use_standard_tags=1)
+
+    error_message = re.escape("use_standard_tags contains columns that do not exist: ['invalid_col']")
+    with pytest.raises(LookupError, match=error_message):
+        _check_use_standard_tags(sample_column_names, use_standard_tags={'invalid_col': True})
+
+    error_message = "use_standard_tags for column id must be a boolean"
+    with pytest.raises(TypeError, match=error_message):
+        _check_use_standard_tags(sample_column_names, use_standard_tags={'id': 1})
 
 
 def test_schema_init(sample_column_names, sample_inferred_logical_types):


### PR DESCRIPTION
- This PR stops storing `use_standard_tags` on the `TableSchema` and stores it only on `ColumnSchema`. This causes a few changes:
  - Different columns in Woodwork can have different use_standard_tags values within the same table
  - At init, use_standard_tags can either be a bool or a dict[str -> bool] . Any columns not included in the dictionary will default to the default use_standard_tags value
  - If a user is setting a new series without Woodwork initialized with df.ww['new_col'] = pd.Series(), the use_standard_tags value will be the default `True` instead of following the wider Table's setting
  - Serialization has changed
- Closes #794 