### PR TITLE
Add setter and getter methods for name

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -19,8 +19,10 @@ WoodworkTableAccessor
     WoodworkTableAccessor.init
     WoodworkTableAccessor.loc
     WoodworkTableAccessor.logical_types
+    WoodworkTableAccessor.metadata
     WoodworkTableAccessor.mutual_information
     WoodworkTableAccessor.mutual_information_dict
+    WoodworkTableAccessor.name
     WoodworkTableAccessor.physical_types
     WoodworkTableAccessor.pop
     WoodworkTableAccessor.remove_semantic_tags

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -74,9 +74,11 @@ TableSchema
     TableSchema.add_semantic_tags
     TableSchema.index
     TableSchema.logical_types
+    TableSchema.metadata
     TableSchema.rename
     TableSchema.remove_semantic_tags
     TableSchema.reset_semantic_tags
+    TableSchema.name
     TableSchema.semantic_tags
     TableSchema.set_index
     TableSchema.set_time_index
@@ -93,10 +95,12 @@ ColumnSchema
     :toctree: generated/
 
     ColumnSchema
+    ColumnSchema.description
     ColumnSchema.is_boolean
     ColumnSchema.is_categorical
     ColumnSchema.is_datetime
     ColumnSchema.is_numeric
+    ColumnSchema.metadata
     
 Serialization
 =============

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Future Release
     * Enhancements
         * Add option to return ``TableSchema`` instead of ``DataFrame`` from table accessor ``select`` method (:pr:`916`)
     * Fixes
