### PR TITLE
Allow initializing a WoodworkColumnAccessor with a ColumnSchema

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,7 @@ Release Notes
         * Add optional ``exclude`` parameter to WoodworkTableAccessor ``select`` method (:pr:`783`)
         * Add validation control to ``deserialize.read_woodwork_table`` and ``ww.read_csv`` (:pr:`788`)
         * Add ``WoodworkColumnAccessor.schema`` and handle copying column schema (:pr:`799`)
+        * Allow initializing a ``WoodworkColumnAccessor`` with a ``ColumnSchema`` (:pr:`814`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -32,7 +32,8 @@ class WoodworkColumnAccessor:
         self._schema = None
 
     def init(self, logical_type=None, semantic_tags=None,
-             use_standard_tags=True, description=None, metadata=None):
+             use_standard_tags=True, description=None, metadata=None,
+             schema=None):
         """Initializes Woodwork typing information for a Series.
 
         Args:
@@ -49,21 +50,31 @@ class WoodworkColumnAccessor:
                 based on the inferred or specified logical type of the series. Defaults to True.
             description (str, optional): Optional text describing the contents of the series.
             metadata (dict[str -> json serializable], optional): Metadata associated with the series.
+            schema (Woodwork.TableSchema, optional): Typing information to use for the Series instead of performing inference.
+                Any other arguments provided will be ignored. Note that any changes made to the schema object after
+                initialization will propagate to the Series. Similarly, to avoid unintended typing information changes,
+                the same schema object should not be shared between Series.
         """
-        logical_type = _get_column_logical_type(self._series, logical_type, self._series.name)
 
-        self._validate_logical_type(logical_type)
+        if schema is not None:
+            # --> implement validation - check that it's the correct type and that it matches the series!
+            # _validate_schema(schema)
+            # --> confirm other parameters aren't being passed in
 
-        self._schema = ColumnSchema(logical_type=logical_type,
-                                    semantic_tags=semantic_tags,
-                                    use_standard_tags=use_standard_tags,
-                                    description=description,
-                                    metadata=metadata)
+            self._schema = schema
+        else:
+            logical_type = _get_column_logical_type(self._series, logical_type, self._series.name)
+
+            self._validate_logical_type(logical_type)
+
+            self._schema = ColumnSchema(logical_type=logical_type,
+                                        semantic_tags=semantic_tags,
+                                        use_standard_tags=use_standard_tags,
+                                        description=description,
+                                        metadata=metadata)
 
     @property
     def schema(self):
-        if self._schema is None:
-            _raise_init_error()
         return copy.deepcopy(self._schema)
 
     @property

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -236,11 +236,7 @@ class WoodworkColumnAccessor:
                 if _is_series(result):
                     valid_dtype = _get_valid_dtype(type(result), self._schema.logical_type)
                     if str(result.dtype) == valid_dtype:
-                        result.ww.init(logical_type=self._schema.logical_type,
-                                       semantic_tags=copy.deepcopy(self._schema.semantic_tags),
-                                       description=self._schema.description,
-                                       metadata=copy.deepcopy(self._schema.metadata),
-                                       use_standard_tags=self._schema.use_standard_tags)
+                        result.ww.init(schema=self.schema)
                     else:
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \
                             f'{valid_dtype}, and returned dtype, {result.dtype}'

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -53,7 +53,7 @@ class WoodworkColumnAccessor:
                 based on the inferred or specified logical type of the series. Defaults to True.
             description (str, optional): Optional text describing the contents of the series.
             metadata (dict[str -> json serializable], optional): Metadata associated with the series.
-            schema (Woodwork.TableSchema, optional): Typing information to use for the Series instead of performing inference.
+            schema (Woodwork.ColumnSchema, optional): Typing information to use for the Series instead of performing inference.
                 Any other arguments provided will be ignored. Note that any changes made to the schema object after
                 initialization will propagate to the Series. Similarly, to avoid unintended typing information changes,
                 the same schema object should not be shared between Series.

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -42,16 +42,14 @@ def _process_selection(selection, original_data):
         elif _is_dataframe(original_data):
             # Selecting a single column from a DataFrame
             schema = original_data.ww.schema.columns[selection.name]
