### PR TITLE
Use ColumnNotPresentError for dataframe/input mismatches

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
         * Add ``is_schema_valid`` and ``get_invalid_schema_message`` functions for checking schema validity (:pr:`834`)
     * Fixes
     * Changes
+        * Consistently use ``ColumnNotPresentError`` for mismatches between user input and dataframe/schema columns (:pr:`837`)
     * Documentation Changes
     * Testing Changes
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -692,7 +692,7 @@ class WoodworkTableAccessor:
 
         not_present = [col for col in columns if col not in self._dataframe.columns]
         if not_present:
-            raise ValueError(f'{not_present} not found in DataFrame')
+            raise ColumnNotPresentError(not_present)
 
         return self._get_subset_df_with_schema([col for col in self._dataframe.columns if col not in columns])
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -659,7 +659,7 @@ class WoodworkTableAccessor:
         if self._schema is None:
             _raise_init_error()
         if column_name not in self._dataframe.columns:
-            raise LookupError(f'Column with name {column_name} not found in DataFrame')
+            raise ColumnNotPresentError(column_name)
 
         series = self._dataframe.pop(column_name)
 
@@ -876,8 +876,8 @@ def _check_unique_column_names(dataframe):
 def _check_index(dataframe, index, make_index=False):
     if not make_index and index not in dataframe.columns:
         # User specifies an index that is not in the dataframe, without setting make_index to True
-        raise LookupError(f'Specified index column `{index}` not found in dataframe. '
-                          'To create a new index column, set make_index to True.')
+        raise ColumnNotPresentError(f'Specified index column `{index}` not found in dataframe. '
+                                    'To create a new index column, set make_index to True.')
     if index is not None and not make_index and isinstance(dataframe, pd.DataFrame) and not dataframe[index].is_unique:
         # User specifies an index that is in the dataframe but not unique
         # Does not check for Dask as Dask does not support is_unique
@@ -894,7 +894,7 @@ def _check_index(dataframe, index, make_index=False):
 
 def _check_time_index(dataframe, time_index, datetime_format=None, logical_type=None):
     if time_index not in dataframe.columns:
-        raise LookupError(f'Specified time index column `{time_index}` not found in dataframe')
+        raise ColumnNotPresentError(f'Specified time index column `{time_index}` not found in dataframe')
     if not (_is_numeric_series(dataframe[time_index], logical_type) or
             col_is_datetime(dataframe[time_index], datetime_format=datetime_format)):
         raise TypeError('Time index column must contain datetime or numeric values')
@@ -905,8 +905,8 @@ def _check_logical_types(dataframe_columns, logical_types):
         raise TypeError('logical_types must be a dictionary')
     cols_not_found = set(logical_types.keys()).difference(set(dataframe_columns))
     if cols_not_found:
-        raise LookupError('logical_types contains columns that are not present in '
-                          f'dataframe: {sorted(list(cols_not_found))}')
+        raise ColumnNotPresentError('logical_types contains columns that are not present in '
+                                    f'dataframe: {sorted(list(cols_not_found))}')
 
 
 def _check_schema(dataframe, schema):

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -253,8 +253,7 @@ class TableSchema(object):
         columns = _convert_input_to_set(columns, "columns")
         cols_not_found = sorted(list(columns.difference(set(self.columns.keys()))))
         if cols_not_found:
-            raise LookupError("Input contains columns that are not present in "
-                              f"dataframe: '{', '.join(cols_not_found)}'")
+            raise ColumnNotPresentError(cols_not_found)
         if not columns:
             columns = self.columns.keys()
 
@@ -519,12 +518,12 @@ def _check_column_names(column_names):
 def _check_index(column_names, index):
     if index not in column_names:
         # User specifies an index that is not in the list of column names
-        raise LookupError(f'Specified index column `{index}` not found in TableSchema.')
+        raise ColumnNotPresentError(f'Specified index column `{index}` not found in TableSchema.')
 
 
 def _check_time_index(column_names, time_index, logical_type):
     if time_index not in column_names:
-        raise LookupError(f'Specified time index column `{time_index}` not found in TableSchema')
+        raise ColumnNotPresentError(f'Specified time index column `{time_index}` not found in TableSchema')
     ltype_class = _get_ltype_class(logical_type)
 
     if not (ltype_class == ww.logical_types.Datetime or 'numeric' in ltype_class.standard_tags):
