### PR TITLE
POC: Use a weak reference to the original data

### DIFF
--- a/woodwork/indexers.py
+++ b/woodwork/indexers.py
@@ -16,8 +16,8 @@ class _iLocIndexer:
             raise TypeError("iloc is not supported for Dask Series")
 
     def __getitem__(self, key):
-        selection = self.data.iloc[key]
-        return _process_selection(selection, self.data)
+        selection = self.data().iloc[key]
+        return _process_selection(selection, self.data())
 
 
 class _locIndexer:
@@ -25,8 +25,8 @@ class _locIndexer:
         self.data = data
 
     def __getitem__(self, key):
-        selection = self.data.loc[key]
-        return _process_selection(selection, self.data)
+        selection = self.data().loc[key]
+        return _process_selection(selection, self.data())
 
 
 def _process_selection(selection, original_data):


### PR DESCRIPTION
- Use a weak reference to the original data to allow the garbage collector to free up memory. Useful for workflows that end up creating a lot of dataframes with woodwork. Just a proof-of-concept.
- Closes #880

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*