### PR TITLE
Update latest unit tests to test koalas, dask, pandas separately

### DIFF
--- a/.github/workflows/latest_unit_tests.yml
+++ b/.github/workflows/latest_unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9"]
-        optional_libraries: ["minimal", "optional"]
+        libraries: ["core", "dask", "koalas"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -86,26 +86,30 @@ jobs:
         run: |
           pip config --site set global.progress_bar off
           python -m pip install --upgrade pip
-      - if: ${{ matrix.optional_libraries != 'optional' }}
-        name: Install woodwork with test requirements
+      - name: Install woodwork - tests requirements
         run: |
           python -m pip install -e unpacked_sdist/
+      - name: Install woodwork - tests requirements
+        run: |
           python -m pip install -r unpacked_sdist/test-requirements.txt
-      - if: ${{ matrix.optional_libraries == 'optional' }}
-        name: Install woodwork with test and optional requirements
+      - if: ${{ matrix.libraries == 'koalas' }}
+        name: Install woodwork - koalas requirements
         run: |
           sudo apt update
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
-          python -m pip install -e unpacked_sdist/[dask]
+
           python -m pip install -e unpacked_sdist/[koalas]
-          python -m pip install -r unpacked_sdist/test-requirements.txt
-      - if: ${{ matrix.python_version != 3.7 || matrix.optional_libraries != 'optional' }}
+      - if: ${{ matrix.libraries == 'dask' }}
+        name: Install woodwork - dask requirements
+        run: |
+          python -m pip install -e unpacked_sdist/[dask]
+      - if: ${{ matrix.python_version != 3.6 }}
         name: Run unit tests (no code coverage)
         run: |
           cd unpacked_sdist
           pytest woodwork/ -n 2
-      - if: ${{ matrix.python_version == 3.7 && matrix.optional_libraries == 'optional' }}
+      - if: ${{ matrix.python_version == 3.7 }}
         name: Run unit tests with code coverage
         run: |
           python -m pip install "$(cat dev-requirements.txt | grep codecov)"
@@ -113,7 +117,7 @@ jobs:
           cd unpacked_sdist/
           coverage erase
           pytest woodwork/ -n 2 --cov=woodwork --cov-config=../.coveragerc
-      - if: ${{ matrix.python_version == 3.7 && matrix.optional_libraries == 'optional' }}
+      - if: ${{ matrix.python_version == 3.7 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/latest_unit_tests.yml
+++ b/.github/workflows/latest_unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9"]
-        libraries: ["core", "dask", "koalas"]
+        libraries: ["pandas", "dask", "koalas"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/latest_unit_tests.yml
+++ b/.github/workflows/latest_unit_tests.yml
@@ -103,7 +103,7 @@ jobs:
         name: Install woodwork - dask requirements
         run: |
           python -m pip install -e unpacked_sdist/[dask]
-      - if: ${{ matrix.python_version != 3.6 }}
+      - if: ${{ matrix.python_version != 3.7 }}
         name: Run unit tests (no code coverage)
         run: |
           cd unpacked_sdist

--- a/.github/workflows/latest_unit_tests.yml
+++ b/.github/workflows/latest_unit_tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: make lint
 
   unit_latest_tests:
-    name: ${{ matrix.python_version }} unit tests ${{ matrix.optional_libraries }}
+    name: ${{ matrix.python_version }} unit tests ${{ matrix.libraries }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -86,7 +86,7 @@ jobs:
         run: |
           pip config --site set global.progress_bar off
           python -m pip install --upgrade pip
-      - name: Install woodwork - tests requirements
+      - name: Install woodwork - requirements
         run: |
           python -m pip install -e unpacked_sdist/
       - name: Install woodwork - tests requirements
@@ -98,7 +98,6 @@ jobs:
           sudo apt update
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
-
           python -m pip install -e unpacked_sdist/[koalas]
       - if: ${{ matrix.libraries == 'dask' }}
         name: Install woodwork - dask requirements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -31,6 +31,7 @@ Release Notes
     * Testing Changes
         * Add unit tests against minimum dependencies for python 3.6 on PRs and main (:pr:`743`, :pr:`753`, :pr:`763`)
         * Update spark config for test fixtures (:pr:`787`)
+        * Separate latest unit tests into pandas, dask, koalas (:pr:`813`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`


### PR DESCRIPTION
- Similar to the minimum unit tests, the latest unit tests now run with koalas, dask, pandas separately
- Codecov will automatically combine the code coverage reports from multiple runs (in this case its from pandas, dask, koalas runs on Python 3.7)