@@ -539,12 +538,12 @@ def _check_logical_types(column_names, logical_types, require_all_cols=True):
 
     cols_not_found_in_schema = cols_in_ltypes.difference(cols_in_schema)
     if cols_not_found_in_schema:
-        raise LookupError('logical_types contains columns that are not present in '
-                          f'TableSchema: {sorted(list(cols_not_found_in_schema))}')
+        raise ColumnNotPresentError('logical_types contains columns that are not present in '
+                                    f'TableSchema: {sorted(list(cols_not_found_in_schema))}')
     cols_not_found_in_ltypes = cols_in_schema.difference(cols_in_ltypes)
     if cols_not_found_in_ltypes and require_all_cols:
-        raise LookupError(f'logical_types is missing columns that are present in '
-                          f'TableSchema: {sorted(list(cols_not_found_in_ltypes))}')
+        raise ColumnNotPresentError(f'logical_types is missing columns that are present in '
+                                    f'TableSchema: {sorted(list(cols_not_found_in_ltypes))}')
 
     for col_name, logical_type in logical_types.items():
         if _get_ltype_class(logical_type) not in ww.type_system.registered_types:
@@ -558,8 +557,8 @@ def _check_semantic_tags(column_names, semantic_tags):
         raise TypeError('semantic_tags must be a dictionary')
     cols_not_found = set(semantic_tags.keys()).difference(set(column_names))
     if cols_not_found:
-        raise LookupError('semantic_tags contains columns that do not exist: '
-                          f'{sorted(list(cols_not_found))}')
+        raise ColumnNotPresentError('semantic_tags contains columns that are not present in '
+                                    f'TableSchema: {sorted(list(cols_not_found))}')
 
     for col_name, col_tags in semantic_tags.items():
         if not isinstance(col_tags, (str, list, set)):
@@ -571,8 +570,8 @@ def _check_column_descriptions(column_names, column_descriptions):
         raise TypeError('column_descriptions must be a dictionary')
     cols_not_found = set(column_descriptions.keys()).difference(set(column_names))
     if cols_not_found:
-        raise LookupError('column_descriptions contains columns that do not exist: '
-                          f'{sorted(list(cols_not_found))}')
+        raise ColumnNotPresentError('column_descriptions contains columns that are not present in '
+                                    f'TableSchema: {sorted(list(cols_not_found))}')
 
 
 def _check_table_metadata(table_metadata):
@@ -585,8 +584,8 @@ def _check_column_metadata(column_names, column_metadata):
         raise TypeError('Column metadata must be a dictionary.')
     cols_not_found = set(column_metadata.keys()).difference(set(column_names))
     if cols_not_found:
-        raise LookupError('column_metadata contains columns that do not exist: '
-                          f'{sorted(list(cols_not_found))}')
+        raise ColumnNotPresentError('column_metadata contains columns that are not present in '
+                                    f'TableSchema: {sorted(list(cols_not_found))}')
 
 
 def _check_use_standard_tags(column_names, use_standard_tags):
@@ -595,8 +594,8 @@ def _check_use_standard_tags(column_names, use_standard_tags):
     if isinstance(use_standard_tags, dict):
         cols_not_found = set(use_standard_tags.keys()).difference(set(column_names))
         if cols_not_found:
-            raise LookupError('use_standard_tags contains columns that do not exist: '
-                              f'{sorted(list(cols_not_found))}')
+            raise ColumnNotPresentError('use_standard_tags contains columns that are not present in '
+                                        f'TableSchema: {sorted(list(cols_not_found))}')
 
         for col_name, use_standard_tags_for_col in use_standard_tags.items():
             if not isinstance(use_standard_tags_for_col, bool):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1831,15 +1831,15 @@ def test_accessor_drop_indices(sample_df):
 def test_accessor_drop_errors(sample_df):
     sample_df.ww.init()
 
-    error = re.escape("['not_present'] not found in DataFrame")
-    with pytest.raises(ValueError, match=error):
+    error = re.escape("Column(s) '['not_present']' not found in DataFrame")
+    with pytest.raises(ColumnNotPresentError, match=error):
         sample_df.ww.drop('not_present')
 
-    with pytest.raises(ValueError, match=error):
+    with pytest.raises(ColumnNotPresentError, match=error):
         sample_df.ww.drop(['age', 'not_present'])
 
