### PR TITLE
Add support for parquet to read_file

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Future Release
 ==============
     * Enhancements
         * Add ``deep`` parameter to Woodwork Accessor and Schema equality checks (:pr:`889`)
+        * Add support for reading from parquet files to ``woodwork.read_file`` (:pr:`909`)
     * Fixes
     * Changes
         * Remove command line functions for list logical and semantic tags (:pr:`891`)
@@ -15,7 +16,7 @@ Future Release
         * Use Minimum Dependency Generator GitHub Action and remove tools folder (:pr:`897`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`jeff-hernandez`, :user:`tamargrey`
+    :user:`gsheni`, :user:`jeff-hernandez`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 Breaking Changes
 ++++++++++++++++

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -296,6 +296,20 @@ def test_read_file_parquet(sample_df_pandas, tmpdir):
         pd.testing.assert_frame_equal(df_from_parquet, schema_df)
 
 
+def test_read_file_parquet_no_params(sample_df_pandas, tmpdir):
+    filepath = os.path.join(tmpdir, 'sample.parquet')
+    sample_df_pandas.to_parquet(filepath, index=False)
+
+    df_from_parquet = ww.read_file(filepath=filepath)
+    assert isinstance(df_from_parquet.ww.schema, ww.table_schema.TableSchema)
+
+    schema_df = sample_df_pandas.copy()
+    schema_df.ww.init()
+
+    assert df_from_parquet.ww.schema == schema_df.ww.schema
+    pd.testing.assert_frame_equal(df_from_parquet, schema_df)
+
+
 def test_is_numeric_datetime_series(time_index_df):
     assert _is_numeric_series(time_index_df['ints'], None)
     assert _is_numeric_series(time_index_df['ints'], Double)

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -281,17 +281,19 @@ def test_read_file_parquet(sample_df_pandas, tmpdir):
     filepath = os.path.join(tmpdir, 'sample.parquet')
     sample_df_pandas.to_parquet(filepath, index=False)
 
-    df_from_parquet = ww.read_file(filepath=filepath,
-                                   content_type='application/parquet',
-                                   index='id',
-                                   use_nullable_dtypes=True)
-    assert isinstance(df_from_parquet.ww.schema, ww.table_schema.TableSchema)
+    content_types = ['parquet', 'application/parquet']
+    for content_type in content_types:
+        df_from_parquet = ww.read_file(filepath=filepath,
+                                    content_type=content_type,
+                                    index='id',
+                                    use_nullable_dtypes=True)
+        assert isinstance(df_from_parquet.ww.schema, ww.table_schema.TableSchema)
 
-    schema_df = sample_df_pandas.copy()
-    schema_df.ww.init(index='id')
+        schema_df = sample_df_pandas.copy()
+        schema_df.ww.init(index='id')
 
-    assert df_from_parquet.ww.schema == schema_df.ww.schema
-    pd.testing.assert_frame_equal(df_from_parquet, schema_df)
+        assert df_from_parquet.ww.schema == schema_df.ww.schema
+        pd.testing.assert_frame_equal(df_from_parquet, schema_df)
 
 
 def test_is_numeric_datetime_series(time_index_df):

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -284,9 +284,9 @@ def test_read_file_parquet(sample_df_pandas, tmpdir):
     content_types = ['parquet', 'application/parquet']
     for content_type in content_types:
         df_from_parquet = ww.read_file(filepath=filepath,
-                                    content_type=content_type,
-                                    index='id',
-                                    use_nullable_dtypes=True)
+                                       content_type=content_type,
+                                       index='id',
+                                       use_nullable_dtypes=True)
         assert isinstance(df_from_parquet.ww.schema, ww.table_schema.TableSchema)
 
         schema_df = sample_df_pandas.copy()

