### PR TITLE
Delete latest dependencies text files

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -34,7 +34,7 @@ Release Notes
         * Add unit tests against minimum dependencies for python 3.6 on PRs and main (:pr:`743`, :pr:`753`, :pr:`763`)
         * Update spark config for test fixtures (:pr:`787`)
         * Separate latest unit tests into pandas, dask, koalas (:pr:`813`)
-        * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`)
+        * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`, :pr:`819`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`

--- a/woodwork/tests/latest_core_dependencies.txt
+++ b/woodwork/tests/latest_core_dependencies.txt
@@ -1,5 +1,0 @@
-click==7.1.2
-numpy==1.20.2
-pandas==1.2.4
-pyarrow==3.0.0
-scikit-learn==0.24.1

--- a/woodwork/tests/latest_dask_dependencies.txt
+++ b/woodwork/tests/latest_dask_dependencies.txt
@@ -1,8 +1,0 @@
-click==7.1.2
-dask==2.30.0
-koalas==1.7.0
-numpy==1.19.5
-pandas==1.1.5
-pyarrow==3.0.0
-pyspark==3.1.1
-scikit-learn==0.24.1

--- a/woodwork/tests/latest_koalas_dependencies.txt
+++ b/woodwork/tests/latest_koalas_dependencies.txt
@@ -1,7 +1,0 @@
-click==7.1.2
-koalas==1.7.0
-numpy==1.19.5
-pandas==1.1.5
-pyarrow==3.0.0
-pyspark==3.1.1
-scikit-learn==0.24.1


### PR DESCRIPTION
- The latest dependency checker is create MRs and then closing them with no changes.
- This might be because the latest dependencies text files were not from another user.
- This MR attempts to fix this by deleting the files, and the latest dependencies checker will re-generate them.