### PR TITLE
Create WoodworkNotInitError for use in accessing woodwork attributes before initialization

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
         * Add ``is_schema_valid`` and ``get_invalid_schema_message`` functions for checking schema validity (:pr:`834`)
     * Fixes
     * Changes
+        * Raise custom ``WoodworkNotInitError`` when accessing Woodwork attributes before initialization (:pr:`838`)
     * Documentation Changes
     * Testing Changes
 

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -11,7 +11,8 @@ from woodwork.column_schema import (
 )
 from woodwork.exceptions import (
     ParametersIgnoredWarning,
-    TypingInfoMismatchWarning
+    TypingInfoMismatchWarning,
+    WoodworkNotInitError
 )
 from woodwork.indexers import _iLocIndexer, _locIndexer
 from woodwork.logical_types import LatLong, Ordinal
@@ -350,7 +351,7 @@ def _validate_schema(schema, series):
 
 
 def _raise_init_error():
-    raise AttributeError("Woodwork not initialized for this Series. Initialize by calling Series.ww.init")
+    raise WoodworkNotInitError("Woodwork not initialized for this Series. Initialize by calling Series.ww.init")
 
 
 @pd.api.extensions.register_series_accessor('ww')

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -47,3 +47,7 @@ class ColumnNotPresentError(KeyError):
             return super().__init__(f"Column with name '{column}' not found in DataFrame")
         elif isinstance(column, list):
             return super().__init__(f"Column(s) '{column}' not found in DataFrame")