--- a/woodwork/tests/test_utils.py
+++ b/woodwork/tests/test_utils.py
@@ -277,6 +277,23 @@ def test_read_file_validation_control(mock_validate_accessor_params, sample_df_p
     assert mock_validate_accessor_params.called
 
 
+def test_read_file_parquet(sample_df_pandas, tmpdir):
+    filepath = os.path.join(tmpdir, 'sample.parquet')
+    sample_df_pandas.to_parquet(filepath, index=False)
+
+    df_from_parquet = ww.read_file(filepath=filepath,
+                                   content_type='application/parquet',
+                                   index='id',
+                                   use_nullable_dtypes=True)
+    assert isinstance(df_from_parquet.ww.schema, ww.table_schema.TableSchema)
+
+    schema_df = sample_df_pandas.copy()
+    schema_df.ww.init(index='id')
+
+    assert df_from_parquet.ww.schema == schema_df.ww.schema
+    pd.testing.assert_frame_equal(df_from_parquet, schema_df)
+
+
 def test_is_numeric_datetime_series(time_index_df):
     assert _is_numeric_series(time_index_df['ints'], None)
     assert _is_numeric_series(time_index_df['ints'], Double)

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -27,6 +27,7 @@ PYARROW_ERR_MSG = (
 # Add new mimetypes
 add_type('application/parquet', '.parquet')
 
+
 def import_or_none(library):
     """Attempts to import the requested library.
 

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -12,6 +12,7 @@ import woodwork as ww
 type_to_read_func_map = {
     'csv': pd.read_csv,
     'text/csv': pd.read_csv,
+    'parquet': pd.read_parquet,
     'application/parquet': pd.read_parquet
 }
 

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -90,6 +90,10 @@ def read_file(filepath=None,
               **kwargs):
     """Read data from the specified file and return a DataFrame with initialized Woodwork typing information.
 
+        Note:
+            As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used
+            for reading from parquet.
+                
     Args:
         filepath (str): A valid string path to the file to read
         content_type (str): Content type of file to read

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -93,7 +93,7 @@ def read_file(filepath=None,
         Note:
             As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used
             for reading from parquet.
-                
+
     Args:
         filepath (str): A valid string path to the file to read
         content_type (str): Content type of file to read

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -12,7 +12,16 @@ import woodwork as ww
 type_to_read_func_map = {
     'csv': pd.read_csv,
     'text/csv': pd.read_csv,
+    'application/parquet': pd.read_parquet
 }
+
+PYARROW_ERR_MSG = (
+    "The pyarrow library is required to read from parquet files.\n"
+    "Install via pip:\n"
+    "    pip install 'pyarrow>=3.0.0'\n"
+    "Install via conda:\n"
+    "    conda install 'pyarrow>=3.0.0'"
+)
 
 
 def import_or_none(library):
@@ -114,6 +123,10 @@ def read_file(filepath=None,
 
     if content_type not in type_to_read_func_map:
         raise RuntimeError('Reading from content type {} is not currently supported'.format(content_type))
+
+    if content_type == 'application/parquet':
+        import_or_raise('pyarrow', PYARROW_ERR_MSG)
+        kwargs['engine'] = 'pyarrow'
 
     dataframe = type_to_read_func_map[content_type](filepath, **kwargs)
     dataframe.ww.init(name=name,

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -1,7 +1,7 @@
 import ast
 import importlib
 import re
-from mimetypes import guess_type
+from mimetypes import add_type, guess_type
 
 import numpy as np
 import pandas as pd
@@ -24,6 +24,8 @@ PYARROW_ERR_MSG = (
     "    conda install 'pyarrow>=3.0.0'"
 )
 
+# Add new mimetypes
+add_type('application/parquet', '.parquet')
 
 def import_or_none(library):
     """Attempts to import the requested library.

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -125,7 +125,7 @@ def read_file(filepath=None,
     if content_type not in type_to_read_func_map:
         raise RuntimeError('Reading from content type {} is not currently supported'.format(content_type))
 
-    if content_type == 'application/parquet':
+    if content_type in ['parquet', 'application/parquet']:
         import_or_raise('pyarrow', PYARROW_ERR_MSG)
         kwargs['engine'] = 'pyarrow'
 


### PR DESCRIPTION
- Add support for parquet to read_file
- Closes #839 

Adds support from reading from a parquet file into a Woodwork dataframe using the `ww.read_file` function. Checks that `pyarrow` is installed and raises `ImportError` if not, instructing users to install pyarrow.