-            schema.semantic_tags = schema.semantic_tags - {'index'} - {'time_index'}
+            schema.semantic_tags = (schema.semantic_tags - {'index'} - {'time_index'})
+            if schema.use_standard_tags:
+                schema.semantic_tags |= schema.logical_type.standard_tags
         else:
             # Selecting a new Series from an existing Series
             schema = original_data.ww._schema
         if schema:
-            selection.ww.init(logical_type=schema.logical_type,
-                              semantic_tags=copy.deepcopy(schema.semantic_tags),
-                              description=schema.description,
-                              metadata=copy.deepcopy(schema.metadata),
-                              use_standard_tags=schema.use_standard_tags)
+            selection.ww.init(schema=copy.deepcopy(schema))
     elif _is_dataframe(selection):
         # Selecting a new DataFrame from an existing DataFrame
         schema = original_data.ww.schema

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -42,7 +42,7 @@ def _process_selection(selection, original_data):
         elif _is_dataframe(original_data):
             # Selecting a single column from a DataFrame
             schema = original_data.ww.schema.columns[selection.name]
-            schema.semantic_tags = (schema.semantic_tags - {'index'} - {'time_index'})
+            schema.semantic_tags = schema.semantic_tags - {'index'} - {'time_index'}
             if schema.use_standard_tags:
                 schema.semantic_tags |= schema.logical_type.standard_tags
         else:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -111,6 +111,8 @@ class WoodworkTableAccessor:
                 extra_params.append('logical_types')
             if already_sorted:
                 extra_params.append('already_sorted')
+            if not use_standard_tags or isinstance(use_standard_tags, dict):
+                extra_params.append('use_standard_tags')
             for key in kwargs:
                 extra_params.append(key)
             if extra_params:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -205,12 +205,10 @@ class WoodworkTableAccessor:
         series = self._dataframe[key]
         column = copy.deepcopy(self._schema.columns[key])
         column.semantic_tags -= {'index', 'time_index'}
+        if column.use_standard_tags:
+            column.semantic_tags |= column.logical_type.standard_tags
 
-        series.ww.init(logical_type=column.logical_type,
-                       semantic_tags=copy.deepcopy(column.semantic_tags),
-                       description=column.description,
-                       metadata=copy.deepcopy(column.metadata),
-                       use_standard_tags=self.use_standard_tags[key])
+        series.ww.init(schema=column)
 
         return series
 
@@ -664,12 +662,7 @@ class WoodworkTableAccessor:
         series = self._dataframe.pop(column_name)
 
         # Initialize Woodwork typing info for series
-        col_schema = self._schema.columns[column_name]
-        series.ww.init(logical_type=col_schema.logical_type,
-                       semantic_tags=copy.deepcopy(col_schema.semantic_tags),
-                       description=col_schema.description,
-                       metadata=copy.deepcopy(col_schema.metadata),
-                       use_standard_tags=self.use_standard_tags[column_name])
+        series.ww.init(schema=self.schema.columns[column_name])
 
         # Update schema to not include popped column
         del self._schema.columns[column_name]

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -9,6 +9,7 @@ from woodwork.column_accessor import WoodworkColumnAccessor
 from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
     DuplicateTagsWarning,
+    ParametersIgnoredWarning,
     StandardTagsChangedWarning,
     TypeConversionError,
     TypingInfoMismatchWarning
@@ -45,7 +46,7 @@ def test_accessor_init(sample_series):
 
 def test_accessor_init_with_schema(sample_series):
     sample_series.ww.init(semantic_tags={'test_tag'}, description='this is a column')
-    schema = sample_series.ww._schema
+    schema = sample_series.ww.schema
 
     head_series = sample_series.head(2)
     assert head_series.ww.schema is None
@@ -64,41 +65,45 @@ def test_accessor_init_with_schema(sample_series):
     assert iloc_series.ww.semantic_tags == {'test_tag', 'category'}
     assert iloc_series.ww.logical_type == Categorical
 
-# --> add these back in
-# def test_accessor_init_with_schema_errors(sample_df):
-#     schema_df = sample_df.copy()
-#     schema_df.ww.init()
-#     schema = schema_df.ww.schema
 