+
+
+class WoodworkNotInitError(AttributeError):
+    pass

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -14,7 +14,8 @@ from woodwork.accessor_utils import (
 from woodwork.exceptions import (
     ColumnNotPresentError,
     ParametersIgnoredWarning,
-    TypingInfoMismatchWarning
+    TypingInfoMismatchWarning,
+    WoodworkNotInitError
 )
 from woodwork.indexers import _iLocIndexer, _locIndexer
 from woodwork.logical_types import Datetime
@@ -933,7 +934,7 @@ def _make_index(dataframe, index):
 
 
 def _raise_init_error():
-    raise AttributeError("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
+    raise WoodworkNotInitError("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
 
 
 @pd.api.extensions.register_dataframe_accessor('ww')

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -11,7 +11,8 @@ from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
     ParametersIgnoredWarning,
     TypeConversionError,
-    TypingInfoMismatchWarning
+    TypingInfoMismatchWarning,
+    WoodworkNotInitError
 )
 from woodwork.logical_types import (
     Categorical,
@@ -145,7 +146,7 @@ def test_error_accessing_properties_before_init(sample_series):
 
     error = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
     for prop in props:
-        with pytest.raises(AttributeError, match=error):
+        with pytest.raises(WoodworkNotInitError, match=error):
             getattr(sample_series.ww, prop)
 
 
@@ -165,7 +166,7 @@ def test_error_accessing_methods_before_init(sample_series):
     for method in public_methods:
         func = getattr(sample_series.ww, method)
         method_args = method_args_dict[method]
-        with pytest.raises(AttributeError, match=error):
+        with pytest.raises(WoodworkNotInitError, match=error):
             if method_args:
                 func(*method_args)
             else:
@@ -220,7 +221,7 @@ def test_accessor_description(sample_series):
 
 def test_description_setter_error_before_init(sample_series):
     err_msg = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
-    with pytest.raises(AttributeError, match=err_msg):
+    with pytest.raises(WoodworkNotInitError, match=err_msg):
         sample_series.ww.description = "description"
 
 
@@ -250,7 +251,7 @@ def test_accessor_repr(sample_series):
 
 def test_accessor_repr_error_before_init(sample_series):
     err_msg = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
-    with pytest.raises(AttributeError, match=err_msg):
+    with pytest.raises(WoodworkNotInitError, match=err_msg):
         sample_series.ww.__repr__()
 
 
@@ -490,7 +491,7 @@ def test_series_methods_on_accessor_new_schema_object(sample_series):
 
 def test_series_getattr_errors(sample_series):
     error_message = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_series.ww.shape
 
     sample_series.ww.init()
@@ -645,7 +646,7 @@ def test_accessor_metadata(sample_series):
 
 def test_metadata_setter_error_before_init(sample_series):
     err_msg = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
-    with pytest.raises(AttributeError, match=err_msg):
+    with pytest.raises(WoodworkNotInitError, match=err_msg):
         sample_series.ww.metadata = {"key": "val"}
 
 

--- a/woodwork/tests/accessor/test_indexers.py
+++ b/woodwork/tests/accessor/test_indexers.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+from woodwork.exceptions import WoodworkNotInitError
 from woodwork.indexers import _iLocIndexer, _locIndexer
 from woodwork.logical_types import (
     Categorical,
@@ -51,20 +52,20 @@ def test_locIndexer_class(sample_df):
 def test_error_before_table_init(sample_df):
     error_message = "Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init"
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_df.ww.iloc[:, :]
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_df.ww.loc[:, :]
 
 
 def test_error_before_column_init(sample_series):
     error_message = "Woodwork not initialized for this Series. Initialize by calling Series.ww.init"
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_series.ww.iloc[:]
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_series.ww.loc[:]
 
 

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -8,7 +8,11 @@ from mock import patch
 
 import woodwork.deserialize as deserialize
 import woodwork.serialize as serialize
-from woodwork.exceptions import OutdatedSchemaWarning, UpgradeSchemaWarning
+from woodwork.exceptions import (
+    OutdatedSchemaWarning,
+    UpgradeSchemaWarning,
+    WoodworkNotInitError
+)
 from woodwork.logical_types import Ordinal
 from woodwork.tests.testing_utils import to_pandas
 from woodwork.utils import import_or_none
@@ -34,16 +38,16 @@ def xfail_tmp_disappears(dataframe):
 def test_error_before_table_init(sample_df, tmpdir):
     error_message = "Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init"
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_df.ww.to_dictionary()
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_df.ww.to_csv(str(tmpdir), encoding='utf-8', engine='python')
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_df.ww.to_pickle(str(tmpdir))
 
-    with pytest.raises(AttributeError, match=error_message):
+    with pytest.raises(WoodworkNotInitError, match=error_message):
         sample_df.ww.to_parquet(str(tmpdir))
 
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -11,7 +11,8 @@ from woodwork.exceptions import (
     ColumnNotPresentError,
     ParametersIgnoredWarning,
     TypeConversionError,
-    TypingInfoMismatchWarning
+    TypingInfoMismatchWarning,
+    WoodworkNotInitError
 )
 from woodwork.logical_types import (
     URL,
@@ -207,7 +208,7 @@ def test_accessor_init_errors_methods(sample_df):
     for method in public_methods:
         func = getattr(sample_df.ww, method)
         method_args = method_args_dict[method]
-        with pytest.raises(AttributeError, match=error):
+        with pytest.raises(WoodworkNotInitError, match=error):
             if method_args:
                 func(*method_args)
             else:
@@ -220,7 +221,7 @@ def test_accessor_init_errors_properties(sample_df):
 
     error = re.escape("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
     for prop in props:
-        with pytest.raises(AttributeError, match=error):
+        with pytest.raises(WoodworkNotInitError, match=error):
             getattr(sample_df.ww, prop)
 
 
@@ -267,7 +268,7 @@ def test_accessor_getattr(sample_df):
     assert schema_df.ww.schema is None
 
     error = re.escape("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
-    with pytest.raises(AttributeError, match=error):
+    with pytest.raises(WoodworkNotInitError, match=error):
         schema_df.ww.index
 
     schema_df.ww.init()
@@ -328,7 +329,7 @@ def test_getitem(sample_df):
 
 def test_getitem_init_error(sample_df):
     error = re.escape("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
-    with pytest.raises(AttributeError, match=error):
+    with pytest.raises(WoodworkNotInitError, match=error):
         sample_df.ww['age']
 
 
@@ -2227,7 +2228,7 @@ def test_accessor_types(sample_df):
 
 def test_accessor_repr(small_df):
     error = 'Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init'
-    with pytest.raises(AttributeError, match=error):
+    with pytest.raises(WoodworkNotInitError, match=error):
         repr(small_df.ww)
     small_df.ww.init()
 


### PR DESCRIPTION
- Create WoodworkNotInitError for use in accessing woodwork attributes before initialization
- Closes #621 

This PR adds a new custom `WoodworkNotInitError` that is used when users attempt to access attributes through the Woodwork accessor before initialization, replacing the generic `AttributeError` that was used previously.