### PR TITLE
Add ColumnSchema repr

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
         * Add validation control to ``deserialize.read_woodwork_table`` and ``ww.read_csv`` (:pr:`788`)
         * Add ``WoodworkColumnAccessor.schema`` and handle copying column schema (:pr:`799`)
         * Allow initializing a ``WoodworkColumnAccessor`` with a ``ColumnSchema`` (:pr:`814`)
+        * Add ``__repr__`` to ``ColumnSchema`` (:pr:`817`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -21,7 +21,6 @@ class ColumnSchema(object):
         """Create ColumnSchema
 
         Args:
-            name (str, optional): The name of the column.
             logical_type (str, LogicalType, optional): The column's LogicalType.
             semantic_tags (str, list, set, optional): The semantic tag(s) specified for the column.
             use_standard_tags (boolean, optional): If True, will add standard semantic tags to the column based

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -61,6 +61,15 @@ class ColumnSchema(object):
 
         return True
 
+    def __repr__(self):
+        msg = "<ColumnSchema"
+        if self.logical_type is not None:
+            msg += u" (Logical Type = {})".format(self.logical_type)
+        if self.semantic_tags:
+            msg += u" (Semantic Tags = {})".format(sorted(list(self.semantic_tags)))
+        msg += ">"
+        return msg
+
 
 def _validate_logical_type(logical_type):
     ltype_class = _get_ltype_class(logical_type)

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -234,3 +234,14 @@ def test_schema_equality():
     assert datetime_col != datetime_col_instantiated
     assert datetime_col_instantiated != datetime_col_format
     assert datetime_col_instantiated == datetime_col_param
+
+
+def test_schema_repr():
+    assert (repr(ColumnSchema(logical_type=Datetime, semantic_tags='time_index')) ==
+            "<ColumnSchema (Logical Type = Datetime) (Semantic Tags = ['time_index'])>")
+    assert (repr(ColumnSchema(logical_type=Integer)) ==
+            "<ColumnSchema (Logical Type = Integer)>")
+    assert (repr(ColumnSchema(semantic_tags={'category', 'foreign_key'})) ==
+            "<ColumnSchema (Semantic Tags = ['category', 'foreign_key'])>")
+    assert (repr(ColumnSchema()) ==
+            "<ColumnSchema>")


### PR DESCRIPTION
- The repr only show logical type and semantic tags, and if either is not present, doesn't include it in the repr (treats empty semantic tags list as not present, which is good for Featuretools' use but not for the ColumnAccessor, so the Column Accessor will not inherit this behavior)
- Closes #798 

Note: This repr will be used to look at a Featuretools primitive's input and return types, so it's important that this is functional for that purpose.