### PR TITLE
Add option to return schema to accessor select

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,7 @@
 
 Release Notes
 -------------
+
 Future Release
 ==============
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,7 +3,7 @@
 Release Notes
 -------------
 Future Release
-  ==============
+==============
     * Enhancements
         * Add option to return ``TableSchema`` instead of ``DataFrame`` from table accessor ``select`` method (:pr:`916`)
     * Fixes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,17 @@
 
 Release Notes
 -------------
-.. Future Release
+Future Release
   ==============
     * Enhancements
+        * Add option to return ``TableSchema`` instead of ``DataFrame`` from table accessor ``select`` method (:pr:`9161)
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 
 v0.3.1 May 12, 2021

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,7 +5,7 @@ Release Notes
 Future Release
   ==============
     * Enhancements
-        * Add option to return ``TableSchema`` instead of ``DataFrame`` from table accessor ``select`` method (:pr:`9161)
+        * Add option to return ``TableSchema`` instead of ``DataFrame`` from table accessor ``select`` method (:pr:`916`)
     * Fixes
     * Changes
     * Documentation Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -421,7 +421,7 @@ class WoodworkTableAccessor:
             if updated_series is not series:
                 self._dataframe[col_name] = updated_series
 
-    def select(self, include=None, exclude=None):
+    def select(self, include=None, exclude=None, return_schema=False):
         """Create a DataFrame with Woodwork typing information initialized
         that includes only columns whose Logical Type and semantic tags match
         conditions specified in the list of types and tags to include or exclude.
@@ -435,6 +435,8 @@ class WoodworkTableAccessor:
                 types, semantic tags to include in the DataFrame.
             exclude (str or LogicalType or list[str or LogicalType]): Logical
                 types, semantic tags to exclude from the DataFrame.
+            return_schema (boolen): If True, return only the schema for the
+                matching columns. Defaults to False
 
         Returns:
             DataFrame: The subset of the original DataFrame that matches the
@@ -449,6 +451,9 @@ class WoodworkTableAccessor:
             raise ValueError("Must specify values for either 'include' or 'exclude'.")
 
         cols_to_include = self._schema._filter_cols(include, exclude)
+
+        if return_schema:
+            return self._schema._get_subset_schema(cols_to_include)
         return self._get_subset_df_with_schema(cols_to_include)
 
     def add_semantic_tags(self, semantic_tags):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1677,6 +1677,27 @@ def test_select_instantiated_ltype():
         df.ww.select(ymd_format)
 
 
+def test_select_return_schema(sample_df):
+    sample_df.ww.init()
+    
+    # Multiple column matches
+    df_schema = sample_df.ww.select(include='NaturalLanguage', return_schema=True)
+    assert isinstance(df_schema, TableSchema)
+    assert len(df_schema.columns) == 3
+    assert df_schema == sample_df.ww.select(include='NaturalLanguage').ww.schema
+
+    # Single column match
+    single_schema = sample_df.ww.select(include='BooleanNullable', return_schema=True)
+    assert isinstance(single_schema, TableSchema)
+    assert len(single_schema.columns) == 1
+    assert single_schema == sample_df.ww.select(include='BooleanNullable').ww.schema
+    
+    # No matches
+    empty_schema = sample_df.ww.select(include='Double', return_schema=True)
+    assert isinstance(empty_schema, TableSchema)
+    assert len(empty_schema.columns) == 0
+
+
 def test_select_include_and_exclude_error(sample_df):
     sample_df.ww.init()
     err_msg = "Cannot specify values for both 'include' and 'exclude' in a single call."

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1679,7 +1679,7 @@ def test_select_instantiated_ltype():
 
 def test_select_return_schema(sample_df):
     sample_df.ww.init()
-    
+
     # Multiple column matches
     df_schema = sample_df.ww.select(include='NaturalLanguage', return_schema=True)
     assert isinstance(df_schema, TableSchema)
@@ -1691,7 +1691,7 @@ def test_select_return_schema(sample_df):
     assert isinstance(single_schema, TableSchema)
     assert len(single_schema.columns) == 1
     assert single_schema == sample_df.ww.select(include='BooleanNullable').ww.schema
-    
+
     # No matches
     empty_schema = sample_df.ww.select(include='Double', return_schema=True)
     assert isinstance(empty_schema, TableSchema)


### PR DESCRIPTION
- Add option to return schema to accessor select
- Closes #883

This PR adds a `return_schema` boolean argument to the table accessor select method that returns a TableSchema object for the column matches instead of a DataFrame object. 