### PR TITLE
Allow NaNs in schema validation check

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
         * Add ``is_schema_valid`` and ``get_invalid_schema_message`` functions for checking schema validity (:pr:`834`)
     * Fixes
         * Raise error when a column is set as the index and time index (:pr:`859`)
+        * Allow NaNs in index for schema validation check (:pr:`862`)
     * Changes
         * Consistently use ``ColumnNotPresentError`` for mismatches between user input and dataframe/schema columns (:pr:`837`)
         * Raise custom ``WoodworkNotInitError`` when accessing Woodwork attributes before initialization (:pr:`838`)
@@ -17,7 +18,7 @@ Release Notes
         * Update README.md with non-nullable dtypes in code example (:pr:`856`)
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`, :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`
+    :user:`jeff-hernandez`, :user:`gsheni`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 **v0.2.0 April 20, 2021**
     .. warning::

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -153,8 +153,7 @@ def get_invalid_schema_message(dataframe, schema):
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'
     if schema.index is not None and isinstance(dataframe, pd.DataFrame):
         # Index validation not performed for Dask/Koalas
-        if not all((dataframe.index == dataframe[schema.index]) |
-                   (pd.isnull(dataframe.index) & pd.isnull(dataframe[schema.index]))):
+        if not pd.Series(dataframe.index).equals(pd.Series(dataframe[schema.index].values)):
             return 'Index mismatch between DataFrame and typing information'
         elif not dataframe[schema.index].is_unique:
             return 'Index column is not unique'

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -153,7 +153,7 @@ def get_invalid_schema_message(dataframe, schema):
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'
     if schema.index is not None and isinstance(dataframe, pd.DataFrame):
         # Index validation not performed for Dask/Koalas
-        if not pd.Series(dataframe.index).equals(pd.Series(dataframe[schema.index].values)):
+        if not pd.Series(dataframe.index, dtype=dataframe[schema.index].dtype).equals(pd.Series(dataframe[schema.index].values)):
             return 'Index mismatch between DataFrame and typing information'
         elif not dataframe[schema.index].is_unique:
             return 'Index column is not unique'

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -153,7 +153,8 @@ def get_invalid_schema_message(dataframe, schema):
                 f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'
     if schema.index is not None and isinstance(dataframe, pd.DataFrame):
         # Index validation not performed for Dask/Koalas
-        if not all(dataframe.index == dataframe[schema.index]):
+        if not all((dataframe.index == dataframe[schema.index]) |
+                   (pd.isnull(dataframe.index) & pd.isnull(dataframe[schema.index]))):
             return 'Index mismatch between DataFrame and typing information'
         elif not dataframe[schema.index].is_unique:
             return 'Index column is not unique'

--- a/woodwork/tests/accessor/test_accessor_utils.py
+++ b/woodwork/tests/accessor/test_accessor_utils.py
@@ -181,6 +181,12 @@ def test_get_invalid_schema_message_index_checks(sample_df):
     not_unique_df.index.name = None
     assert get_invalid_schema_message(not_unique_df, schema) == 'Index column is not unique'
 
+    nan_df = pd.DataFrame({'id': pd.Series([5, 4, None, 2], dtype='float64'), 'col': pd.Series(['b', 'b', 'b', 'd'], dtype='category')})
+    nan_df.ww.init(index='id')
+    nan_df_schema = nan_df.ww.schema
+
+    assert get_invalid_schema_message(nan_df, nan_df_schema) is None
+
 
 def test_is_schema_valid_true(sample_df):
     sample_df.ww.init(index='id', logical_types={'phone_number': 'Categorical'})


### PR DESCRIPTION
- Stops indicating that the schema is invalid if there are null values in the index column
- Closes #861 