### PR TITLE
Fix serialization bug for categorical types

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Future Release
         * Add option to pass progress callback function to mutual information functions (:pr:`943`)
     * Fixes
         * Fix bug when setting table name and metadata through accessor (:pr:`942`)
+        * Fix bug in which the dtype of category values were not restored properly on deserialization (:pr:`949`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -85,8 +85,9 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
         if col['physical_type']['type'] == 'category':
             # Make sure categories are recreated properly
             cat_values = col['physical_type']['cat_values']
+            cat_dtype = col['physical_type']['cat_dtype']
             if table_type == 'pandas':
-                cat_object = pd.CategoricalDtype(pd.Index(cat_values, dtype='object'))
+                cat_object = pd.CategoricalDtype(pd.Index(cat_values, dtype=cat_dtype))
             else:
                 cat_object = pd.CategoricalDtype(pd.Series(cat_values))
             category_dtypes[col_name] = cat_object
@@ -191,6 +192,6 @@ def _check_schema_version(saved_version_str):
             break
 
     # Check if saved has older major version.
-    if current[0] > saved[0]:
+    if int(current[0]) > int(saved[0]):
         warnings.warn(OutdatedSchemaWarning().get_warning_message(saved_version_str),
                       OutdatedSchemaWarning)

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -17,7 +17,7 @@ from woodwork.utils import _is_s3, _is_url, import_or_none
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
 
-SCHEMA_VERSION = '9.0.0'
+SCHEMA_VERSION = '10.0.0'
 FORMATS = ['csv', 'pickle', 'parquet']
 
 
@@ -48,7 +48,8 @@ def typing_info_to_dict(dataframe):
          'physical_type': {
              'type': str(dataframe[col_name].dtype),
              # Store categorical values so they can be recreated if they are modified during serialization
-             'cat_values': dataframe[col_name].dtype.categories.to_list() if str(dataframe[col_name].dtype) == 'category' else None
+             'cat_values': dataframe[col_name].dtype.categories.to_list() if str(dataframe[col_name].dtype) == 'category' else None,
+             'cat_dtype': str(dataframe[col_name].dtype.categories.dtype) if str(dataframe[col_name].dtype) == 'category' else None
          },
          'semantic_tags': sorted(list(col.semantic_tags)),
          'description': col.description,

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -38,11 +38,9 @@ def typing_info_to_dict(dataframe):
         dataframe = dataframe.ww.categorize(columns=category_cols)
     ordered_columns = dataframe.columns
 
-    def get_physical_type_dict(column):
-        type_dict = {}
-        column_dtype = str(column.dtype)
-        type_dict['type'] = column_dtype
-        if column_dtype == 'category':
+    def _get_physical_type_dict(column):
+        type_dict = {'type': str(column.dtype)}
+        if str(column.dtype) == 'category':
             type_dict['cat_values'] = column.dtype.categories.to_list()
             type_dict['cat_dtype'] = str(column.dtype.categories.dtype)
         return type_dict
@@ -55,7 +53,7 @@ def typing_info_to_dict(dataframe):
              'parameters': _get_specified_ltype_params(col.logical_type),
              'type': str(_get_ltype_class(col.logical_type))
          },
-         'physical_type': get_physical_type_dict(dataframe[col_name]),
+         'physical_type': _get_physical_type_dict(dataframe[col_name]),
          'semantic_tags': sorted(list(col.semantic_tags)),
          'description': col.description,
          'metadata': col.metadata,

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -37,6 +37,16 @@ def typing_info_to_dict(dataframe):
         category_cols = [colname for colname, col in dataframe.ww._schema.columns.items() if col.is_categorical]
         dataframe = dataframe.ww.categorize(columns=category_cols)
     ordered_columns = dataframe.columns
