### PR TITLE
Updates for koalas 1.8.0

### DIFF
--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -70,7 +70,7 @@
     "|-------------------|-------------|----------------------------------------|\n",
     "| boto3             | 1.10.45     | Required to read/write to URLs and S3  |\n",
     "| smart_open        | 5.0.0       | Required to read/write to URLs and S3  |\n",
-    "| pyarrow           | 2.0.0       | Required to serialize to parquet       |\n",
+    "| pyarrow           | 3.0.0       | Required to serialize to parquet       |\n",
     "| dask[distributed] | 2.30.0      | Required to use with Dask DataFrames   |\n",
     "| koalas            | 1.8.0       | Required to use with Koalas DataFrames |\n",
     "| pyspark           | 3.0.0       | Required to use with Koalas DataFrames |\n",
@@ -99,7 +99,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -72,7 +72,7 @@
     "| smart_open        | 5.0.0       | Required to read/write to URLs and S3  |\n",
     "| pyarrow           | 2.0.0       | Required to serialize to parquet       |\n",
     "| dask[distributed] | 2.30.0      | Required to use with Dask DataFrames   |\n",
-    "| koalas            | 1.7.0       | Required to use with Koalas DataFrames |\n",
+    "| koalas            | 1.8.0       | Required to use with Koalas DataFrames |\n",
     "| pyspark           | 3.0.0       | Required to use with Koalas DataFrames |\n",
     "\n",
     "\n",
@@ -99,7 +99,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Future Release
         * Consistently use ``ColumnNotPresentError`` for mismatches between user input and dataframe/schema columns (:pr:`837`)
         * Raise custom ``WoodworkNotInitError`` when accessing Woodwork attributes before initialization (:pr:`838`)
         * Remove check requiring ``Ordinal`` instance for initializing a ``ColumnSchema`` object (:pr:`870`)
+        * Increase koalas min version to 1.8.0 (:pr:`885`)
     * Documentation Changes
         * Improve formatting of release notes (:pr:`874`)
     * Testing Changes

--- a/koalas-requirements.txt
+++ b/koalas-requirements.txt
@@ -1,3 +1,2 @@
 pyspark>=3.0.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
-koalas>=1.7.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
-numpy<1.20.0 # remove when koalas supports 1.20.0
+koalas>=1.8.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.15.4
-pandas>=1.1.1
+pandas>=1.2.0
 click>=7.1.2
 scikit-learn>=0.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy>=1.15.4
 pandas>=1.2.0
 click>=7.1.2
 scikit-learn>=0.22

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,4 @@ mock==4.0.3
 boto3>=1.10.45
 moto[all]>=1.3.14
 smart-open>=5.0.0
-pyarrow>=2.0.0
+pyarrow>=3.0.0

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -85,7 +85,7 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
         if col['physical_type']['type'] == 'category':
             # Make sure categories are recreated properly
             cat_values = col['physical_type']['cat_values']
-            if table_type == 'pandas' and pd.__version__ > '1.1.5':
+            if table_type == 'pandas':
                 cat_object = pd.CategoricalDtype(pd.Index(cat_values, dtype='object'))
             else:
                 cat_object = pd.CategoricalDtype(pd.Series(cat_values))

--- a/woodwork/tests/accessor/test_accessor_utils.py
+++ b/woodwork/tests/accessor/test_accessor_utils.py
@@ -148,15 +148,16 @@ def test_get_invalid_schema_message_dtype_mismatch(sample_df):
 
     incorrect_int_dtype_df = schema_df.ww.astype({'id': 'Int64'})
     incorrect_bool_dtype_df = schema_df.ww.astype({'is_registered': 'Int64'})
-    incorrect_str_dtype_df = schema_df.ww.astype({'full_name': 'object'})  # wont work for koalas
-    incorrect_categorical_dtype_df = schema_df.ww.astype({'age': 'string'})  # wont work for koalas
 
     assert (get_invalid_schema_message(incorrect_int_dtype_df, schema) ==
             'dtype mismatch for column id between DataFrame dtype, Int64, and Integer dtype, int64')
     assert (get_invalid_schema_message(incorrect_bool_dtype_df, schema) ==
             'dtype mismatch for column is_registered between DataFrame dtype, Int64, and BooleanNullable dtype, boolean')
+
     # Koalas backup dtypes make these checks not relevant
     if ks and not isinstance(sample_df, ks.DataFrame):
