### PR TITLE
Expand ColumnSchema Tests

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -39,6 +39,7 @@ Release Notes
         * Update latest dependency checker to generate separate core, koalas, and dask dependencies (:pr:`815`, :pr:`825`)
         * Ignore latest dependency branch when checking for updates to the release notes (:pr:`827`)
         * Change from GitHub PAT to auto generated GitHub Token for dependency checker (:pr:`831`)
+        * Expand ``ColumnSchema`` semantic tag testing coverage and null ``logical_type`` testing coverage (:pr:`832`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -82,6 +82,7 @@ class ColumnSchema(object):
 
     @property
     def is_numeric(self):
+        # --> raises an error if no logical type - also add tests for null ltype
         """Whether the ColumnSchema is numeric in nature"""
         return 'numeric' in self.logical_type.standard_tags
 
@@ -126,8 +127,8 @@ class ColumnSchema(object):
         invalid_tags = sorted(list(tags_to_remove.difference(self.semantic_tags)))
         if invalid_tags:
             raise LookupError(f"Semantic tag(s) '{', '.join(invalid_tags)}' not present on column '{name}'")
-        standard_tags_to_remove = sorted(list(tags_to_remove.intersection(self.logical_type.standard_tags)))
-        if standard_tags_to_remove and self.use_standard_tags:
+
+        if self.use_standard_tags and sorted(list(tags_to_remove.intersection(self.logical_type.standard_tags))):
             warnings.warn(StandardTagsChangedWarning().get_warning_message(not self.use_standard_tags, name),
                           StandardTagsChangedWarning)
         self.semantic_tags = self.semantic_tags.difference(tags_to_remove)

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -82,14 +82,13 @@ class ColumnSchema(object):
 
     @property
     def is_numeric(self):
-        # --> raises an error if no logical type - also add tests for null ltype
         """Whether the ColumnSchema is numeric in nature"""
-        return 'numeric' in self.logical_type.standard_tags
+        return self.logical_type is not None and 'numeric' in self.logical_type.standard_tags
 
     @property
     def is_categorical(self):
         """Whether the ColumnSchema is categorical in nature"""
-        return 'category' in self.logical_type.standard_tags
+        return self.logical_type is not None and 'category' in self.logical_type.standard_tags
 
     @property
     def is_datetime(self):

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -8,9 +8,7 @@ from woodwork.accessor_utils import init_series
 from woodwork.column_accessor import WoodworkColumnAccessor
 from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
-    DuplicateTagsWarning,
     ParametersIgnoredWarning,
-    StandardTagsChangedWarning,
     TypeConversionError,
     TypingInfoMismatchWarning
 )
@@ -257,17 +255,7 @@ def test_accessor_repr_error_before_init(sample_series):
 
 def test_set_semantic_tags(sample_series):
     semantic_tags = {'tag1', 'tag2'}
-    sample_series.ww.init(semantic_tags=semantic_tags, use_standard_tags=False)
-    assert sample_series.ww.semantic_tags == semantic_tags
-
-    new_tags = ['new_tag']
-    sample_series.ww.set_semantic_tags(new_tags)
-    assert sample_series.ww.semantic_tags == set(new_tags)
-
-
-def test_set_semantic_tags_with_standard_tags(sample_series):
-    semantic_tags = {'tag1', 'tag2'}
-    sample_series.ww.init(semantic_tags=semantic_tags, use_standard_tags=True)
+    sample_series.ww.init(semantic_tags=semantic_tags)
     assert sample_series.ww.semantic_tags == semantic_tags.union({'category'})
 
     new_tags = ['new_tag']
@@ -307,38 +295,16 @@ def test_does_not_add_standard_tags():
 
 def test_add_custom_tags(sample_series):
     semantic_tags = 'initial_tag'
-    sample_series.ww.init(semantic_tags=semantic_tags, use_standard_tags=False)
+    sample_series.ww.init(semantic_tags=semantic_tags)
 
     sample_series.ww.add_semantic_tags('string_tag')
-    assert sample_series.ww.semantic_tags == {'initial_tag', 'string_tag'}
+    assert sample_series.ww.semantic_tags == {'initial_tag', 'string_tag', 'category'}
 
     sample_series.ww.add_semantic_tags(['list_tag'])
-    assert sample_series.ww.semantic_tags == {'initial_tag', 'string_tag', 'list_tag'}
+    assert sample_series.ww.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'category'}
 
     sample_series.ww.add_semantic_tags({'set_tag'})
