### PR TITLE
Add `deep` parameter to Woodwork equality checks

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,17 @@
 
 Release Notes
 -------------
-.. Future Release
+Future Release
   ==============
     * Enhancements
+        * Add ``deep`` parameter to Woodwork Accessor and Schema equality checks (:pr:`889`)
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`tamargrey`
 
 v0.3.0 May 3, 2021
 ==================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,7 +3,7 @@
 Release Notes
 -------------
 Future Release
-  ==============
+==============
     * Enhancements
         * Add ``deep`` parameter to Woodwork Accessor and Schema equality checks (:pr:`889`)
     * Fixes

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -196,13 +196,12 @@ class WoodworkColumnAccessor:
             _raise_init_error()
         return self._schema.use_standard_tags
 
-    # --> pass deep to column schema
     def __eq__(self, other, deep=True):
-        if self._schema != other._schema:
+        if not self._schema.__eq__(other._schema, deep=deep):
             return False
         if self._series.name != other._series.name:
             return False
-        if isinstance(self._series, pd.Series):
+        if deep and isinstance(self._series, pd.Series):
             return self._series.equals(other._series)
         return True
 

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -196,7 +196,8 @@ class WoodworkColumnAccessor:
             _raise_init_error()
         return self._schema.use_standard_tags
 
-    def __eq__(self, other):
+    # --> pass deep to column schema
+    def __eq__(self, other, deep=True):
         if self._schema != other._schema:
             return False
         if self._series.name != other._series.name:

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -56,7 +56,7 @@ class ColumnSchema(object):
             return False
         if self.description != other.description:
             return False
-        if self.metadata != other.metadata:
+        if deep and self.metadata != other.metadata:
             return False
 
         return True

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -46,7 +46,8 @@ class ColumnSchema(object):
         semantic_tags = self._get_column_tags(semantic_tags, validate)
         self.semantic_tags = semantic_tags
 
-    def __eq__(self, other):
+    # --> dont include metadata if shallow
+    def __eq__(self, other, deep=True):
         if self.use_standard_tags != other.use_standard_tags:
             return False
         if self.logical_type != other.logical_type:

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -46,7 +46,6 @@ class ColumnSchema(object):
         semantic_tags = self._get_column_tags(semantic_tags, validate)
         self.semantic_tags = semantic_tags
 
-    # --> dont include metadata if shallow
     def __eq__(self, other, deep=True):
         if self.use_standard_tags != other.use_standard_tags:
             return False

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -164,16 +164,15 @@ class WoodworkTableAccessor:
             if self._schema.time_index is not None:
                 self._sort_columns(already_sorted)
 
-    # --> pass to table schema
     def __eq__(self, other, deep=True):
         if self.make_index != other.ww.make_index:
             return False
 
-        if self._schema != other.ww._schema:
+        if not self._schema.__eq__(other.ww._schema, deep=deep):
             return False
 
         # Only check pandas DataFrames for equality
-        if isinstance(self._dataframe, pd.DataFrame) and isinstance(other.ww._dataframe, pd.DataFrame):
+        if deep and isinstance(self._dataframe, pd.DataFrame) and isinstance(other.ww._dataframe, pd.DataFrame):
             return self._dataframe.equals(other.ww._dataframe)
         return True
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -164,7 +164,8 @@ class WoodworkTableAccessor:
             if self._schema.time_index is not None:
                 self._sort_columns(already_sorted)
 
-    def __eq__(self, other):
+    # --> pass to table schema
+    def __eq__(self, other, deep=True):
         if self.make_index != other.ww.make_index:
             return False
 

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -92,9 +92,10 @@ class TableSchema(object):
             return False
         if self.time_index != other.time_index:
             return False
-        if self.columns != other.columns:
-            return False
-        if self.metadata != other.metadata:
+        for col_name in self.columns:
+            if not self.columns[col_name].__eq__(other.columns[col_name], deep=deep):
+                return False
+        if deep and self.metadata != other.metadata:
             return False
 
         return True

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -84,7 +84,8 @@ class TableSchema(object):
 
         self.metadata = table_metadata or {}
 
-    def __eq__(self, other):
+    # --> pass deep to column schema
+    def __eq__(self, other, deep=True):
         if self.name != other.name:
             return False
         if self.index != other.index:

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -91,6 +91,8 @@ class TableSchema(object):
             return False
         if self.time_index != other.time_index:
             return False
+        if set(self.columns.keys()) != set(other.columns.keys()):
+            return False
         for col_name in self.columns:
             if not self.columns[col_name].__eq__(other.columns[col_name], deep=deep):
                 return False

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -84,7 +84,6 @@ class TableSchema(object):
 
         self.metadata = table_metadata or {}
 
