### PR TITLE
Fix type system test bug

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,9 +11,10 @@ Future Release
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Fix bug in ``test_list_logical_types_default`` (:pr:`954`)
 
     Thanks to the following people for contributing to this release:
-    :user:`tamargrey`
+    :user:`tamargrey`, :user:`thehomebrewnerd`
     
 
 v0.4.0 May 26, 2021

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -23,6 +23,7 @@ from woodwork.logical_types import (
     PostalCode,
     SubRegionCode
 )
+from woodwork.type_sys.type_system import DEFAULT_INFERENCE_FUNCTIONS
 from woodwork.type_sys.utils import (
     _get_specified_ltype_params,
     _is_numeric_series,
@@ -113,10 +114,9 @@ def test_list_logical_types_default():
                                'standard_tags', 'is_default_type', 'is_registered', 'parent_type'}
 
     assert len(all_ltypes) == len(df)
-    for name in df['name']:
-        assert ww.type_system.str_to_logical_type(name) in all_ltypes
-    assert all(df['is_default_type'])
-    assert all(df['is_registered'])
+    default_types_set = {str(cls) for cls in DEFAULT_INFERENCE_FUNCTIONS.keys()}
+    listed_as_default = set(df[df['is_default_type']]['name'])
+    assert listed_as_default == default_types_set
 
 
 def test_list_logical_types_customized_type_system():

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -318,7 +318,6 @@ class TypeSystem(object):
     def str_to_logical_type(self, logical_str, params=None, raise_error=True):
         """Helper function for converting a string value to the corresponding logical type object.
         If a dictionary of params for the logical type is provided, apply them."""
-
         logical_str_lower = logical_str.lower()
         logical_types_dict = {ltype_name.lower(): ltype for ltype_name, ltype in self._get_logical_types().items()}
 

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -318,6 +318,7 @@ class TypeSystem(object):
     def str_to_logical_type(self, logical_str, params=None, raise_error=True):
         """Helper function for converting a string value to the corresponding logical type object.
         If a dictionary of params for the logical type is provided, apply them."""
+
         logical_str_lower = logical_str.lower()
         logical_types_dict = {ltype_name.lower(): ltype for ltype_name, ltype in self._get_logical_types().items()}
 


### PR DESCRIPTION
This PR fixes a bug in `test_list_logical_types_default` in `test_utils.py` that was caused by changing the order in which tests were run, causing custom logical types to show up in the output of `list_logical_types()` when they did not before because they had not been created yet. This update to the test should be more robust to future test order changes.