-    assert sample_series.ww.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'set_tag'}
-
-
-def test_warns_on_adding_duplicate_tag(sample_series):
-    semantic_tags = ['first_tag', 'second_tag']
-    sample_series.ww.init(semantic_tags=semantic_tags, use_standard_tags=False)
-
-    expected_message = "Semantic tag(s) 'first_tag, second_tag' already present on column 'sample_series'"
-    with pytest.warns(DuplicateTagsWarning) as record:
-        sample_series.ww.add_semantic_tags(['first_tag', 'second_tag'])
-    assert len(record) == 1
-    assert record[0].message.args[0] == expected_message
-
-
-def test_set_logical_type_with_standard_tags(sample_series):
-    sample_series.ww.init(logical_type='Categorical',
-                          semantic_tags='original_tag',
-                          use_standard_tags=True)
-
-    new_series = sample_series.ww.set_logical_type('CountryCode')
-    assert sample_series.ww.logical_type == Categorical
-    assert new_series.ww.logical_type == CountryCode
-    assert new_series.ww.semantic_tags == {'category'}
+    assert sample_series.ww.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'set_tag', 'category'}
 
 
 def test_set_logical_type_without_standard_tags(sample_series):
@@ -383,16 +349,6 @@ def test_set_logical_type_invalid_dtype_change(sample_series):
         sample_series.ww.set_logical_type('Integer')
 
 
-def test_reset_semantic_tags_with_standard_tags(sample_series):
-    semantic_tags = 'initial_tag'
-    sample_series.ww.init(semantic_tags=semantic_tags,
-                          logical_type=Categorical,
-                          use_standard_tags=True)
-
-    sample_series.ww.reset_semantic_tags()
-    assert sample_series.ww.semantic_tags == Categorical.standard_tags
-
-
 def test_reset_semantic_tags_without_standard_tags(sample_series):
     semantic_tags = 'initial_tag'
     sample_series.ww.init(semantic_tags=semantic_tags, use_standard_tags=False)
@@ -410,37 +366,9 @@ def test_remove_semantic_tags(sample_series):
 
     for tag in tags_to_remove:
         series = sample_series.copy()
-        series.ww.init(semantic_tags=['tag1', 'tag2'], use_standard_tags=False)
+        series.ww.init(semantic_tags=['tag1', 'tag2'], use_standard_tags=True)
         series.ww.remove_semantic_tags(tag)
-        assert series.ww.semantic_tags == {'tag2'}
-
-
-def test_remove_standard_semantic_tag(sample_series):
-    series = sample_series.copy()
-    # Check that warning is raised if use_standard_tags is True - tag should be removed
-    series.ww.init(logical_type=Categorical, semantic_tags='tag1', use_standard_tags=True)
-    expected_message = 'Standard tags have been removed from "sample_series"'
-    with pytest.warns(StandardTagsChangedWarning) as record:
-        series.ww.remove_semantic_tags(['tag1', 'category'])
-    assert len(record) == 1
-    assert record[0].message.args[0] == expected_message
-    assert series.ww.semantic_tags == set()
-
-    # Check that warning is not raised if use_standard_tags is False - tag should be removed
-    series = sample_series.copy()
-    series.ww.init(logical_type=Categorical, semantic_tags=['category', 'tag1'], use_standard_tags=False)
-
-    with pytest.warns(None) as record:
-        series.ww.remove_semantic_tags(['tag1', 'category'])
-    assert len(record) == 0
-    assert series.ww.semantic_tags == set()
-
-
-def test_remove_semantic_tags_raises_error_with_invalid_tag(sample_series):
-    sample_series.ww.init(semantic_tags='tag1')
-    error_msg = re.escape("Semantic tag(s) 'invalid_tagname' not present on column 'sample_series'")
-    with pytest.raises(LookupError, match=error_msg):
-        sample_series.ww.remove_semantic_tags('invalid_tagname')
+        assert series.ww.semantic_tags == {'tag2', 'category'}
 
 
 def test_series_methods_on_accessor(sample_series):
@@ -542,7 +470,7 @@ def test_series_methods_on_accessor_other_returns(sample_series):
     assert series_nunique == ww_nunique
 
 
-def test_series_methods_on_accessor_new_schema_dict(sample_series):
+def test_series_methods_on_accessor_new_schema_object(sample_series):
     sample_series.ww.init(semantic_tags=['new_tag', 'tag2'], metadata={'important_keys': [1, 2, 3]})
 
     copied_series = sample_series.ww.copy()

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -10,6 +10,10 @@ from woodwork.column_schema import (
     _validate_logical_type,
     _validate_metadata
 )
