### PR TITLE
Update release notes workflow

### DIFF
--- a/.github/workflows/release_notes_updated.yml
+++ b/.github/workflows/release_notes_updated.yml
@@ -16,7 +16,7 @@ jobs:
           from re import compile
           main = '^main$'
           release = '^release_v\d+\.\d+\.\d+$'
-          dep_update = '^dep-update-[a-f0-9]{7}$'
+          dep_update = '^latest-dep-update-[a-f0-9]{7}$'
           min_dep_update = '^min-dep-update-[a-f0-9]{7}$'
           regex = main, release, dep_update, min_dep_update
           patterns = list(map(compile, regex))

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,6 +35,7 @@ Release Notes
         * Update spark config for test fixtures (:pr:`787`)
         * Separate latest unit tests into pandas, dask, koalas (:pr:`813`)
         * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`, :pr:`825`)
+        * Ignore latest dependency branch when checking for updates to the release notes (:pr:`827`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`


### PR DESCRIPTION
The workflow was updated to check for the `latest-dep-update` branch