### PR TITLE
Update README.md with correct dtypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ df.ww
 ```
                    Physical Type     Logical Type Semantic Tag(s)
 Column
-order_product_id           Int64          Integer       ['index']
+order_product_id           int64          Integer       ['index']
 order_id                category      Categorical    ['category']
 product_id              category      Categorical    ['category']
 description               string  NaturalLanguage              []
@@ -70,7 +70,7 @@ unit_price               float64           Double     ['numeric']
 customer_name             string   PersonFullName              []
 country                 category      Categorical    ['category']
 total                    float64           Double     ['numeric']
-cancelled                boolean          Boolean              []
+cancelled                   bool          Boolean              []
 ```
 
 We now have initialized Woodwork on the DataFrame with the specified logical types assigned. For columns that did not have a specified logical type value, Woodwork has automatically inferred the logical type based on the underlying data. Additionally, Woodwork has automatically assigned semantic tags to some of the columns, based on the inferred or assigned logical type.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
     * Testing Changes
         * Remove unnecessary argument in codecov upload job (:pr:`853`)
         * Change from GitHub Token to regenerated GitHub PAT dependency checkers (:pr:`855`)
+        * Update README.md with non-nullable dtypes in code example (:pr:`856`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`


### PR DESCRIPTION
- We added nullable and non-nullable Logical Types, therefore the Readme needs to updated. 
- Tested 4/26/2021 with latest in `main` branch:
<img width="662" alt="Screen Shot 2021-04-26 at 10 33 33 AM" src="https://user-images.githubusercontent.com/8726321/116100382-daae2980-a67a-11eb-9cb2-42e284f66ca0.png">