-    error = re.escape("['not_present1', 4] not found in DataFrame")
-    with pytest.raises(ValueError, match=error):
+    error = re.escape("Column(s) '['not_present1', 4]' not found in DataFrame")
+    with pytest.raises(ColumnNotPresentError, match=error):
         sample_df.ww.drop(['not_present1', 4])
 
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -57,7 +57,7 @@ ks = import_or_none('databricks.koalas')
 
 def test_check_index_errors(sample_df):
     error_message = 'Specified index column `foo` not found in dataframe. To create a new index column, set make_index to True.'
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_index(dataframe=sample_df, index='foo')
 
     if isinstance(sample_df, pd.DataFrame):
@@ -87,13 +87,13 @@ def test_check_logical_types_errors(sample_df):
         'occupation': None,
     }
     error_message = re.escape("logical_types contains columns that are not present in dataframe: ['birthday', 'occupation']")
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_logical_types(sample_df, bad_logical_types_keys)
 
 
 def test_check_time_index_errors(sample_df):
     error_message = 'Specified time index column `foo` not found in dataframe'
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_time_index(dataframe=sample_df, time_index='foo')
 
 
@@ -1679,7 +1679,7 @@ def test_accessor_set_index_errors(sample_df):
     sample_df.ww.init()
 
     error = 'Specified index column `testing` not found in TableSchema.'
-    with pytest.raises(LookupError, match=error):
+    with pytest.raises(ColumnNotPresentError, match=error):
         sample_df.ww.set_index('testing')
 
     if isinstance(sample_df, pd.DataFrame):
@@ -1777,7 +1777,7 @@ def test_pop_error(sample_df):
         semantic_tags={'age': 'custom_tag'},
         use_standard_tags=True)
 