-    # --> pass deep to column schema
     def __eq__(self, other, deep=True):
         if self.name != other.name:
             return False

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -627,6 +627,36 @@ def test_accessor_equality(sample_series):
         assert str_col.ww == changed_series.ww
 
 
+def test_accessor_shallow_equality(sample_series):
+    metadata_col = init_series(sample_series.copy(), logical_type='NaturalLanguage',
+                               metadata={'interesting_values': ['a', 'b']})
+    diff_metadata_col = init_series(sample_series.copy(), logical_type='NaturalLanguage',
+                                    metadata={'interesting_values': ['c']})
+
+    assert metadata_col.ww.__eq__(diff_metadata_col.ww, deep=False)
+    assert not metadata_col.ww.__eq__(diff_metadata_col.ww, deep=True)
+
+    schema = metadata_col.ww.schema
+    diff_data_col = metadata_col.replace({'a': '1'})
+    # dtype gets changed to object in replace
+    diff_data_col = diff_data_col.astype('string')
+
+    diff_data_col.ww.init(schema=schema)
+    same_data_col = metadata_col.ww.copy()
+
+    assert diff_data_col.ww.schema == metadata_col.ww.schema
+    assert same_data_col.ww.schema == metadata_col.ww.schema
+
+    assert diff_data_col.ww.__eq__(metadata_col.ww, deep=False)
+    assert same_data_col.ww.__eq__(metadata_col.ww, deep=False)
+    assert same_data_col.ww.__eq__(metadata_col.ww, deep=True)
+    if isinstance(sample_series, pd.Series):
+        # We only check underlying data for equality with pandas dataframes
+        assert not diff_data_col.ww.__eq__(metadata_col.ww, deep=True)
+    else:
+        assert diff_data_col.ww.__eq__(metadata_col.ww, deep=True)
+
+
 def test_accessor_metadata(sample_series):
     column_metadata = {'metadata_field': [1, 2, 3], 'created_by': 'user0'}
 

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -644,8 +644,8 @@ def test_accessor_shallow_equality(sample_series):
     diff_data_col.ww.init(schema=schema)
     same_data_col = metadata_col.ww.copy()
 
-    assert diff_data_col.ww.schema == metadata_col.ww.schema
-    assert same_data_col.ww.schema == metadata_col.ww.schema
+    assert diff_data_col.ww.schema.__eq__(metadata_col.ww.schema, deep=True)
+    assert same_data_col.ww.schema.__eq__(metadata_col.ww.schema, deep=True)
 
     assert diff_data_col.ww.__eq__(metadata_col.ww, deep=False)
     assert same_data_col.ww.__eq__(metadata_col.ww, deep=False)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -360,11 +360,11 @@ def test_accessor_equality(sample_df):
     assert schema_df.ww != copy_df.ww
 
     # Confirm not equal with same schema but different data - only pandas
-    iloc_df = schema_df.ww.loc[:2, :]
+    loc_df = schema_df.ww.loc[:2, :]
     if isinstance(sample_df, pd.DataFrame):
-        assert schema_df.ww != iloc_df
+        assert schema_df.ww != loc_df
     else:
-        assert schema_df.ww == iloc_df
+        assert schema_df.ww == loc_df
 
 
 def test_accessor_equality_make_index(sample_df_pandas):
@@ -378,6 +378,30 @@ def test_accessor_equality_make_index(sample_df_pandas):
     pd.testing.assert_frame_equal(schema_df, made_index_df)
 
     assert made_index_df.ww != schema_df.ww
+
+
+def test_accessor_shallow_equality(sample_df):
+    metadata_table = sample_df.copy()
+    metadata_table.ww.init(table_metadata={'user': 'user0'})
+    diff_metadata_table = sample_df.copy()
+    diff_metadata_table.ww.init(table_metadata={'user': 'user2'})
+
+    assert diff_metadata_table.ww.__eq__(metadata_table, deep=False)
+    assert not diff_metadata_table.ww.__eq__(metadata_table, deep=True)
+
+    schema = metadata_table.ww.schema
+    diff_data_table = metadata_table.ww.loc[:2, :]
+    same_data_table = metadata_table.ww.copy()
+
+    assert diff_data_table.ww.schema.__eq__(schema, deep=True)
+    assert same_data_table.ww.schema.__eq__(schema, deep=True)
+
+    assert same_data_table.ww.__eq__(metadata_table.ww, deep=False)
+    assert same_data_table.ww.__eq__(metadata_table.ww, deep=True)
+
+    assert diff_data_table.ww.__eq__(metadata_table.ww, deep=False)
+    if isinstance(sample_df, pd.DataFrame):
+        assert not diff_data_table.ww.__eq__(metadata_table.ww, deep=True)
 
 
 def test_accessor_init_with_valid_string_time_index(time_index_df):

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -386,6 +386,23 @@ def test_schema_equality():
     assert datetime_col_instantiated == datetime_col_param
 
 