+
+    def get_physical_type_dict(column):
+        type_dict = {}
+        column_dtype = str(column.dtype)
+        type_dict['type'] = column_dtype
+        if column_dtype == 'category':
+            type_dict['cat_values'] = column.dtype.categories.to_list()
+            type_dict['cat_dtype'] = str(column.dtype.categories.dtype)
+        return type_dict
+
     column_typing_info = [
         {'name': col_name,
          'ordinal': ordered_columns.get_loc(col_name),
@@ -45,12 +55,7 @@ def typing_info_to_dict(dataframe):
              'parameters': _get_specified_ltype_params(col.logical_type),
              'type': str(_get_ltype_class(col.logical_type))
          },
-         'physical_type': {
-             'type': str(dataframe[col_name].dtype),
-             # Store categorical values so they can be recreated if they are modified during serialization
-             'cat_values': dataframe[col_name].dtype.categories.to_list() if str(dataframe[col_name].dtype) == 'category' else None,
-             'cat_dtype': str(dataframe[col_name].dtype.categories.dtype) if str(dataframe[col_name].dtype) == 'category' else None
-         },
+         'physical_type': get_physical_type_dict(dataframe[col_name]),
          'semantic_tags': sorted(list(col.semantic_tags)),
          'description': col.description,
          'metadata': col.metadata,

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -13,7 +13,7 @@ from woodwork.exceptions import (
     UpgradeSchemaWarning,
     WoodworkNotInitError
 )
-from woodwork.logical_types import Ordinal
+from woodwork.logical_types import Categorical, Ordinal
 from woodwork.tests.testing_utils import to_pandas
 from woodwork.utils import import_or_none
 
@@ -23,7 +23,7 @@ ks = import_or_none('databricks.koalas')
 BUCKET_NAME = "test-bucket"
 WRITE_KEY_NAME = "test-key"
 TEST_S3_URL = "s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)
-TEST_FILE = "test_serialization_woodwork_table_schema_9.0.0.tar"
+TEST_FILE = "test_serialization_woodwork_table_schema_10.0.0.tar"
 S3_URL = "s3://woodwork-static/" + TEST_FILE
 URL = "https://woodwork-static.s3.amazonaws.com/" + TEST_FILE
 TEST_KEY = "test_access_key_es"
@@ -48,22 +48,25 @@ def test_error_before_table_init(sample_df, tmpdir):
 def test_to_dictionary(sample_df):
     if dd and isinstance(sample_df, dd.DataFrame):
         table_type = 'dask'
-    elif ks and isinstance(sample_df, ks.DataFrame):
-        table_type = 'koalas'
-    else:
-        table_type = 'pandas'
-
-    if ks and isinstance(sample_df, ks.DataFrame):
-        cat_str = 'string'
-        cat_data = None
-    else:
         cat_str = 'category'
         cat_data = [33, 57]
+        cat_dtype = 'int64'
+    elif ks and isinstance(sample_df, ks.DataFrame):
+        table_type = 'koalas'
+        cat_str = 'string'
+        cat_data = None
+        cat_dtype = None
+    else:
+        table_type = 'pandas'
+        cat_str = 'category'
+        cat_data = [33, 57]
+        cat_dtype = 'object'
+
     int_val = 'int64'
     string_val = 'string'
     bool_val = 'boolean'
 
-    expected = {'schema_version': '9.0.0',
+    expected = {'schema_version': '10.0.0',
                 'name': 'test_data',
                 'index': 'id',
                 'time_index': None,
@@ -72,7 +75,8 @@ def test_to_dictionary(sample_df):
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'Integer'},
                                         'physical_type': {'type': int_val,
-                                                          'cat_values': None},
+                                                          'cat_values': None,
+                                                          'cat_dtype': None},
                                         'semantic_tags': ['index', 'tag1'],
                                         'description': None,
                                         'metadata':{'is_sorted': True}},