-    with pytest.raises(LookupError, match="Column with name missing not found in DataFrame"):
+    with pytest.raises(ColumnNotPresentError, match="Column with name 'missing' not found in DataFrame"):
         sample_df.ww.pop("missing")
 
 

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -424,7 +424,7 @@ def test_set_logical_types_invalid_data(sample_column_names, sample_inferred_log
     schema = TableSchema(sample_column_names, sample_inferred_logical_types)
 
     error_message = re.escape("logical_types contains columns that are not present in TableSchema: ['birthday']")
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         schema.set_types(logical_types={'birthday': Double})
 
     error_message = ("Logical Types must be of the LogicalType class "
@@ -645,8 +645,8 @@ def test_reset_semantic_tags_with_time_index(sample_column_names, sample_inferre
 
 def test_reset_semantic_tags_invalid_column(sample_column_names, sample_inferred_logical_types):
     schema = TableSchema(sample_column_names, sample_inferred_logical_types,)
-    error_msg = "Input contains columns that are not present in dataframe: 'invalid_column'"
-    with pytest.raises(LookupError, match=error_msg):
+    error_msg = re.escape("Column(s) \'[\'invalid_column\']\' not found in DataFrame")
+    with pytest.raises(ColumnNotPresentError, match=error_msg):
         schema.reset_semantic_tags('invalid_column')
 
 
@@ -792,7 +792,7 @@ def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
     schema = TableSchema(sample_column_names, sample_inferred_logical_types)
 
     error = re.escape("Specified index column `testing` not found in TableSchema.")
-    with pytest.raises(LookupError, match=error):
+    with pytest.raises(ColumnNotPresentError, match=error):
         schema.set_index('testing')
 
 
@@ -836,7 +836,7 @@ def test_set_time_index_errors(sample_column_names, sample_inferred_logical_type
     schema = TableSchema(sample_column_names, sample_inferred_logical_types)
 
     error = re.escape("Specified time index column `testing` not found in TableSchema")
-    with pytest.raises(LookupError, match=error):
+    with pytest.raises(ColumnNotPresentError, match=error):
         schema.set_time_index('testing')
 
     error = re.escape("Time index column must be a Datetime or numeric column.")

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -3,6 +3,7 @@ import re
 import pytest
 from mock import patch
 
+from woodwork.exceptions import ColumnNotPresentError
 from woodwork.logical_types import (
     Boolean,
     Categorical,
@@ -43,13 +44,13 @@ def test_validate_params_errors(sample_column_names):
 
 def test_check_index_errors(sample_column_names):
     error_message = 'Specified index column `foo` not found in TableSchema.'
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_index(column_names=sample_column_names, index='foo')
 
 
 def test_check_time_index_errors(sample_column_names):
     error_message = 'Specified time index column `foo` not found in TableSchema'
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_time_index(column_names=sample_column_names, time_index='foo', logical_type=Integer)
 
     error_msg = 'Time index column must be a Datetime or numeric column'
@@ -79,7 +80,7 @@ def test_check_logical_types_errors(sample_column_names):
         'occupation': None,
     }
     error_message = re.escape("logical_types contains columns that are not present in TableSchema: ['birthday', 'occupation']")
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_logical_types(sample_column_names, bad_logical_types_keys)
 
     bad_logical_types_keys = {
@@ -90,7 +91,7 @@ def test_check_logical_types_errors(sample_column_names):
         'age': None,
     }
     error_message = re.escape("logical_types is missing columns that are present in TableSchema: ['is_registered', 'signup_date']")
-    with pytest.raises(LookupError, match=error_message):
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_logical_types(sample_column_names, bad_logical_types_keys)
 
     bad_logical_types_keys = {'email': 1}
@@ -123,8 +124,8 @@ def test_check_semantic_tags_errors(sample_column_names):
         'birthday': None,
         'occupation': None,
     }
-    error_message = re.escape("semantic_tags contains columns that do not exist: ['birthday', 'occupation']")
-    with pytest.raises(LookupError, match=error_message):
+    error_message = re.escape("semantic_tags contains columns that are not present in TableSchema: ['birthday', 'occupation']")
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_semantic_tags(sample_column_names, bad_semantic_tags_keys)
 
     error_message = "semantic_tags for id must be a string, set or list"
@@ -146,8 +147,8 @@ def test_check_column_metadata_errors(sample_column_names):
     column_metadata = {
         'invalid_col': {'description': 'not a valid column'}
     }
-    err_msg = re.escape("column_metadata contains columns that do not exist: ['invalid_col']")
-    with pytest.raises(LookupError, match=err_msg):
+    err_msg = re.escape("column_metadata contains columns that are not present in TableSchema: ['invalid_col']")
+    with pytest.raises(ColumnNotPresentError, match=err_msg):
         _check_column_metadata(sample_column_names, column_metadata=column_metadata)
 
 
@@ -159,8 +160,8 @@ def test_check_column_description_errors(sample_column_names):
     column_descriptions = {
         'invalid_col': 'a description'
     }
-    err_msg = re.escape("column_descriptions contains columns that do not exist: ['invalid_col']")
-    with pytest.raises(LookupError, match=err_msg):
+    err_msg = re.escape("column_descriptions contains columns that are not present in TableSchema: ['invalid_col']")
+    with pytest.raises(ColumnNotPresentError, match=err_msg):
         _check_column_descriptions(sample_column_names, column_descriptions=column_descriptions)
 
 
@@ -169,8 +170,8 @@ def test_check_use_standard_tags_errors(sample_column_names):
     with pytest.raises(TypeError, match=error_message):
         _check_use_standard_tags(sample_column_names, use_standard_tags=1)
 
-    error_message = re.escape("use_standard_tags contains columns that do not exist: ['invalid_col']")
-    with pytest.raises(LookupError, match=error_message):
+    error_message = re.escape("use_standard_tags contains columns that are not present in TableSchema: ['invalid_col']")
+    with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_use_standard_tags(sample_column_names, use_standard_tags={'invalid_col': True})
 
     error_message = "use_standard_tags for column id must be a boolean"
@@ -371,8 +372,8 @@ def test_schema_col_descriptions_errors(sample_column_names, sample_inferred_log
         'invalid_col': 'not a valid column',
         'signup_date': 'date of account creation'
     }
-    err_msg = re.escape("column_descriptions contains columns that do not exist: ['invalid_col']")
-    with pytest.raises(LookupError, match=err_msg):
+    err_msg = re.escape("column_descriptions contains columns that are not present in TableSchema: ['invalid_col']")
+    with pytest.raises(ColumnNotPresentError, match=err_msg):
         TableSchema(sample_column_names, sample_inferred_logical_types, column_descriptions=descriptions)
 
 


### PR DESCRIPTION
- Use ColumnNotPresentError for dataframe/input mismatches
- Closes #649 

Updates code in multiple places to use a ColumnNotPresentError in place of the previous LookupError when there is a mismatch between columns specified by users in input and the columns present in a dataframe/schema.