-#     iloc_df = schema_df.iloc[:, :-1]
-#     assert iloc_df.ww.schema is None
+def test_accessor_init_with_schema_errors(sample_series):
+    sample_series.ww.init(semantic_tags={'test_tag'}, description='this is a column')
+    schema = sample_series.ww.schema
 
-#     error = 'Provided schema must be a Woodwork.TableSchema object.'
-#     with pytest.raises(TypeError, match=error):
-#         iloc_df.ww.init(schema=int)
+    head_series = sample_series.head(2)
+    assert head_series.ww.schema is None
 
-#     error = ("Woodwork typing information is not valid for this DataFrame: "
-#              "The following columns in the typing information were missing from the DataFrame: {'is_registered'}")
-#     with pytest.raises(ValueError, match=error):
-#         iloc_df.ww.init(schema=schema)
+    error = 'Provided schema must be a Woodwork.ColumnSchema object.'
+    with pytest.raises(TypeError, match=error):
+        head_series.ww.init(schema=int)
+
+    ltype_dtype = 'category'
+    if ks and isinstance(sample_series, ks.Series):
+        ltype_dtype = 'string'
+    error = f"dtype mismatch between Series dtype object, and Categorical dtype, {ltype_dtype}"
+
+    diff_dtype_series = sample_series.astype('object')
+    with pytest.raises(ValueError, match=error):
+        diff_dtype_series.ww.init(schema=schema)
 
 
-# def test_accessor_with_schema_parameter_warning(sample_df):
-#     schema_df = sample_df.copy()
-#     schema_df.ww.init(name='test_schema', semantic_tags={'id': 'test_tag'}, index='id')
-#     schema = schema_df.ww.schema
+def test_accessor_with_schema_parameter_warning(sample_series):
+    sample_series.ww.init(semantic_tags={'test_tag'}, description='this is a column')
+    schema = sample_series.ww.schema
 
-#     head_df = schema_df.head(2)
+    head_series = sample_series.head(2)
 
-#     warning = "A schema was provided and the following parameters were ignored: index, make_index, " \
-#               "time_index, logical_types, already_sorted, semantic_tags"
-#     with pytest.warns(ParametersIgnoredWarning, match=warning):
-#         head_df.ww.init(index='ignored_id', time_index="ignored_time_index", logical_types={'ignored': 'ltypes'},
-#                         make_index=True, already_sorted=True, semantic_tags={'ignored_id': 'ignored_test_tag'},
-#                         schema=schema)
+    warning = "A schema was provided and the following parameters were ignored: " \
+              "logical_type, semantic_tags, description, metadata, use_standard_tags"
+    with pytest.warns(ParametersIgnoredWarning, match=warning):
+        head_series.ww.init(logical_type=Integer, semantic_tags={'ignored_test_tag'},
+                            description='an ignored description', metadata={'user_id': 'user1'},
+                            use_standard_tags=False, schema=schema)
 
-#     assert head_df.ww.name == 'test_schema'
-#     assert head_df.ww.semantic_tags['id'] == {'index', 'test_tag'}
+    assert head_series.ww.semantic_tags == {'category', 'test_tag'}
+    assert head_series.ww.logical_type == Categorical
+    assert head_series.ww.description == 'this is a column'
+    assert head_series.ww.metadata == {}
 
 
 def test_accessor_init_with_logical_type(sample_series):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -43,6 +43,64 @@ def test_accessor_init(sample_series):
     assert sample_series.ww.semantic_tags == {'category'}
 
 
