### PR TITLE
Check tags for index and time index

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
     * Enhancements
         * Add ``is_schema_valid`` and ``get_invalid_schema_message`` functions for checking schema validity (:pr:`834`)
     * Fixes
+        * Raise error when a column is set as the index and time index (:pr:`859`)
     * Changes
         * Consistently use ``ColumnNotPresentError`` for mismatches between user input and dataframe/schema columns (:pr:`837`)
         * Raise custom ``WoodworkNotInitError`` when accessing Woodwork attributes before initialization (:pr:`838`)
@@ -16,7 +17,7 @@ Release Notes
         * Update README.md with non-nullable dtypes in code example (:pr:`856`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`
+    :user:`jeff-hernandez`, :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`
 
 **v0.2.0 April 20, 2021**
     .. warning::

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -307,10 +307,10 @@ class TableSchema(object):
             if validate:
                 _check_index(self.columns.keys(), new_index)
 
-            if 'time_index' in self.columns[new_index].semantic_tags:
-                info = f'"{new_index}" is already set as the time index. '
-                info += 'A time index cannot also be the index.'
-                raise ValueError(info)
+                if 'time_index' in self.columns[new_index].semantic_tags:
+                    info = f'"{new_index}" is already set as the time index. '
+                    info += 'A time index cannot also be the index.'
+                    raise ValueError(info)
 
             self._set_index_tags(new_index)
 

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -306,6 +306,12 @@ class TableSchema(object):
         if new_index is not None:
             if validate:
                 _check_index(self.columns.keys(), new_index)
+
+            if 'time_index' in self.columns[new_index].semantic_tags:
+                info = f'"{new_index}" is already set as the time index. '
+                info += 'A time index cannot also be the index.'
+                raise ValueError(info)
+
             self._set_index_tags(new_index)
 
     def set_time_index(self, new_time_index, validate=True):
@@ -322,6 +328,12 @@ class TableSchema(object):
         if new_time_index is not None:
             if validate:
                 _check_time_index(self.columns.keys(), new_time_index, self.logical_types.get(new_time_index))
+
+                if 'index' in self.columns[new_time_index].semantic_tags:
+                    info = f'"{new_time_index}" is already set as the index. '
+                    info += 'An index cannot also be the time index.'
+                    raise ValueError(info)
+
             self._set_time_index_tags(new_time_index)
 
     def rename(self, columns):

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -795,9 +795,17 @@ def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
     with pytest.raises(ColumnNotPresentError, match=error):
         schema.set_index('testing')
 
-    schema.set_index('id')
     match = '"id" is already set as the index. '
     match += 'An index cannot also be the time index.'
+    with pytest.raises(ValueError, match=match):
+        TableSchema(
+            sample_column_names,
+            sample_inferred_logical_types,
+            index='id',
+            time_index='id',
+        )
+
+    schema.set_index('id')
     with pytest.raises(ValueError, match=match):
         schema.set_time_index('id')
 

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -795,6 +795,18 @@ def test_set_index_errors(sample_column_names, sample_inferred_logical_types):
     with pytest.raises(ColumnNotPresentError, match=error):
         schema.set_index('testing')
 
+    schema.set_index('id')
+    match = '"id" is already set as the index. '
+    match += 'An index cannot also be the time index.'
+    with pytest.raises(ValueError, match=match):
+        schema.set_time_index('id')
+
+    schema.set_time_index('signup_date')
+    match = '"signup_date" is already set as the time index. '
+    match += 'A time index cannot also be the index.'
+    with pytest.raises(ValueError, match=match):
+        schema.set_index('signup_date')
+
 
 def test_set_time_index(sample_column_names, sample_inferred_logical_types):
     schema = TableSchema(sample_column_names, sample_inferred_logical_types, use_standard_tags=True)


### PR DESCRIPTION
Closes #301 by validating the semantic tags when setting a column as the index or time index.