+        incorrect_str_dtype_df = schema_df.ww.astype({'full_name': 'object'})  # wont work for koalas
+        incorrect_categorical_dtype_df = schema_df.ww.astype({'age': 'string'})  # wont work for koalas
         assert (get_invalid_schema_message(incorrect_str_dtype_df, schema) ==
                 'dtype mismatch for column full_name between DataFrame dtype, object, and NaturalLanguage dtype, string')
         assert (get_invalid_schema_message(incorrect_categorical_dtype_df, schema) ==

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -77,12 +77,15 @@ def test_accessor_init_with_schema_errors(sample_series):
     with pytest.raises(TypeError, match=error):
         head_series.ww.init(schema=int)
 
-    ltype_dtype = 'category'
     if ks and isinstance(sample_series, ks.Series):
         ltype_dtype = 'string'
-    error = f"dtype mismatch between Series dtype object, and Categorical dtype, {ltype_dtype}"
+        new_dtype = '<U0'
+    else:
+        ltype_dtype = 'category'
+        new_dtype = 'object'
 
-    diff_dtype_series = sample_series.astype('object')
+    error = re.escape(f"dtype mismatch between Series dtype {new_dtype}, and Categorical dtype, {ltype_dtype}")
+    diff_dtype_series = sample_series.astype(new_dtype)
     with pytest.raises(ValueError, match=error):
         diff_dtype_series.ww.init(schema=schema)
 
@@ -124,12 +127,15 @@ def test_accessor_init_with_logical_type(sample_series):
 
 
 def test_accessor_init_with_invalid_logical_type(sample_series):
-    series = sample_series.astype('object')
-    series_dtype = 'object'
+    if ks and isinstance(sample_series, ks.Series):
+        series_dtype = '<U0'
+    else:
+        series_dtype = 'object'
+    series = sample_series.astype(series_dtype)
     correct_dtype = 'string'
-    error_message = f"Cannot initialize Woodwork. Series dtype '{series_dtype}' is incompatible with " \
-        f"NaturalLanguage dtype. Try converting series dtype to '{correct_dtype}' before initializing " \
-        "or use the woodwork.init_series function to initialize."
+    error_message = re.escape(f"Cannot initialize Woodwork. Series dtype '{series_dtype}' is incompatible with "
+                              f"NaturalLanguage dtype. Try converting series dtype to '{correct_dtype}' before "
+                              "initializing or use the woodwork.init_series function to initialize.")
     with pytest.raises(ValueError, match=error_message):
         series.ww.init(logical_type=NaturalLanguage)
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -829,19 +829,14 @@ def test_invalid_dtype_casting():
 
     # pandas >=1.2.0 converts to an object dtype when converting a series with missing
     # values with `.astype('bool')` but does not error. Woodwork should not allow this to succeed.
-    # Earlier versions of pandas cast to the correct dtype, replacing missing values
-    # with True, so this error will only happen on newer versions of pandas
-    # TODO: Remove the 'if' condition once we bump pandas min version to 1.2.0 or higher
-    # but leave the test in place.
-    if pd.__version__ > '1.1.5':
-        series = pd.Series(['a', 'b', None], name=column_name, dtype='category')
-        ltypes = {
-            column_name: Boolean,
-        }
-        err_msg = 'Error converting datatype for test_series from type category to type ' \
-            'bool. Please confirm the underlying data is consistent with logical type Boolean.'
-        with pytest.raises(TypeConversionError, match=err_msg):
-            pd.DataFrame(series).ww.init(logical_types=ltypes)
+    series = pd.Series(['a', 'b', None], name=column_name, dtype='category')
+    ltypes = {
+        column_name: Boolean,
+    }
+    err_msg = 'Error converting datatype for test_series from type category to type ' \
+        'bool. Please confirm the underlying data is consistent with logical type Boolean.'
+    with pytest.raises(TypeConversionError, match=err_msg):
+        pd.DataFrame(series).ww.init(logical_types=ltypes)
 
 
 def test_make_index(sample_df):

--- a/woodwork/tests/minimum_core_requirements.txt
+++ b/woodwork/tests/minimum_core_requirements.txt
@@ -1,4 +1,3 @@
-numpy==1.15.4
 pandas==1.2.0
 click==7.1.2
 scikit-learn==0.22

--- a/woodwork/tests/minimum_core_requirements.txt
+++ b/woodwork/tests/minimum_core_requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.15.4
-pandas==1.1.1
+pandas==1.2.0
 click==7.1.2
 scikit-learn==0.22

--- a/woodwork/tests/minimum_dask_requirements.txt
+++ b/woodwork/tests/minimum_dask_requirements.txt
@@ -1,5 +1,4 @@
 dask[dataframe]==2.30.0
-numpy==1.15.4
 pandas==1.2.0
 click==7.1.2
 scikit-learn==0.22

--- a/woodwork/tests/minimum_dask_requirements.txt
+++ b/woodwork/tests/minimum_dask_requirements.txt
@@ -1,5 +1,5 @@
 dask[dataframe]==2.30.0
 numpy==1.15.4
-pandas==1.1.1
+pandas==1.2.0
 click==7.1.2
 scikit-learn==0.22

--- a/woodwork/tests/minimum_koalas_requirements.txt
+++ b/woodwork/tests/minimum_koalas_requirements.txt
@@ -1,6 +1,6 @@
 pyspark==3.0.0
-koalas==1.7.0
+koalas==1.8.0
 numpy==1.15.4
-pandas==1.1.1
+pandas==1.2.0
 click==7.1.2
 scikit-learn==0.22

--- a/woodwork/tests/minimum_koalas_requirements.txt
+++ b/woodwork/tests/minimum_koalas_requirements.txt
@@ -1,6 +1,5 @@
 pyspark==3.0.0
 koalas==1.8.0
-numpy==1.15.4
 pandas==1.2.0
 click==7.1.2
 scikit-learn==0.22

--- a/woodwork/tests/minimum_test_requirements.txt
+++ b/woodwork/tests/minimum_test_requirements.txt
@@ -6,4 +6,4 @@ mock==4.0.3
 boto3==1.10.45
 moto[all]==1.3.14
 smart-open==5.0.0
-pyarrow==2.0.0
+pyarrow==3.0.0


### PR DESCRIPTION
- Updates for koalas 1.8.0
- Closes #836 

Several changes related to Koalas 1.8.0
- bump koalas min version to 1.8.0
- bump pandas min version to 1.2.0
- bump pyarrow min version to 3.0.0
- remove pandas specific code for versions <1.2.0
- Fix tests to use different type casting compatible with koalas 1.8.0
- Update minimum dependency txt files
- Remove numpy from requirements