@@ -81,7 +85,8 @@ def test_to_dictionary(sample_df):
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
                                         'physical_type': {'type': string_val,
-                                                          'cat_values': None},
+                                                          'cat_values': None,
+                                                          'cat_dtype': None},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata':{}},
@@ -90,7 +95,8 @@ def test_to_dictionary(sample_df):
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
                                         'physical_type': {'type': string_val,
-                                                          'cat_values': None},
+                                                          'cat_values': None,
+                                                          'cat_dtype': None},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata':{}},
@@ -99,7 +105,8 @@ def test_to_dictionary(sample_df):
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
                                         'physical_type': {'type': string_val,
-                                                          'cat_values': None},
+                                                          'cat_values': None,
+                                                          'cat_dtype': None},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata': {}},
@@ -108,7 +115,8 @@ def test_to_dictionary(sample_df):
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {'order': [25, 33, 57]}, 'type': 'Ordinal'},
                                         'physical_type': {'type': cat_str,
-                                                          'cat_values': cat_data},
+                                                          'cat_values': cat_data,
+                                                          'cat_dtype': cat_dtype},
                                         'semantic_tags': ['category'],
                                         'description': 'age of the user',
                                         'metadata':{'interesting_values': [33, 57]}},
@@ -118,7 +126,8 @@ def test_to_dictionary(sample_df):
                                         'logical_type': {'parameters': {},
                                                          'type': 'Datetime'},
                                         'physical_type': {'type': 'datetime64[ns]',
-                                                          'cat_values': None},
+                                                          'cat_values': None,
+                                                          'cat_dtype': None},
                                         'semantic_tags': [],
                                         'description': 'original signup date',
                                         'metadata':{}},
@@ -127,7 +136,8 @@ def test_to_dictionary(sample_df):
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'BooleanNullable'},
                                         'physical_type': {'type': bool_val,
-                                                          'cat_values': None},
+                                                          'cat_values': None,
+                                                          'cat_dtype': None},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata':{}}],
@@ -265,6 +275,30 @@ def test_to_parquet_with_latlong(latlong_df, tmpdir):
     pd.testing.assert_frame_equal(to_pandas(latlong_df, index=latlong_df.ww.index, sort_index=True),
                                   to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True))
     assert latlong_df.ww.schema == deserialized_df.ww.schema
+
+
+def test_categorical_dtype_serialization(serialize_df, tmpdir):
+    ltypes = {
+        'cat_int': Categorical,
+        'ord_int': Ordinal(order=[1, 2]),
+        'cat_float': Categorical,
+        'ord_float': Ordinal(order=[1.0, 2.0]),
+        'cat_bool': Categorical,
+        'ord_bool': Ordinal(order=[True, False]),
+    }
+    if isinstance(serialize_df, pd.DataFrame):
+        formats = ['csv', 'pickle', 'parquet']
+    else:
+        formats = ['csv']
+
+    for format in formats:
+        df = serialize_df.copy()
+        df.ww.init(index='id', logical_types=ltypes)
+        df.ww.to_disk(str(tmpdir), format=format)
+        deserialized_df = deserialize.read_woodwork_table(str(tmpdir))
+        pd.testing.assert_frame_equal(to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),
+                                      to_pandas(df, index=df.ww.index, sort_index=True))
+        assert deserialized_df.ww.schema == df.ww.schema
 
 
 @pytest.fixture

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -48,19 +48,23 @@ def test_error_before_table_init(sample_df, tmpdir):
 def test_to_dictionary(sample_df):
     if dd and isinstance(sample_df, dd.DataFrame):
         table_type = 'dask'
-        cat_str = 'category'
-        cat_data = [33, 57]
-        cat_dtype = 'int64'
+        cat_type_dict = {
+            'type': 'category',
+            'cat_values': [33, 57],
+            'cat_dtype': 'int64'
+        }
     elif ks and isinstance(sample_df, ks.DataFrame):
         table_type = 'koalas'
-        cat_str = 'string'
-        cat_data = None
-        cat_dtype = None
+        cat_type_dict = {
+            'type': 'string'
+        }
     else:
         table_type = 'pandas'
-        cat_str = 'category'
-        cat_data = [33, 57]
-        cat_dtype = 'object'
+        cat_type_dict = {
+            'type': 'category',
+            'cat_values': [33, 57],
+            'cat_dtype': 'object'
+        }
 
     int_val = 'int64'
     string_val = 'string'
@@ -74,9 +78,7 @@ def test_to_dictionary(sample_df):
                                         'ordinal': 0,
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'Integer'},
-                                        'physical_type': {'type': int_val,
-                                                          'cat_values': None,
-                                                          'cat_dtype': None},
+                                        'physical_type': {'type': int_val},
                                         'semantic_tags': ['index', 'tag1'],
                                         'description': None,
                                         'metadata':{'is_sorted': True}},