+from woodwork.exceptions import (
+    DuplicateTagsWarning,
+    StandardTagsChangedWarning
+)
 from woodwork.logical_types import (
     Boolean,
     Categorical,
@@ -190,6 +194,92 @@ def test_is_datetime():
     assert not double_column.is_datetime
 
 
+def test_set_semantic_tags_no_standard_tags():
+    semantic_tags = {'tag1', 'tag2'}
+    schema = ColumnSchema(logical_type=Categorical, semantic_tags=semantic_tags)
+    assert schema.semantic_tags == semantic_tags
+
+    new_tag = ['new_tag']
+    schema._set_semantic_tags(new_tag)
+    assert schema.semantic_tags == set(new_tag)
+
+
+def test_set_semantic_tags_with_standard_tags():
+    semantic_tags = {'tag1', 'tag2'}
+    schema = ColumnSchema(logical_type=Categorical, semantic_tags=semantic_tags, use_standard_tags=True)
+    assert schema.semantic_tags == semantic_tags.union({'category'})
+
+    new_tag = ['new_tag']
+    schema._set_semantic_tags(new_tag)
+    assert schema.semantic_tags == set(new_tag).union({'category'})
+
+
+def test_set_semantic_tags_no_logical_type():
+    semantic_tags = {'tag1', 'tag2'}
+    schema = ColumnSchema(semantic_tags=semantic_tags, use_standard_tags=False)
+
+    new_tag = ['new_tag']
+    schema._set_semantic_tags(new_tag)
+    assert schema.semantic_tags == set(new_tag)
+
+
+def test_add_custom_tags():
+    semantic_tags = 'initial_tag'
+    schema = ColumnSchema(logical_type=Categorical, semantic_tags=semantic_tags, use_standard_tags=True)
+
+    schema._add_semantic_tags('string_tag', 'col_name')
+    assert schema.semantic_tags == {'initial_tag', 'string_tag', 'category'}
+
+    schema._add_semantic_tags(['list_tag'], 'col_name')
+    assert schema.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'category'}
+
+    schema._add_semantic_tags({'set_tag'}, 'col_name')
+    assert schema.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'set_tag', 'category'}
+
+
+def test_add_custom_tags_no_logical_type():
+    semantic_tags = 'initial_tag'
+    schema = ColumnSchema(semantic_tags=semantic_tags, use_standard_tags=False)
+
+    schema._add_semantic_tags('string_tag', 'col_name')
+    assert schema.semantic_tags == {'initial_tag', 'string_tag'}
+
+    schema._add_semantic_tags(['list_tag'], 'col_name')
+    assert schema.semantic_tags == {'initial_tag', 'string_tag', 'list_tag'}
+
+    schema._add_semantic_tags({'set_tag'}, 'col_name')
+    assert schema.semantic_tags == {'initial_tag', 'string_tag', 'list_tag', 'set_tag'}
+
+
+def test_warns_on_adding_duplicate_tag():
+    semantic_tags = ['first_tag', 'second_tag']
+    schema = ColumnSchema(logical_type=Categorical, semantic_tags=semantic_tags, use_standard_tags=False)
+
+    expected_message = "Semantic tag(s) 'first_tag, second_tag' already present on column 'col_name'"
+    with pytest.warns(DuplicateTagsWarning) as record:
+        schema._add_semantic_tags(['first_tag', 'second_tag'], 'col_name')
+    assert len(record) == 1
+    assert record[0].message.args[0] == expected_message
+
+
+def test_reset_semantic_tags_with_standard_tags():
+    semantic_tags = 'initial_tag'
+    schema = ColumnSchema(semantic_tags=semantic_tags,
+                          logical_type=Categorical,
+                          use_standard_tags=True)
+
+    schema._reset_semantic_tags()
+    assert schema.semantic_tags == Categorical.standard_tags
+
+
+def test_reset_semantic_tags_without_standard_tags():
+    semantic_tags = 'initial_tag'
+    schema = ColumnSchema(semantic_tags=semantic_tags, use_standard_tags=False)
+
+    schema._reset_semantic_tags()
+    assert schema.semantic_tags == set()
+
+
 def test_reset_semantic_tags_returns_new_object():
     schema = ColumnSchema(logical_type=Integer, semantic_tags=set(), use_standard_tags=True)
     standard_tags = Integer.standard_tags
