### PR TITLE
Add validation control to column accessor init

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Add ``WoodworkColumnAccessor.schema`` and handle copying column schema (:pr:`799`)
         * Allow initializing a ``WoodworkColumnAccessor`` with a ``ColumnSchema`` (:pr:`814`)
         * Add ``__repr__`` to ``ColumnSchema`` (:pr:`817`)
+        * Add validation control to WoodworkColumnAccessor (:pr:`833`)
     * Fixes
     * Changes
         * Rename ``FullName`` logical type to ``PersonFullName`` (:pr:`740`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -32,7 +32,7 @@ class WoodworkColumnAccessor:
 
     def init(self, logical_type=None, semantic_tags=None,
              use_standard_tags=True, description=None, metadata=None,
-             schema=None):
+             schema=None, validate=True):
         """Initializes Woodwork typing information for a Series.
 
         Args:
@@ -53,10 +53,14 @@ class WoodworkColumnAccessor:
                 Any other arguments provided will be ignored. Note that any changes made to the schema object after
                 initialization will propagate to the Series. Similarly, to avoid unintended typing information changes,
                 the same schema object should not be shared between Series.
+            validate (bool, optional): Whether parameter and data validation should occur. Defaults to True. Warning:
+                Should be set to False only when parameters and data are known to be valid.
+                Any errors resulting from skipping validation with invalid inputs may not be easily understood.
         """
 
         if schema is not None:
-            _validate_schema(schema, self._series)
+            if validate:
+                _validate_schema(schema, self._series)
 
             extra_params = []
             if logical_type is not None:
@@ -76,13 +80,15 @@ class WoodworkColumnAccessor:
         else:
             logical_type = _get_column_logical_type(self._series, logical_type, self._series.name)
 
-            self._validate_logical_type(logical_type)
+            if validate:
+                self._validate_logical_type(logical_type)
 
             self._schema = ColumnSchema(logical_type=logical_type,
                                         semantic_tags=semantic_tags,
                                         use_standard_tags=use_standard_tags,
                                         description=description,
-                                        metadata=metadata)
+                                        metadata=metadata,
+                                        validate=validate)
 
     @property
     def schema(self):

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -238,7 +238,7 @@ class WoodworkColumnAccessor:
                 if _is_series(result):
                     valid_dtype = _get_valid_dtype(type(result), self._schema.logical_type)
                     if str(result.dtype) == valid_dtype:
-                        result.ww.init(schema=self.schema)
+                        result.ww.init(schema=self.schema, validate=False)
                     else:
                         invalid_schema_message = 'dtype mismatch between original dtype, ' \
                             f'{valid_dtype}, and returned dtype, {result.dtype}'

--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -49,11 +49,11 @@ def _process_selection(selection, original_data):
             # Selecting a new Series from an existing Series
             schema = original_data.ww._schema
         if schema:
-            selection.ww.init(schema=copy.deepcopy(schema))
+            selection.ww.init(schema=copy.deepcopy(schema), validate=False)
     elif _is_dataframe(selection):
         # Selecting a new DataFrame from an existing DataFrame
         schema = original_data.ww.schema
         new_schema = schema._get_subset_schema(list(selection.columns))
-        selection.ww.init(schema=new_schema)
+        selection.ww.init(schema=new_schema, validate=False)
     # Selecting a single value or return selection from above
     return selection

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -208,7 +208,7 @@ class WoodworkTableAccessor:
         if column.use_standard_tags:
             column.semantic_tags |= column.logical_type.standard_tags
 
-        series.ww.init(schema=column)
+        series.ww.init(schema=column, validate=False)
 
         return series
 
@@ -662,7 +662,7 @@ class WoodworkTableAccessor:
         series = self._dataframe.pop(column_name)
 
         # Initialize Woodwork typing info for series
-        series.ww.init(schema=self.schema.columns[column_name])
+        series.ww.init(schema=self.schema.columns[column_name], validate=False)
 
         # Update schema to not include popped column
         del self._schema.columns[column_name]


### PR DESCRIPTION
- Add validation control to column accessor init
- Closes #737 

This PR adds a validate parameter to the WoodworkColumnAccessor `init` method to allow users to optionally skip validation checks during initialization. Default behavior is for validation to happen.