@@ -84,9 +86,7 @@ def test_to_dictionary(sample_df):
                                         'ordinal': 1,
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
-                                        'physical_type': {'type': string_val,
-                                                          'cat_values': None,
-                                                          'cat_dtype': None},
+                                        'physical_type': {'type': string_val},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata':{}},
@@ -94,9 +94,7 @@ def test_to_dictionary(sample_df):
                                         'ordinal': 2,
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
-                                        'physical_type': {'type': string_val,
-                                                          'cat_values': None,
-                                                          'cat_dtype': None},
+                                        'physical_type': {'type': string_val},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata':{}},
@@ -104,9 +102,7 @@ def test_to_dictionary(sample_df):
                                         'ordinal': 3,
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'NaturalLanguage'},
-                                        'physical_type': {'type': string_val,
-                                                          'cat_values': None,
-                                                          'cat_dtype': None},
+                                        'physical_type': {'type': string_val},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata': {}},
@@ -114,9 +110,7 @@ def test_to_dictionary(sample_df):
                                         'ordinal': 4,
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {'order': [25, 33, 57]}, 'type': 'Ordinal'},
-                                        'physical_type': {'type': cat_str,
-                                                          'cat_values': cat_data,
-                                                          'cat_dtype': cat_dtype},
+                                        'physical_type': cat_type_dict,
                                         'semantic_tags': ['category'],
                                         'description': 'age of the user',
                                         'metadata':{'interesting_values': [33, 57]}},
@@ -125,9 +119,7 @@ def test_to_dictionary(sample_df):
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {},
                                                          'type': 'Datetime'},
-                                        'physical_type': {'type': 'datetime64[ns]',
-                                                          'cat_values': None,
-                                                          'cat_dtype': None},
+                                        'physical_type': {'type': 'datetime64[ns]'},
                                         'semantic_tags': [],
                                         'description': 'original signup date',
                                         'metadata':{}},
@@ -135,9 +127,7 @@ def test_to_dictionary(sample_df):
                                         'ordinal': 6,
                                         'use_standard_tags': True,
                                         'logical_type': {'parameters': {}, 'type': 'BooleanNullable'},
-                                        'physical_type': {'type': bool_val,
-                                                          'cat_values': None,
-                                                          'cat_dtype': None},
+                                        'physical_type': {'type': bool_val},
                                         'semantic_tags': [],
                                         'description': None,
                                         'metadata':{}}],

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -522,3 +522,34 @@ def sample_inferred_logical_types():
             'age': Integer,
             'signup_date': Datetime,
             'is_registered': Boolean}
+
+
+@pytest.fixture
+def serialize_df_pandas():
+    df = pd.DataFrame({
+        'id': [0, 1, 2],
+        'cat_int': [1, 2, 1],
+        'ord_int': [1, 2, 1],
+        'cat_float': [1.0, 2.0, 1.0],
+        'ord_float': [1.0, 2.0, 1.0],
+        'cat_bool': [True, False, True],
+        'ord_bool': [True, False, True],
+    })
+    return df
+
+
+@pytest.fixture()
+def serialize_df_dask(serialize_df_pandas):
+    dd = pytest.importorskip('dask.dataframe', reason='Dask not installed, skipping')
+    return dd.from_pandas(serialize_df_pandas, npartitions=2)
+
+
+@pytest.fixture()
+def serialize_df_koalas(serialize_df_pandas):
+    ks = pytest.importorskip('databricks.koalas', reason='Koalas not installed, skipping')
+    return ks.from_pandas(serialize_df_pandas)
+
+
+@pytest.fixture(params=['serialize_df_pandas', 'serialize_df_dask', 'serialize_df_koalas'])
+def serialize_df(request):
+    return request.getfixturevalue(request.param)


### PR DESCRIPTION
- Fix serialization bug for categorical types
- Closes #947 

Fixes a bug in which deserialization did not properly restore the dtype used to store the values associated with a categorical column causing the original and deserialized dataframes to evaluate as unequal during equality checks.