@@ -197,6 +287,54 @@ def test_reset_semantic_tags_returns_new_object():
     schema._reset_semantic_tags()
     assert schema.semantic_tags is not standard_tags
     assert schema.semantic_tags == standard_tags
+
+
+def test_remove_semantic_tags():
+    # --> keep the equivalent with categorical ltype
+    tags_to_remove = [
+        'tag1',
+        ['tag1'],
+        {'tag1'}
+    ]
+
+    for tag in tags_to_remove:
+        schema = ColumnSchema(semantic_tags=['tag1', 'tag2'], use_standard_tags=False)
+        schema._remove_semantic_tags(tag, 'col_name')
+        assert schema.semantic_tags == {'tag2'}
+
+
+def test_remove_standard_semantic_tag():
+    # Check that warning is raised if use_standard_tags is True - tag should be removed
+    schema = ColumnSchema(logical_type=Categorical, semantic_tags='tag1', use_standard_tags=True)
+    expected_message = 'Standard tags have been removed from "col_name"'
+    with pytest.warns(StandardTagsChangedWarning) as record:
+        schema._remove_semantic_tags(['tag1', 'category'], 'col_name')
+    assert len(record) == 1
+    assert record[0].message.args[0] == expected_message
+    assert schema.semantic_tags == set()
+
+    # Check that warning is not raised if use_standard_tags is False - tag should be removed
+    schema = ColumnSchema(logical_type=Categorical, semantic_tags=['category', 'tag1'], use_standard_tags=False)
+
+    with pytest.warns(None) as record:
+        schema._remove_semantic_tags(['tag1', 'category'], 'col_name')
+    assert len(record) == 0
+    assert schema.semantic_tags == set()
+
+    # Check that warning is not raised if use_standard_tags is False and no Logical Type is specified
+    schema = ColumnSchema(semantic_tags=['category', 'tag1'], use_standard_tags=False)
+
+    with pytest.warns(None) as record:
+        schema._remove_semantic_tags(['tag1', 'category'], 'col_name')
+    assert len(record) == 0
+    assert schema.semantic_tags == set()
+
+
+def test_remove_semantic_tags_raises_error_with_invalid_tag():
+    schema = ColumnSchema(logical_type=Categorical, semantic_tags='tag1')
+    error_msg = re.escape("Semantic tag(s) 'invalid_tagname' not present on column 'col_name'")
+    with pytest.raises(LookupError, match=error_msg):
+        schema._remove_semantic_tags('invalid_tagname', 'col_name')
 
 
 def test_schema_equality():

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -145,6 +145,9 @@ def test_is_numeric():
     instantiated_column = ColumnSchema(logical_type=Integer())
     assert instantiated_column.is_numeric
 
+    empty_column = ColumnSchema()
+    assert not empty_column.is_numeric
+
 
 def test_is_categorical():
     categorical_column = ColumnSchema(logical_type=Categorical)
@@ -162,6 +165,9 @@ def test_is_categorical():
     no_standard_tags = ColumnSchema(logical_type=Categorical, use_standard_tags=False)
     assert no_standard_tags.is_categorical
 
+    empty_column = ColumnSchema()
+    assert not empty_column.is_categorical
+
 
 def test_is_boolean():
     boolean_column = ColumnSchema(logical_type=Boolean)
@@ -175,6 +181,9 @@ def test_is_boolean():
 
     nl_column = ColumnSchema(logical_type=NaturalLanguage)
     assert not nl_column.is_boolean
+
+    empty_column = ColumnSchema()
+    assert not empty_column.is_boolean
 
 
 def test_is_datetime():
@@ -192,6 +201,9 @@ def test_is_datetime():
 
     double_column = ColumnSchema(logical_type=Double)
     assert not double_column.is_datetime
+
+    empty_column = ColumnSchema()
+    assert not empty_column.is_datetime
 
 
 def test_set_semantic_tags_no_standard_tags():
@@ -290,7 +302,6 @@ def test_reset_semantic_tags_returns_new_object():
 
 
 def test_remove_semantic_tags():
-    # --> keep the equivalent with categorical ltype
     tags_to_remove = [
         'tag1',
         ['tag1'],


### PR DESCRIPTION
- There was a lot of testing logic for semantic tag updates that only existed on the `WoodworkColumnAccessor`, which meant that when making changes to any of the semantic tag update ColumnSchema methods you then had to run the column accessor tests.
- In moving over these tests, added extra checks for the `logical_type=None` case and discovered a few bugs in `is_numeric` `is_categorical` and `_remove_semantic_tags`, so added tests and fixed
- Closes #797 