+def test_schema_shallow_equality():
+    no_metadata_1 = ColumnSchema(logical_type=Categorical)
+    no_metadata_2 = ColumnSchema(logical_type=Categorical)
+
+    assert no_metadata_1.__eq__(no_metadata_2, deep=False)
+    assert no_metadata_1.__eq__(no_metadata_2, deep=True)
+
+    metadata_1 = ColumnSchema(logical_type=Categorical, metadata={'interesting_values': ['a', 'b']})
+    metadata_2 = ColumnSchema(logical_type=Categorical, metadata={'interesting_values': ['a', 'b']})
+    metadata_3 = ColumnSchema(logical_type=Categorical, metadata={'interesting_values': ['c', 'd']})
+
+    assert metadata_1.__eq__(metadata_2, deep=False)
+    assert metadata_1.__eq__(metadata_2, deep=True)
+    assert metadata_1.__eq__(metadata_3, deep=False)
+    assert not metadata_1.__eq__(metadata_3, deep=True)
+
+
 def test_schema_repr():
     assert (repr(ColumnSchema(logical_type=Datetime, semantic_tags='time_index')) ==
             "<ColumnSchema (Logical Type = Datetime) (Semantic Tags = ['time_index'])>")

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -167,6 +167,33 @@ def test_schema_equality_standard_tags(sample_column_names, sample_inferred_logi
     assert schema != no_standard_tags_schema
 
 
+def test_schema_shallow_equality(sample_column_names, sample_inferred_logical_types):
+    metadata_table_1 = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                   table_metadata={'user': 'user0'}
+                                   )
+    metadata_table_2 = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                   table_metadata={'user': 'user0'}
+                                   )
+
+    assert metadata_table_1.__eq__(metadata_table_2, deep=False)
+    assert metadata_table_1.__eq__(metadata_table_2, deep=True)
+
+    diff_metadata_table = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                      table_metadata={'user': 'user1'}
+                                      )
+
+    assert metadata_table_1.__eq__(diff_metadata_table, deep=False)
+    assert not metadata_table_1.__eq__(diff_metadata_table, deep=True)
+
+    diff_col_metadata_table = TableSchema(sample_column_names, sample_inferred_logical_types,
+                                          table_metadata={'user': 'user0'},
+                                          column_metadata={'id': {'interesting_values': [0]}}
+                                          )
+
+    assert metadata_table_1.__eq__(diff_col_metadata_table, deep=False)
+    assert not metadata_table_1.__eq__(diff_col_metadata_table, deep=True)
+
+
 def test_schema_table_metadata(sample_column_names, sample_inferred_logical_types):
     metadata = {'secondary_time_index': {'is_registered': 'age'}, 'date_created': '11/13/20'}
 

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -194,7 +194,7 @@ def test_schema_shallow_equality(sample_column_names, sample_inferred_logical_ty
     assert not metadata_table_1.__eq__(diff_col_metadata_table, deep=True)
 
     diff_ltype_table = TableSchema(sample_column_names, {**sample_inferred_logical_types, 'id': Categorical},
-                                   table_metadata={'user': 'user1'}
+                                   table_metadata={'user': 'user0'}
                                    )
     assert not metadata_table_1.__eq__(diff_ltype_table, deep=False)
     assert not metadata_table_1.__eq__(diff_ltype_table, deep=True)

--- a/woodwork/tests/schema/test_table_schema.py
+++ b/woodwork/tests/schema/test_table_schema.py
@@ -193,6 +193,12 @@ def test_schema_shallow_equality(sample_column_names, sample_inferred_logical_ty
     assert metadata_table_1.__eq__(diff_col_metadata_table, deep=False)
     assert not metadata_table_1.__eq__(diff_col_metadata_table, deep=True)
 
+    diff_ltype_table = TableSchema(sample_column_names, {**sample_inferred_logical_types, 'id': Categorical},
+                                   table_metadata={'user': 'user1'}
+                                   )
+    assert not metadata_table_1.__eq__(diff_ltype_table, deep=False)
+    assert not metadata_table_1.__eq__(diff_ltype_table, deep=True)
+
 
 def test_schema_table_metadata(sample_column_names, sample_inferred_logical_types):
     metadata = {'secondary_time_index': {'is_registered': 'age'}, 'date_created': '11/13/20'}


### PR DESCRIPTION
- Adds a `deep` parameter to the Table Accessor, Table Schema, Column Accessor, and Column Schema where a deep check will include the comparison of metadata and underlying data.
- Passes `deep` value from Table Accessor to Table Schema to Column Schema and from Column Accessor to Column Schema.
- Defaults to `deep=True` to match current behavior
- Closes #868 