### PR TITLE
Remove Ordinal validation in ColumnSchema

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,7 @@ Release Notes
     * Changes
         * Consistently use ``ColumnNotPresentError`` for mismatches between user input and dataframe/schema columns (:pr:`837`)
         * Raise custom ``WoodworkNotInitError`` when accessing Woodwork attributes before initialization (:pr:`838`)
+        * Remove check requiring ``Ordinal`` instance for initializing a ``ColumnSchema`` object (:pr:`870`)
     * Documentation Changes
     * Testing Changes
         * Remove unnecessary argument in codecov upload job (:pr:`853`)

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -21,7 +21,7 @@ class ColumnSchema(object):
         """Create ColumnSchema
 
         Args:
-            logical_type (str, LogicalType, optional): The column's LogicalType.
+            logical_type (LogicalType, optional): The column's LogicalType.
             semantic_tags (str, list, set, optional): The semantic tag(s) specified for the column.
             use_standard_tags (boolean, optional): If True, will add standard semantic tags to the column based
                     on the specified logical type if a logical type is defined for the column. Defaults to False.

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -5,7 +5,7 @@ from woodwork.exceptions import (
     DuplicateTagsWarning,
     StandardTagsChangedWarning
 )
-from woodwork.logical_types import Boolean, BooleanNullable, Datetime, Ordinal
+from woodwork.logical_types import Boolean, BooleanNullable, Datetime
 from woodwork.type_sys.utils import _get_ltype_class
 from woodwork.utils import _convert_input_to_set
 
@@ -163,8 +163,6 @@ def _validate_logical_type(logical_type):
 
     if ltype_class not in ww.type_system.registered_types:
         raise TypeError(f'logical_type {logical_type} is not a registered LogicalType.')
-    if ltype_class == Ordinal and not isinstance(logical_type, Ordinal):
-        raise TypeError("Must use an Ordinal instance with order values defined")
 
 
 def _validate_description(column_description):

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -38,10 +38,6 @@ def test_validate_logical_type_errors():
         _validate_logical_type(Integer)
     ww.type_system.reset_defaults()
 
-    error_msg = 'Must use an Ordinal instance with order values defined'
-    with pytest.raises(TypeError, match=error_msg):
-        ColumnSchema(Ordinal)
-
 
 def test_validate_description_errors():
     match = re.escape("Column description must be a string")


### PR DESCRIPTION
- Remove Ordinal validation in ColumnSchema
- Closes #865 

Removes the check in ColumnSchema that requires an instance of Ordinal to be passed. This does not remove the corresponding check in `_parse_logical_type` so attempting to initialize a series or table accessor without and instance will still raise an error.