+def test_accessor_init_with_schema(sample_series):
+    sample_series.ww.init(semantic_tags={'test_tag'}, description='this is a column')
+    schema = sample_series.ww._schema
+
+    head_series = sample_series.head(2)
+    assert head_series.ww.schema is None
+    head_series.ww.init(schema=schema)
+
+    assert head_series.ww._schema is schema
+    assert head_series.ww.description == 'this is a column'
+    assert head_series.ww.semantic_tags == {'test_tag', 'category'}
+
+    iloc_series = sample_series.loc[[2, 3]]
+    assert iloc_series.ww.schema is None
+    iloc_series.ww.init(schema=schema)
+
+    assert iloc_series.ww._schema is schema
+    assert iloc_series.ww.description == 'this is a column'
+    assert iloc_series.ww.semantic_tags == {'test_tag', 'category'}
+    assert iloc_series.ww.logical_type == Categorical
+
+# --> add these back in
+# def test_accessor_init_with_schema_errors(sample_df):
+#     schema_df = sample_df.copy()
+#     schema_df.ww.init()
+#     schema = schema_df.ww.schema
+
+#     iloc_df = schema_df.iloc[:, :-1]
+#     assert iloc_df.ww.schema is None
+
+#     error = 'Provided schema must be a Woodwork.TableSchema object.'
+#     with pytest.raises(TypeError, match=error):
+#         iloc_df.ww.init(schema=int)
+
+#     error = ("Woodwork typing information is not valid for this DataFrame: "
+#              "The following columns in the typing information were missing from the DataFrame: {'is_registered'}")
+#     with pytest.raises(ValueError, match=error):
+#         iloc_df.ww.init(schema=schema)
+
+
+# def test_accessor_with_schema_parameter_warning(sample_df):
+#     schema_df = sample_df.copy()
+#     schema_df.ww.init(name='test_schema', semantic_tags={'id': 'test_tag'}, index='id')
+#     schema = schema_df.ww.schema
+
+#     head_df = schema_df.head(2)
+
+#     warning = "A schema was provided and the following parameters were ignored: index, make_index, " \
+#               "time_index, logical_types, already_sorted, semantic_tags"
+#     with pytest.warns(ParametersIgnoredWarning, match=warning):
+#         head_df.ww.init(index='ignored_id', time_index="ignored_time_index", logical_types={'ignored': 'ltypes'},
+#                         make_index=True, already_sorted=True, semantic_tags={'ignored_id': 'ignored_test_tag'},
+#                         schema=schema)
+
+#     assert head_df.ww.name == 'test_schema'
+#     assert head_df.ww.semantic_tags['id'] == {'index', 'test_tag'}
+
+
 def test_accessor_init_with_logical_type(sample_series):
     series = sample_series.astype('string')
     series.ww.init(logical_type=NaturalLanguage)
@@ -78,7 +136,7 @@ def test_accessor_init_with_semantic_tags(sample_series):
 
 
 def test_error_accessing_properties_before_init(sample_series):
-    props_to_exclude = ['iloc', 'loc']
+    props_to_exclude = ['iloc', 'loc', 'schema']
     props = [prop for prop in dir(sample_series.ww) if is_property(WoodworkColumnAccessor, prop) and prop not in props_to_exclude]
 
     error = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -171,6 +171,15 @@ def test_loc_indices_column(sample_df):
     assert sliced_time_index.ww.semantic_tags == set()
 
 
+def test_indexer_uses_standard_tags(sample_df):
+    sample_df.ww.init(index='id', time_index='age', use_standard_tags={'id': False, 'age': True})
+    sliced_index = sample_df.ww.loc[:, 'id']
+    assert sliced_index.ww.semantic_tags == set()
+
+    sliced_time_index = sample_df.ww.loc[:, 'age']
+    assert sliced_time_index.ww.semantic_tags == {'numeric'}
+
+
 def test_iloc_with_properties(sample_df):
     if dd and isinstance(sample_df, dd.DataFrame):
         pytest.xfail('iloc is not supported with Dask inputs')

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -249,11 +249,11 @@ def test_accessor_with_schema_parameter_warning(sample_df):
     head_df = schema_df.head(2)
 
     warning = "A schema was provided and the following parameters were ignored: index, make_index, " \
-              "time_index, logical_types, already_sorted, semantic_tags"
+              "time_index, logical_types, already_sorted, use_standard_tags, semantic_tags"
     with pytest.warns(ParametersIgnoredWarning, match=warning):
         head_df.ww.init(index='ignored_id', time_index="ignored_time_index", logical_types={'ignored': 'ltypes'},
                         make_index=True, already_sorted=True, semantic_tags={'ignored_id': 'ignored_test_tag'},
-                        schema=schema)
+                        use_standard_tags={'id': True, 'age': False}, schema=schema)
 
     assert head_df.ww.name == 'test_schema'
     assert head_df.ww.semantic_tags['id'] == {'index', 'test_tag'}


### PR DESCRIPTION
- This PR allows `series.ww.init(schema=schema)` and updates relevant locations in Woodwork where this is useful
- Closes #795 