### PR TITLE
Fix issue related to serialization of strings containing whitespace characters

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Enhancements
         * Add ``concat_columns`` util function to concatenate multiple Woodwork objects into one, retaining typing information (:pr:`932`)
     * Fixes
+        * Fix issue related to serialization/deserialization of data with whitespace and newline characters (:pr:`957`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -114,13 +114,13 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
     else:
         lib = pd
 
+    if 'index' in kwargs.keys():
+        del kwargs['index']
     if load_format == 'csv':
         dataframe = lib.read_csv(
             file,
-            engine=kwargs['engine'],
-            compression=compression,
-            encoding=kwargs['encoding'],
             dtype=category_dtypes,
+            **kwargs
         )
     elif load_format == 'pickle':
         dataframe = pd.read_pickle(file, **kwargs)

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -92,7 +92,6 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
                 cat_object = pd.CategoricalDtype(pd.Series(cat_values))
             category_dtypes[col_name] = cat_object
 
-    compression = kwargs['compression']
     if table_type == 'dask':
         DASK_ERR_MSG = (
             'Cannot load Dask DataFrame - unable to import Dask.\n\n'
@@ -110,7 +109,8 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
             'conda install pyspark'
         )
         lib = import_or_raise('databricks.koalas', KOALAS_ERR_MSG)
-        compression = str(compression)
+        if 'compression' in kwargs.keys():
+            kwargs['compression'] = str(kwargs['compression'])
     else:
         lib = pd
 

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -155,19 +155,12 @@ def write_dataframe(dataframe, path, format='csv', **kwargs):
     file = os.path.join(path, location)
 
     if format == 'csv':
-        compression = kwargs['compression']
         if ks and isinstance(dataframe, ks.DataFrame):
             dataframe = dataframe.ww.copy()
             columns = list(dataframe.select_dtypes('object').columns)
             dataframe[columns] = dataframe[columns].astype(str)
-            compression = str(compression)
-        dataframe.to_csv(
-            file,
-            index=kwargs['index'],
-            sep=kwargs['sep'],
-            encoding=kwargs['encoding'],
-            compression=compression
-        )
+            kwargs['compression'] = str(kwargs['compression'])
+        dataframe.to_csv(file, **kwargs)
     elif format == 'pickle':
         # Dask and Koalas currently do not support to_pickle
         if not isinstance(dataframe, pd.DataFrame):

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -155,12 +155,16 @@ def write_dataframe(dataframe, path, format='csv', **kwargs):
     file = os.path.join(path, location)
 
     if format == 'csv':
+        # engine kwarg not needed for writing, only reading
+        csv_kwargs = kwargs.copy()
+        if 'engine' in csv_kwargs.keys():
+            del csv_kwargs['engine']
         if ks and isinstance(dataframe, ks.DataFrame):
             dataframe = dataframe.ww.copy()
             columns = list(dataframe.select_dtypes('object').columns)
             dataframe[columns] = dataframe[columns].astype(str)
-            kwargs['compression'] = str(kwargs['compression'])
-        dataframe.to_csv(file, **kwargs)
+            csv_kwargs['compression'] = str(csv_kwargs['compression'])
+        dataframe.to_csv(file, **csv_kwargs)
     elif format == 'pickle':
         # Dask and Koalas currently do not support to_pickle
         if not isinstance(dataframe, pd.DataFrame):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -549,8 +549,12 @@ class WoodworkTableAccessor:
         """
         if self._schema is None:
             _raise_init_error()
-        default_csv_kwargs = {'sep': ',', 'encoding': 'utf-8', 'engine': 'python', 'index': False}
         if format == 'csv':
+            default_csv_kwargs = {'sep': ',', 'encoding': 'utf-8', 'index': False}
+            if ks and isinstance(self._dataframe, ks.DataFrame):
+                default_csv_kwargs['multiline'] = True
+                default_csv_kwargs['ignoreLeadingWhitespace'] = False
+                default_csv_kwargs['ignoreTrailingWhitespace'] = False
             kwargs = {**default_csv_kwargs, **kwargs}
         elif format == 'parquet':
             import_error_message = (

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -550,7 +550,7 @@ class WoodworkTableAccessor:
         if self._schema is None:
             _raise_init_error()
         if format == 'csv':
-            default_csv_kwargs = {'sep': ',', 'encoding': 'utf-8', 'index': False}
+            default_csv_kwargs = {'sep': ',', 'encoding': 'utf-8', 'engine': 'python', 'index': False}
             if ks and isinstance(self._dataframe, ks.DataFrame):
                 default_csv_kwargs['multiline'] = True
                 default_csv_kwargs['ignoreLeadingWhitespace'] = False

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -157,7 +157,7 @@ def test_unserializable_table(sample_df, tmpdir):
 
     error = "Woodwork table is not json serializable. Check table and column metadata for values that may not be serializable."
     with pytest.raises(TypeError, match=error):
-        sample_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8')
+        sample_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8', engine='python')
 
 
 def test_serialize_wrong_format(sample_df, tmpdir):
@@ -181,7 +181,7 @@ def test_to_csv(sample_df, tmpdir):
                              'age': 'age of the user'},
         column_metadata={'id': {'is_sorted': True},
                          'age': {'interesting_values': [33, 57]}})
-    sample_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8')
+    sample_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8', engine='python')
     deserialized_df = deserialize.read_woodwork_table(str(tmpdir))
 
     pd.testing.assert_frame_equal(to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),
@@ -220,13 +220,13 @@ def test_to_csv_use_standard_tags(sample_df, tmpdir):
     no_standard_tags_df = sample_df.copy()
     no_standard_tags_df.ww.init(use_standard_tags=False)
 
-    no_standard_tags_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8')
+    no_standard_tags_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8', engine='python')
     deserialized_no_tags_df = deserialize.read_woodwork_table(str(tmpdir))
 
     standard_tags_df = sample_df.copy()
     standard_tags_df.ww.init(use_standard_tags=True)
 
-    standard_tags_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8')
+    standard_tags_df.ww.to_disk(str(tmpdir), format='csv', encoding='utf-8', engine='python')
     deserialized_tags_df = deserialize.read_woodwork_table(str(tmpdir))
 
     assert no_standard_tags_df.ww.schema != standard_tags_df.ww.schema
@@ -340,7 +340,7 @@ def test_to_csv_S3(sample_df, s3_client, s3_bucket):
         index='id',
         semantic_tags={'id': 'tag1'},
         logical_types={'age': Ordinal(order=[25, 33, 57])})
-    sample_df.ww.to_disk(TEST_S3_URL, format='csv', encoding='utf-8')
+    sample_df.ww.to_disk(TEST_S3_URL, format='csv', encoding='utf-8', engine='python')
     make_public(s3_client, s3_bucket)
 
     deserialized_df = deserialize.read_woodwork_table(TEST_S3_URL)
@@ -383,7 +383,7 @@ def test_to_csv_S3_anon(sample_df, s3_client, s3_bucket):
         time_index='signup_date',
         semantic_tags={'id': 'tag1'},
         logical_types={'age': Ordinal(order=[25, 33, 57])})
-    sample_df.ww.to_disk(TEST_S3_URL, format='csv', encoding='utf-8', profile_name=False)
+    sample_df.ww.to_disk(TEST_S3_URL, format='csv', encoding='utf-8', engine='python', profile_name=False)
     make_public(s3_client, s3_bucket)
 
     deserialized_df = deserialize.read_woodwork_table(TEST_S3_URL, profile_name=False)
@@ -459,7 +459,7 @@ def setup_test_profile(monkeypatch, tmpdir):
 def test_s3_test_profile(sample_df, s3_client, s3_bucket, setup_test_profile):
     xfail_tmp_disappears(sample_df)
     sample_df.ww.init()
-    sample_df.ww.to_disk(TEST_S3_URL, format='csv', encoding='utf-8', profile_name='test')
+    sample_df.ww.to_disk(TEST_S3_URL, format='csv', encoding='utf-8', engine='python', profile_name='test')
     make_public(s3_client, s3_bucket)
     deserialized_df = deserialize.read_woodwork_table(TEST_S3_URL, profile_name='test')
 
@@ -471,7 +471,7 @@ def test_serialize_url_csv(sample_df):
     sample_df.ww.init()
     error_text = "Writing to URLs is not supported"
     with pytest.raises(ValueError, match=error_text):
-        sample_df.ww.to_disk(URL, format='csv', encoding='utf-8')
+        sample_df.ww.to_disk(URL, format='csv', encoding='utf-8', engine='python')
 
 
 def test_serialize_subdirs_not_removed(sample_df, tmpdir):

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -478,6 +478,38 @@ def latlongs(request):
 
 
 @pytest.fixture()
+def whitespace_df_pandas():
+    return pd.DataFrame({
+        'id': [0, 1, 2, 3, 4, 5],
+        'comments': [
+            '\nleading newline',
+            'trailing newline\n',
+            '\n',
+            'newline in \n the middle',
+            '    leading whitespace',
+            'trailing whitespace ',
+        ]
+    })
+
+
+@pytest.fixture()
+def whitespace_df_dask(whitespace_df_pandas):
+    dd = pytest.importorskip('dask.dataframe', reason='Dask not installed, skipping')
+    return dd.from_pandas(whitespace_df_pandas, npartitions=2)
+
+
+@pytest.fixture()
+def whitespace_df_koalas(whitespace_df_pandas):
+    ks = pytest.importorskip('databricks.koalas', reason='Koalas not installed, skipping')
+    return ks.from_pandas(whitespace_df_pandas)
+
+
+@pytest.fixture(params=['whitespace_df_pandas', 'whitespace_df_dask', 'whitespace_df_koalas'])
+def whitespace_df(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture()
 def falsy_names_df_pandas():
     return pd.DataFrame({
         0: ['a', 'b', 'c'],


### PR DESCRIPTION
- Fix issue related to serialization of strings containing whitespace characters
- Closes #950 

Serialization and deserialization of Koalas dataframes containing leading and trailing whitespace characters and/or newline characters anywhere in the string was not working correctly. This PR updates the default spark settings used so that whitespace and newline characters are handled correctly. Also, the previous implementation was not passing any additional user specified kwargs to the underlying to_csv methods. This PR also contains updates to allow users to pass additional kwargs if needed.