### PR TITLE
Improve release notes formatting

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Future Release
         * Raise custom ``WoodworkNotInitError`` when accessing Woodwork attributes before initialization (:pr:`838`)
         * Remove check requiring ``Ordinal`` instance for initializing a ``ColumnSchema`` object (:pr:`870`)
     * Documentation Changes
-        * Improve formatting of release notes (:pr:``)
+        * Improve formatting of release notes (:pr:`874`)
     * Testing Changes
         * Remove unnecessary argument in codecov upload job (:pr:`853`)
         * Change from GitHub Token to regenerated GitHub PAT dependency checkers (:pr:`855`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,7 +2,8 @@
 
 Release Notes
 -------------
-**Future Release**
+Future Release
+==============
     * Enhancements
         * Add ``is_schema_valid`` and ``get_invalid_schema_message`` functions for checking schema validity (:pr:`834`)
         * Add logical type for ``Age`` and ``AgeNullable`` (:pr:`849`)
@@ -17,6 +18,7 @@ Release Notes
         * Raise custom ``WoodworkNotInitError`` when accessing Woodwork attributes before initialization (:pr:`838`)
         * Remove check requiring ``Ordinal`` instance for initializing a ``ColumnSchema`` object (:pr:`870`)
     * Documentation Changes
+        * Improve formatting of release notes (:pr:``)
     * Testing Changes
         * Remove unnecessary argument in codecov upload job (:pr:`853`)
         * Change from GitHub Token to regenerated GitHub PAT dependency checkers (:pr:`855`)
@@ -25,11 +27,13 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`jeff-hernandez`, :user:`gsheni`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`, :user:`frances-h`
 
-**Breaking Changes**
+Breaking Changes
+++++++++++++++++
     * Woodwork tables can no longer be saved using to disk ``df.ww.to_csv``, ``df.ww.to_pickle``, or 
       ``df.ww.to_parquet``. Use ``df.ww.to_disk`` instead.
 
-**v0.2.0 April 20, 2021**
+v0.2.0 Apr 20, 2021
+===================
     .. warning::
         This Woodwork release does not support Python 3.6
 
@@ -72,7 +76,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**Breaking Changes**
+Breaking Changes
+++++++++++++++++
     * The ``ZIPCode`` logical type has been renamed to ``PostalCode``
     * The ``FullName`` logical type has been renamed to ``PersonFullName``
     * The ``Schema`` object has been renamed to ``TableSchema``
@@ -82,7 +87,8 @@ Release Notes
       values. The new ``BooleanNullable`` and ``IntegerNullable`` logical types should be used if
       null values are present.
 
-**v0.1.0 March 22, 2021**
+v0.1.0 Mar 22, 2021
+===================
     * Enhancements
         * Implement Schema and Accessor API (:pr:`497`)
         * Add Schema class that holds typing info (:pr:`499`)
@@ -157,10 +163,12 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`johnbridstrup`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**Breaking Changes**
+Breaking Changes
+++++++++++++++++
     * The ``DataTable`` and ``DataColumn`` classes have been removed and replaced by new ``WoodworkTableAccessor`` and ``WoodworkColumnAccessor`` classes which are used through the ``ww`` namespace available on DataFrames after importing Woodwork.
 
-**v0.0.11 March 15, 2021**
+v0.0.11 Mar 15, 2021
+====================
     * Changes
         * Restrict Koalas version to ``<1.7.0`` due to breaking changes (:pr:`674`)
         * Include unique columns in mutual information calculations (:pr:`687`)
@@ -175,7 +183,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**v0.0.10 February 25, 2021**
+v0.0.10 Feb 25, 2021
+====================
     * Changes
         * Avoid calculating mutualinfo for non-unique columns (:pr:`563`)
         * Preserve underlying DataFrame index if index column is not specified (:pr:`588`)
@@ -188,7 +197,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`johnbridstrup`, :user:`tamargrey`
 
-**v0.0.9 February 5, 2021**
+v0.0.9 Feb 5, 2021
+==================
     * Enhancements
         * Add Python 3.9 support without Koalas testing (:pr:`511`)
         * Add ``get_valid_mi_types`` function to list LogicalTypes valid for mutual information calculation (:pr:`517`)
@@ -206,7 +216,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**v0.0.8 January 25, 2021**
+v0.0.8 Jan 25, 2021
+===================
     * Enhancements
         * Add ``DataTable.df`` property for accessing the underling DataFrame (:pr:`470`)
         * Set index of underlying DataFrame to match DataTable index (:pr:`464`)
@@ -222,7 +233,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**v0.0.7 December 14, 2020**
+v0.0.7 Dec 14, 2020
+===================
     * Enhancements
         * Allow for user-defined logical types and inference functions in TypeSystem object (:pr:`424`)
         * Add ``__repr__`` to DataTable (:pr:`425`)
@@ -247,7 +259,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`jeff-hernandez`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**v0.0.6 November 30, 2020**
+v0.0.6 Nov 30, 2020
+===================
     * Enhancements
         * Add support for creating DataTable from Koalas DataFrame (:pr:`327`)
         * Add ability to initialize DataTable with numpy array (:pr:`367`)
@@ -280,14 +293,16 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`ctduffy`, :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**Breaking Changes**
+Breaking Changes
+++++++++++++++++
     * The ``DataTable.set_semantic_tags`` method was removed. ``DataTable.set_types`` can be used instead.
     * The ``DataTable.set_logical_types`` method was removed. ``DataTable.set_types`` can be used instead.
     * ``WholeNumber`` was removed from LogicalTypes. Columns that were previously inferred as WholeNumber will now be inferred as Integer.
     * The ``DataTable.get_mutual_information`` was renamed to ``DataTable.mutual_information``.
     * The ``copy_dataframe`` parameter was removed from DataTable initialization.
 
-**v0.0.5 November 11, 2020**
+v0.0.5 Nov 11, 2020
+===================
     * Enhancements
         * Add ``__eq__`` to DataTable and DataColumn and update LogicalType equality (:pr:`318`)
         * Add ``value_counts()`` method to DataTable (:pr:`342`)
@@ -327,12 +342,14 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`ctduffy`, :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**Breaking Changes**
+Breaking Changes
+++++++++++++++++
     * The ``DataColumn.to_pandas`` method was renamed to ``DataColumn.to_series``.
     * The ``DataTable.to_pandas`` method was renamed to ``DataTable.to_dataframe``.
     * ``copy`` is no longer a parameter of ``DataTable.to_dataframe`` or ``DataColumn.to_series``.
 
-**v0.0.4 October 21, 2020**
+v0.0.4 Oct 21, 2020
+===================
     * Enhancements
         * Add optional ``include`` parameter for ``DataTable.describe()`` to filter results (:pr:`228`)
         * Add ``make_index`` parameter to ``DataTable.__init__`` to enable optional creation of a new index column (:pr:`238`)
@@ -360,7 +377,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`ctduffy`, :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**v0.0.3 October 9, 2020**
+v0.0.3 Oct 9, 2020
+==================
     * Enhancements
         * Implement setitem on DataTable to create/overwrite an existing DataColumn (:pr:`165`)
         * Add ``to_pandas`` method to DataColumn to access the underlying series (:pr:`169`)
@@ -402,7 +420,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**v0.0.2 September 28, 2020**
+v0.0.2 Sep 28, 2020
+===================
     * Fixes
         * Fix formatting issue when printing global config variables (:pr:`138`)
     * Changes
@@ -415,7 +434,8 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
-**v0.1.0 September 24, 2020**
+v0.1.0 Sep 24, 2020
+===================
     * Add ``natural_language_threshold`` global config option used for Categorical/NaturalLanguage type inference (:pr:`135`)
     * Add global config options and add ``datetime_format`` option for type inference (:pr:`134`)
     * Fix bug with Integer and WholeNumber inference in column with ``pd.NA`` values (:pr:`133`)

--- a/release.md
+++ b/release.md
@@ -42,7 +42,7 @@ If you'd like to create a development release, which won't be deployed to pypi a
 
     ```
     .. Future Release
-      =============
+      ==============
         * Enhancements
         * Fixes
         * Changes

--- a/release.md
+++ b/release.md
@@ -31,7 +31,8 @@ If you'd like to create a development release, which won't be deployed to pypi a
 1. Replace "Future Release" in `docs/source/release_notes.rst` with the current date
 
     ```
-    **v0.13.3 September 28, 2020**
+    v0.13.3 Sep 28, 2020
+    ====================
     ```
 
 2. Remove any unused Release Notes sections for this release (e.g. Fixes, Testing Changes)
@@ -40,7 +41,8 @@ If you'd like to create a development release, which won't be deployed to pypi a
 5. Add a commented out "Future Release" section with all of the Release Notes sections above the current section
 
     ```
-    .. **Future Release**
+    .. Future Release
+      =============
         * Enhancements
         * Fixes
         * Changes


### PR DESCRIPTION
- Improve release notes formatting
- Closes #800

Improves formatting of release notes so that links for each version's notes are displayed on the right side of the document and version headers display more prominently. Also updates release.md to include the new formatting.