-        * Fix bug when setting table name through accessor (:pr:`942`)
+        * Fix bug when setting table name and metadata through accessor (:pr:`942`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Enhancements
         * Add option to return ``TableSchema`` instead of ``DataFrame`` from table accessor ``select`` method (:pr:`916`)
     * Fixes
+        * Use ``TableSchema``'s name as ``WoodworkTableAccessor``'s name (:pr:`942`)
     * Changes
     * Documentation Changes
     * Testing Changes
@@ -15,7 +16,7 @@ Future Release
         * Create separate worksflows for each CI job (:pr:`919`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`thehomebrewnerd`, :user:`tuethan1999`
 
 
 v0.3.1 May 12, 2021

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Future Release
     * Enhancements
         * Add option to return ``TableSchema`` instead of ``DataFrame`` from table accessor ``select`` method (:pr:`916`)
     * Fixes
-        * Use ``TableSchema``'s name as ``WoodworkTableAccessor``'s name (:pr:`942`)
+        * Fix bug when setting table name through accessor (:pr:`942`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -5,11 +5,7 @@ import weakref
 import pandas as pd
 
 from woodwork.accessor_utils import _get_valid_dtype, _is_series, init_series
-from woodwork.column_schema import (
-    ColumnSchema,
-    _validate_description,
-    _validate_metadata
-)
+from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
     ParametersIgnoredWarning,
     TypingInfoMismatchWarning,
@@ -111,7 +107,6 @@ class WoodworkColumnAccessor:
     def description(self, description):
         if self._schema is None:
             _raise_init_error()
-        _validate_description(description)
         self._schema.description = description
 
     @property
@@ -185,7 +180,6 @@ class WoodworkColumnAccessor:
     def metadata(self, metadata):
         if self._schema is None:
             _raise_init_error()
-        _validate_metadata(metadata)
         self._schema.metadata = metadata
 
     @property

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -83,7 +83,7 @@ class ColumnSchema(object):
     def description(self):
         """Description of the column"""
         return self._description
-    
+
     @description.setter
     def description(self, description):
         _validate_description(description)
@@ -93,7 +93,7 @@ class ColumnSchema(object):
     def metadata(self):
         """Metadata of the column"""
         return self._metadata
-    
+
     @metadata.setter
     def metadata(self, metadata):
         metadata = metadata or {}

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -29,16 +29,12 @@ class ColumnSchema(object):
             metadata (dict[str -> json serializable], optional): Extra metadata provided by the user.
             validate (bool, optional): Whether to perform parameter validation. Defaults to True.
         """
-        if metadata is None:
-            metadata = {}
         self.metadata = metadata
+        self.description = description
 
         if validate:
             if logical_type is not None:
                 _validate_logical_type(logical_type)
-            _validate_description(description)
-            _validate_metadata(metadata)
-        self.description = description
         self.logical_type = logical_type
 
         self.use_standard_tags = use_standard_tags
@@ -79,6 +75,25 @@ class ColumnSchema(object):
             semantic_tags = semantic_tags.union(self.logical_type.standard_tags)
 
         return semantic_tags
+
+    @property
+    def description(self):
+        return self._description
+    
+    @description.setter
+    def description(self, description):
+        _validate_description(description)
+        self._description = description
+
+    @property
+    def metadata(self):
+        return self._metadata
+    
+    @metadata.setter
+    def metadata(self, metadata):
+        metadata = metadata or {}
+        _validate_metadata(metadata)
+        self._metadata = metadata
 
     @property
     def is_numeric(self):

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -29,12 +29,15 @@ class ColumnSchema(object):
             metadata (dict[str -> json serializable], optional): Extra metadata provided by the user.
             validate (bool, optional): Whether to perform parameter validation. Defaults to True.
         """
-        self.metadata = metadata
-        self.description = description
+        metadata = metadata or {}
 
         if validate:
             if logical_type is not None:
                 _validate_logical_type(logical_type)
+            _validate_description(description)
+            _validate_metadata(metadata)
+        self._metadata = metadata
+        self._description = description
         self.logical_type = logical_type
 
         self.use_standard_tags = use_standard_tags
@@ -79,7 +82,7 @@ class ColumnSchema(object):
     @property
     def description(self):
         return self._description
-
+    
     @description.setter
     def description(self, description):
         _validate_description(description)
@@ -88,7 +91,7 @@ class ColumnSchema(object):
     @property
     def metadata(self):
         return self._metadata
-
+    
     @metadata.setter
     def metadata(self, metadata):
         metadata = metadata or {}

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -81,6 +81,7 @@ class ColumnSchema(object):
 
     @property
     def description(self):
+        """Description of the column"""
         return self._description
     
     @description.setter
@@ -90,6 +91,7 @@ class ColumnSchema(object):
 
     @property
     def metadata(self):
+        """Metadata of the column"""
         return self._metadata
     
     @metadata.setter

--- a/woodwork/column_schema.py
+++ b/woodwork/column_schema.py
@@ -79,7 +79,7 @@ class ColumnSchema(object):
     @property
     def description(self):
         return self._description
-    
+
     @description.setter
     def description(self, description):
         _validate_description(description)
@@ -88,7 +88,7 @@ class ColumnSchema(object):
     @property
     def metadata(self):
         return self._metadata
-    
+
     @metadata.setter
     def metadata(self, metadata):
         metadata = metadata or {}

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -249,6 +249,20 @@ class WoodworkTableAccessor:
         return typing_info
 
     @property
+    def name(self):
+        """Name of the underlying schema"""
+        if self._schema is None:
+            _raise_init_error()
+        return self._schema.name
+
+    @name.setter
+    def name(self, new_name):
+        """Sets the name of the underlying schema"""
+        if self._schema is None:
+            _raise_init_error()
+        self._schema.name = new_name
+
+    @property
     def _dataframe(self):
         return self._dataframe_weakref()
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -25,11 +25,7 @@ from woodwork.statistics_utils import (
     _get_mutual_information_dict,
     _get_value_counts
 )
-from woodwork.table_schema import (
-    TableSchema,
-    _check_name,
-    _check_table_metadata
-)
+from woodwork.table_schema import TableSchema
 from woodwork.type_sys.utils import (
     _get_ltype_class,
     _is_numeric_series,
@@ -264,7 +260,6 @@ class WoodworkTableAccessor:
         """Set name of the DataFrame"""
         if self._schema is None:
             _raise_init_error()
-        _check_name(name)
         self._schema.name = name
 
     @property
@@ -279,7 +274,6 @@ class WoodworkTableAccessor:
         """Set metadata of the DataFrame"""
         if self._schema is None:
             _raise_init_error()
-        _check_table_metadata(metadata)
         self._schema.metadata = metadata
 
     @property

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -25,7 +25,7 @@ from woodwork.statistics_utils import (
     _get_mutual_information_dict,
     _get_value_counts
 )
-from woodwork.table_schema import TableSchema
+from woodwork.table_schema import TableSchema, _check_name, _check_table_metadata
 from woodwork.type_sys.utils import (
     _get_ltype_class,
     _is_numeric_series,
@@ -256,11 +256,12 @@ class WoodworkTableAccessor:
         return self._schema.name
 
     @name.setter
-    def name(self, new_name):
+    def name(self, name):
         """Set name of the DataFrame"""
         if self._schema is None:
             _raise_init_error()
-        self._schema.name = new_name
+        _check_name(name)
+        self._schema.name = name
 
     @property
     def metadata(self):
@@ -270,11 +271,12 @@ class WoodworkTableAccessor:
         return self._schema.metadata
 
     @metadata.setter
-    def metadata(self, new_metadata):
+    def metadata(self, metadata):
         """Set metadata of the DataFrame"""
         if self._schema is None:
             _raise_init_error()
-        self._schema.metadata = new_metadata
+        _check_table_metadata(metadata)
+        self._schema.metadata = metadata
 
     @property
     def _dataframe(self):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -25,7 +25,11 @@ from woodwork.statistics_utils import (
     _get_mutual_information_dict,
     _get_value_counts
 )
-from woodwork.table_schema import TableSchema, _check_name, _check_table_metadata
+from woodwork.table_schema import (
+    TableSchema,
+    _check_name,
+    _check_table_metadata
+)
 from woodwork.type_sys.utils import (
     _get_ltype_class,
     _is_numeric_series,

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -263,6 +263,20 @@ class WoodworkTableAccessor:
         self._schema.name = new_name
 
     @property
+    def metadata(self):
+        """Metadata of the DataFrame"""
+        if self._schema is None:
+            _raise_init_error()
+        return self._schema.metadata
+
+    @metadata.setter
+    def metadata(self, new_metadata):
+        """Set metadata of the DataFrame"""
+        if self._schema is None:
+            _raise_init_error()
+        self._schema.metadata = new_metadata
+
+    @property
     def _dataframe(self):
         return self._dataframe_weakref()
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -250,14 +250,14 @@ class WoodworkTableAccessor:
 
     @property
     def name(self):
-        """Name of the underlying schema"""
+        """Name of the DataFrame"""
         if self._schema is None:
             _raise_init_error()
         return self._schema.name
 
     @name.setter
     def name(self, new_name):
-        """Sets the name of the underlying schema"""
+        """Set name of the DataFrame"""
         if self._schema is None:
             _raise_init_error()
         self._schema.name = new_name

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -504,8 +504,8 @@ def _validate_params(column_names, name, index, time_index, logical_types,
     """Check that values supplied during TableSchema initialization are valid"""
     _check_column_names(column_names)
     _check_use_standard_tags(column_names, use_standard_tags)
-    if name and not isinstance(name, str):
-        raise TypeError('TableSchema name must be a string')
+    if name:
+        _check_name(name)
     if index is not None:
         _check_index(column_names, index)
     if logical_types:
@@ -520,6 +520,11 @@ def _validate_params(column_names, name, index, time_index, logical_types,
         _check_semantic_tags(column_names, semantic_tags)
     if column_descriptions:
         _check_column_descriptions(column_names, column_descriptions)
+
+
+def _check_name(name):
+    if not isinstance(name, str):
+        raise TypeError('TableSchema name must be a string')
 
 
 def _check_column_names(column_names):

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -56,11 +56,11 @@ class TableSchema(object):
         """
         if validate:
             # Check that inputs are valid
-            _validate_params(column_names, index, time_index, logical_types, column_metadata, semantic_tags, column_descriptions,
+            _validate_params(column_names, name, index, time_index, logical_types, table_metadata, column_metadata, semantic_tags, column_descriptions,
                              use_standard_tags)
 
-        self.name = name
-        self.metadata = table_metadata
+        self._name = name
+        self._metadata = table_metadata or {}
 
         # use_standard_tags should be a dictionary mapping each column to its boolean
         if isinstance(use_standard_tags, bool):
@@ -521,15 +521,20 @@ class TableSchema(object):
                            validate=False)
 
 
-def _validate_params(column_names, index, time_index, logical_types, column_metadata,
-                     semantic_tags, column_descriptions, use_standard_tags):
+def _validate_params(column_names, name, index, time_index, logical_types,
+                     table_metadata, column_metadata, semantic_tags, column_descriptions,
+                     use_standard_tags):
     """Check that values supplied during TableSchema initialization are valid"""
     _check_column_names(column_names)
     _check_use_standard_tags(column_names, use_standard_tags)
+    if name:
+        _check_name(name)
     if index is not None:
         _check_index(column_names, index)
     if logical_types:
         _check_logical_types(column_names, logical_types)
+    if table_metadata:
+        _check_table_metadata(table_metadata)
     if column_metadata:
         _check_column_metadata(column_names, column_metadata)
     if time_index is not None:

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -547,7 +547,7 @@ def _validate_params(column_names, name, index, time_index, logical_types,
 
 def _check_name(name):
     if not isinstance(name, str):
-        raise TypeError('TableSchema name must be a string')
+        raise TypeError('Table name must be a string')
 
 
 def _check_column_names(column_names):

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -134,7 +134,7 @@ class TableSchema(object):
     def name(self):
         """Name of schema"""
         return self._name
-    
+
     @name.setter
     def name(self, name):
         """Set name of schema"""

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -56,8 +56,8 @@ class TableSchema(object):
         """
         if validate:
             # Check that inputs are valid
-            _validate_params(column_names, name, index, time_index, logical_types, table_metadata, column_metadata, semantic_tags, column_descriptions,
-                             use_standard_tags)
+            _validate_params(column_names, name, index, time_index, logical_types, table_metadata,
+                             column_metadata, semantic_tags, column_descriptions, use_standard_tags)
 
         self._name = name
         self._metadata = table_metadata or {}

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -56,11 +56,11 @@ class TableSchema(object):
         """
         if validate:
             # Check that inputs are valid
-            _validate_params(column_names, name, index, time_index, logical_types,
-                             table_metadata, column_metadata, semantic_tags, column_descriptions,
+            _validate_params(column_names, index, time_index, logical_types, column_metadata, semantic_tags, column_descriptions,
                              use_standard_tags)
 
         self.name = name
+        self.metadata = table_metadata
 
         # use_standard_tags should be a dictionary mapping each column to its boolean
         if isinstance(use_standard_tags, bool):
@@ -81,8 +81,6 @@ class TableSchema(object):
 
         if time_index is not None:
             self.set_time_index(time_index, validate=validate)
-
-        self.metadata = table_metadata or {}
 
     def __eq__(self, other, deep=True):
         if self.name != other.name:
@@ -131,6 +129,30 @@ class TableSchema(object):
                                     dtype="object")
         df.index.name = 'Column'
         return df
+
+    @property
+    def name(self):
+        """Name of schema"""
+        return self._name
+    
+    @name.setter
+    def name(self, name):
+        """Set name of schema"""
+        if name:
+            _check_name(name)
+        self._name = name
+
+    @property
+    def metadata(self):
+        """Metadata of the table"""
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """Set table metadata"""
+        if metadata:
+            _check_table_metadata(metadata)
+        self._metadata = metadata or {}
 
     @property
     def logical_types(self):
@@ -499,19 +521,15 @@ class TableSchema(object):
                            validate=False)
 
 
-def _validate_params(column_names, name, index, time_index, logical_types,
-                     table_metadata, column_metadata, semantic_tags, column_descriptions, use_standard_tags):
+def _validate_params(column_names, index, time_index, logical_types, column_metadata,
+                     semantic_tags, column_descriptions, use_standard_tags):
     """Check that values supplied during TableSchema initialization are valid"""
     _check_column_names(column_names)
     _check_use_standard_tags(column_names, use_standard_tags)
-    if name:
-        _check_name(name)
     if index is not None:
         _check_index(column_names, index)
     if logical_types:
         _check_logical_types(column_names, logical_types)
-    if table_metadata:
-        _check_table_metadata(table_metadata)
     if column_metadata:
         _check_column_metadata(column_names, column_metadata)
     if time_index is not None:

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -192,7 +192,6 @@ def test_set_accessor_metadata(sample_df):
     df.ww.init()
     assert df.ww.metadata == {}
     df.ww.metadata = {'new': 'metadata'}
-    df.ww.metadata
     assert df.ww.schema.metadata == {'new': 'metadata'}
     assert df.ww.metadata == {'new': 'metadata'}
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -168,6 +168,44 @@ def test_name_persists_after_drop(sample_df):
     assert dropped_df.ww.schema.name == 'name'
 
 
+def test_set_accessor_metadata(sample_df):
+    df = sample_df.copy()
+    error = re.escape("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
+    with pytest.raises(WoodworkNotInitError, match=error):
+        df.ww.metadata
+    with pytest.raises(WoodworkNotInitError, match=error):
+        df.ww.metadata = {'new': 'metadata'}
+
+    df.ww.init()
+    assert df.ww.metadata == {}
+    df.ww.metadata = {'new': 'metadata'}
+    #breakpoint()
+    df.ww.metadata
+    assert df.ww.schema.metadata == {'new': 'metadata'}
+    assert df.ww.metadata == {'new': 'metadata'}
+
+
+def test_set_metadata_after_init_with_metadata(sample_df):
+    df = sample_df.copy()
+    df.ww.init(table_metadata={'new': 'metadata'})
+    assert df.ww.metadata == {'new': 'metadata'}
+    df.ww.metadata = {'new': 'new_metadata'}
+    assert df.ww.schema.metadata == {'new': 'new_metadata'}
+    assert df.ww.metadata == {'new': 'new_metadata'}
+
+
+def test_metadata_persists_after_drop(sample_df):
+    df = sample_df.copy()
+    df.ww.init()
+
+    df.ww.metadata = {'new': 'metadata'}
+    assert df.ww.metadata == {'new': 'metadata'}
+
+    dropped_df = df.ww.drop(['id'])
+    assert dropped_df.ww.metadata == {'new': 'metadata'}
+    assert dropped_df.ww.schema.metadata == {'new': 'metadata'}
+
+
 def test_accessor_physical_types_property(sample_df):
     sample_df.ww.init(logical_types={'age': 'Categorical'})
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -137,6 +137,8 @@ def test_set_accessor_name(sample_df):
     error = re.escape("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
     with pytest.raises(WoodworkNotInitError, match=error):
         df.ww.name
+    with pytest.raises(WoodworkNotInitError, match=error):
+        df.ww.name = 'name'
 
     df.ww.init()
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -157,14 +157,14 @@ def test_rename_init_with_name(sample_df):
 
 
 def test_name_error_on_init(sample_df):
-    err_msg = "TableSchema name must be a string"
+    err_msg = "Table name must be a string"
     with pytest.raises(TypeError, match=err_msg):
         sample_df.ww.init(name=123)
 
 
 def test_name_error_on_update(sample_df):
     sample_df.ww.init()
-    err_msg = "TableSchema name must be a string"
+    err_msg = "Table name must be a string"
     with pytest.raises(TypeError, match=err_msg):
         sample_df.ww.name = 123
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -156,6 +156,19 @@ def test_rename_init_with_name(sample_df):
     assert df.ww.name == 'new_name'
 
 
+def test_name_error_on_init(sample_df):
+    err_msg = "TableSchema name must be a string"
+    with pytest.raises(TypeError, match=err_msg):
+        sample_df.ww.init(name=123)
+
+
+def test_name_error_on_update(sample_df):
+    sample_df.ww.init()
+    err_msg = "TableSchema name must be a string"
+    with pytest.raises(TypeError, match=err_msg):
+        sample_df.ww.name = 123
+
+
 def test_name_persists_after_drop(sample_df):
     df = sample_df.copy()
     df.ww.init()
@@ -203,6 +216,19 @@ def test_metadata_persists_after_drop(sample_df):
     dropped_df = df.ww.drop(['id'])
     assert dropped_df.ww.metadata == {'new': 'metadata'}
     assert dropped_df.ww.schema.metadata == {'new': 'metadata'}
+
+
+def test_metadata_error_on_init(sample_df):
+    err_msg = 'Table metadata must be a dictionary.'
+    with pytest.raises(TypeError, match=err_msg):
+        sample_df.ww.init(table_metadata=123)
+
+
+def test_metadata_error_on_update(sample_df):
+    sample_df.ww.init()
+    err_msg = 'Table metadata must be a dictionary.'
+    with pytest.raises(TypeError, match=err_msg):
+        sample_df.ww.metadata = 123
 
 
 def test_accessor_physical_types_property(sample_df):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -150,7 +150,7 @@ def test_set_accessor_name(sample_df):
 def test_rename_init_with_name(sample_df):
     df = sample_df.copy()
     df.ww.init(name='name')
-    assert df.ww.name is 'name'
+    assert df.ww.name == 'name'
     df.ww.name = 'new_name'
     assert df.ww.schema.name == 'new_name'
     assert df.ww.name == 'new_name'
@@ -179,7 +179,6 @@ def test_set_accessor_metadata(sample_df):
     df.ww.init()
     assert df.ww.metadata == {}
     df.ww.metadata = {'new': 'metadata'}
-    #breakpoint()
     df.ww.metadata
     assert df.ww.schema.metadata == {'new': 'metadata'}
     assert df.ww.metadata == {'new': 'metadata'}

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -132,6 +132,34 @@ def test_accessor_schema_property(sample_df):
     assert sample_df.ww._schema == sample_df.ww.schema
 
 
+def test_set_accessor_name(sample_df):
+    df = sample_df.copy()
+    error = re.escape("Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init")
+    with pytest.raises(WoodworkNotInitError, match=error):
+        df.ww.name
+
+    df.ww.init()
+
+    assert df.ww.name is None
+
+    df.ww.name = 'name'
+
+    assert df.ww.schema.name == 'name'
+    assert df.ww.name == 'name'
+
+
+def test_name_persists_after_drop(sample_df):
+    df = sample_df.copy()
+    df.ww.init()
+
+    df.ww.name = 'name'
+    assert df.ww.name == 'name'
+
+    dropped_df = df.ww.drop(['id'])
+    assert dropped_df.ww.name == 'name'
+    assert dropped_df.ww.schema.name == 'name'
+
+
 def test_accessor_physical_types_property(sample_df):
     sample_df.ww.init(logical_types={'age': 'Categorical'})
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -141,13 +141,19 @@ def test_set_accessor_name(sample_df):
         df.ww.name = 'name'
 
     df.ww.init()
-
     assert df.ww.name is None
-
     df.ww.name = 'name'
-
     assert df.ww.schema.name == 'name'
     assert df.ww.name == 'name'
+
+
+def test_rename_init_with_name(sample_df):
+    df = sample_df.copy()
+    df.ww.init(name='name')
+    assert df.ww.name is 'name'
+    df.ww.name = 'new_name'
+    assert df.ww.schema.name == 'new_name'
+    assert df.ww.name == 'new_name'
 
 
 def test_name_persists_after_drop(sample_df):

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -28,7 +28,7 @@ from woodwork.table_schema import (
 
 
 def test_validate_params_errors(sample_column_names):
-    error_message = 'TableSchema name must be a string'
+    error_message = 'Table name must be a string'
     with pytest.raises(TypeError, match=error_message):
         _validate_params(column_names=sample_column_names,
                          name=1,


### PR DESCRIPTION
- Add getter and setter methods to use `TableAccessor._schema`'s name and metadata as the name and metadata properties
- Change the ColumnAccessor._schema's description and metadata to use the underlying `ColumnSchema`'s description and metadata
- Closes #918 