### PR TITLE
Add to_disk function to save Woodwork schema + data

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -33,10 +33,8 @@ WoodworkTableAccessor
     WoodworkTableAccessor.set_time_index
     WoodworkTableAccessor.set_types
     WoodworkTableAccessor.time_index
-    WoodworkTableAccessor.to_csv
+    WoodworkTableAccessor.to_disk
     WoodworkTableAccessor.to_dictionary
-    WoodworkTableAccessor.to_parquet
-    WoodworkTableAccessor.to_pickle
     WoodworkTableAccessor.types
     WoodworkTableAccessor.use_standard_tags
     WoodworkTableAccessor.value_counts

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
         * Add ``is_schema_valid`` and ``get_invalid_schema_message`` functions for checking schema validity (:pr:`834`)
         * Add logical type for ``Age`` and ``AgeNullable`` (:pr:`849`)
         * Add logical type for ``Address`` (:pr:`858`)
+        * Add generic ``to_disk`` function to save Woodwork schema and data (:pr:`872`)
     * Fixes
         * Raise error when a column is set as the index and time index (:pr:`859`)
         * Allow NaNs in index for schema validation check (:pr:`862`)
@@ -22,7 +23,11 @@ Release Notes
         * Update README.md with non-nullable dtypes in code example (:pr:`856`)
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`, :user:`gsheni`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`
+    :user:`jeff-hernandez`, :user:`gsheni`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`, :user:`frances-h`
+
+**Breaking Changes**
+    * Woodwork tables can no longer be saved using to disk ``df.ww.to_csv``, ``df.ww.to_pickle``, or 
+      ``df.ww.to_parquet``. Use ``df.ww.to_disk`` instead.
 
 **v0.2.0 April 20, 2021**
     .. warning::

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -200,6 +200,7 @@ def test_accessor_init_errors_methods(sample_df):
         'set_index': ['id'],
         'set_time_index': ['signup_date'],
         'set_types': [{'id': 'Integer'}],
+        'to_disk': ['dir'],
         'to_csv': ['dir'],
         'to_dictionary': None,
         'to_parquet': ['dir'],

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -201,10 +201,7 @@ def test_accessor_init_errors_methods(sample_df):
         'set_time_index': ['signup_date'],
         'set_types': [{'id': 'Integer'}],
         'to_disk': ['dir'],
-        'to_csv': ['dir'],
         'to_dictionary': None,
-        'to_parquet': ['dir'],
-        'to_pickle': ['dir'],
         'value_counts': None,
 
     }


### PR DESCRIPTION
- Add `to_disk` method which takes a path and a format and saves the Woodwork schema and data using the specified format
    - Defaults to using CSV if no format is specified
- Remove `to_csv`, `to_parquet`, and `to_pickle` as they are now consolidated in `to_disk`
- Closes #857 
