### PR TITLE
Use virtualenv with latest dep checker, remove latest text files

### DIFF
--- a/.github/workflows/latest_dependency_check.yml
+++ b/.github/workflows/latest_dependency_check.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8.x'
-    - name: Install woodwork dependencies and test dependencies
+    - name: Install pip and virtualenv
       run: |
         python -m pip install --upgrade pip
         python -m pip install virtualenv

--- a/.github/workflows/latest_dependency_check.yml
+++ b/.github/workflows/latest_dependency_check.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m virtualenv venv_core
         source venv_core/bin/activate
+        python -m pip install --upgrade pip
         python -m pip install -e .
         python -m pip install -r test-requirements.txt
         make checkdeps OUTPUT_FILEPATH=woodwork/tests/latest_core_dependencies.txt
@@ -30,6 +31,7 @@ jobs:
       run: |
         python -m virtualenv venv_koalas
         source venv_koalas/bin/activate
+        python -m pip install --upgrade pip
         python -m pip install -e .
         python -m pip install -r test-requirements.txt
         python -m pip install -r koalas-requirements.txt
@@ -39,6 +41,7 @@ jobs:
       run: |
         python -m virtualenv venv_dask
         source venv_dask/bin/activate
+        python -m pip install --upgrade pip
         python -m pip install -e .
         python -m pip install -r test-requirements.txt
         python -m pip install -r dask-requirements.txt

--- a/.github/workflows/latest_dependency_check.yml
+++ b/.github/workflows/latest_dependency_check.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        libraries: ["core", "dask", "koalas"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
@@ -20,22 +17,30 @@ jobs:
     - name: Install woodwork dependencies and test dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install virtualenv
+    - name: Update latest core dependencies
+      run: |
+        python -m virtualenv venv_core
+        source venv_core/bin/activate
         python -m pip install -e .
         python -m pip install -r test-requirements.txt
-    - if: ${{ matrix.libraries == 'core' }}
-      name: Update latest core dependencies
-      run: |
         make checkdeps OUTPUT_FILEPATH=woodwork/tests/latest_core_dependencies.txt
         cat woodwork/tests/latest_core_dependencies.txt
-    - if: ${{ matrix.libraries == 'koalas' }}
-      name: Update latest koalas dependencies
+    - name: Update latest koalas dependencies
       run: |
+        python -m virtualenv venv_koalas
+        source venv_koalas/bin/activate
+        python -m pip install -e .
+        python -m pip install -r test-requirements.txt
         python -m pip install -r koalas-requirements.txt
         make checkdeps OUTPUT_FILEPATH=woodwork/tests/latest_koalas_dependencies.txt
         cat woodwork/tests/latest_koalas_dependencies.txt
-    - if: ${{ matrix.libraries == 'dask' }}
-      name: Update latest dask dependencies
+    - name: Update latest dask dependencies
       run: |
+        python -m virtualenv venv_dask
+        source venv_dask/bin/activate
+        python -m pip install -e .
+        python -m pip install -r test-requirements.txt
         python -m pip install -r dask-requirements.txt
         make checkdeps OUTPUT_FILEPATH=woodwork/tests/latest_dask_dependencies.txt
         cat woodwork/tests/latest_dask_dependencies.txt

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -34,7 +34,7 @@ Release Notes
         * Add unit tests against minimum dependencies for python 3.6 on PRs and main (:pr:`743`, :pr:`753`, :pr:`763`)
         * Update spark config for test fixtures (:pr:`787`)
         * Separate latest unit tests into pandas, dask, koalas (:pr:`813`)
-        * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`, :pr:`823`)
+        * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`, :pr:`825`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -34,7 +34,7 @@ Release Notes
         * Add unit tests against minimum dependencies for python 3.6 on PRs and main (:pr:`743`, :pr:`753`, :pr:`763`)
         * Update spark config for test fixtures (:pr:`787`)
         * Separate latest unit tests into pandas, dask, koalas (:pr:`813`)
-        * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`)
+        * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`, :pr:`823`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`

--- a/woodwork/tests/latest_core_dependencies.txt
+++ b/woodwork/tests/latest_core_dependencies.txt
@@ -1,5 +1,0 @@
-click==7.1.2
-numpy==1.20.2
-pandas==1.2.4
-pyarrow==3.0.0
-scikit-learn==0.24.1

--- a/woodwork/tests/latest_dask_dependencies.txt
+++ b/woodwork/tests/latest_dask_dependencies.txt
@@ -1,8 +1,0 @@
-click==7.1.2
-dask==2.30.0
-koalas==1.7.0
-numpy==1.19.5
-pandas==1.1.5
-pyarrow==3.0.0
-pyspark==3.1.1
-scikit-learn==0.24.1

--- a/woodwork/tests/latest_koalas_dependencies.txt
+++ b/woodwork/tests/latest_koalas_dependencies.txt
@@ -1,7 +1,0 @@
-click==7.1.2
-koalas==1.7.0
-numpy==1.19.5
-pandas==1.1.5
-pyarrow==3.0.0
-pyspark==3.1.1
-scikit-learn==0.24.1


### PR DESCRIPTION
- The latest dependency checker is create MRs and then closing them with no changes.
- This might be because the latest dependencies text files were not generated from machineFL.
- This also could be because there is a race condition.
- This MR attempts to fix this by deleting the files, and the latest dependencies checker will re-generate them. It also uses virtualenv and has removes the matrix configuration. 