### PR TITLE
Add alteryx_open_src_update_checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ or from the conda-forge channel on [conda](https://anaconda.org/conda-forge/wood
 conda install -c conda-forge woodwork
 ```
 
+### Add-ons
+**Update checker** - Receive automatic notifications of new Woodwork releases
+```
+python -m pip install woodwork[update_checker]
+```
+
+
+
 ## Example
 
 Below is an example of using Woodwork. In this example, a sample dataset of order items is used to create a Woodwork `DataFrame`, specifying the `LogicalType` for four of the columns.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Add ``concat_columns`` util function to concatenate multiple Woodwork objects into one, retaining typing information (:pr:`932`)
+        * Add optional automatic update checker (:pr:`959`)
     * Fixes
     * Changes
     * Documentation Changes
@@ -15,7 +16,7 @@ Future Release
         * Update minimum unit tests to run on all pull requests (:pr:`952`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`, :user:`frances-h`
     
 
 v0.4.0 May 26, 2021

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(dirname, 'README.md')) as f:
 
 extras_require = {'dask': open('dask-requirements.txt').readlines(),
                   'koalas': open('koalas-requirements.txt').readlines(),
-                  'update_checker': ['alteryx-open-src-update-checker > 1.0.2']}
+                  'update_checker': ['alteryx-open-src-update-checker >= 2.0.0']}
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ with open(path.join(dirname, 'README.md')) as f:
     long_description = f.read()
 
 extras_require = {'dask': open('dask-requirements.txt').readlines(),
-                  'koalas': open('koalas-requirements.txt').readlines()}
+                  'koalas': open('koalas-requirements.txt').readlines(),
+                  'update_checker': ['alteryx-open-src-update-checker > 1.0.2']}
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -13,3 +13,14 @@ from woodwork.accessor_utils import (
     init_series,
     is_schema_valid
 )
+
+import pkg_resources
+
+# Call functions registered by other libraries when woodwork is imported
+for entry_point in pkg_resources.iter_entry_points('alteryx_open_src_initialize'):
+    try:
+        method = entry_point.load()
+        if callable(method):
+            method('woodwork')
+    except Exception:
+        pass

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -1,4 +1,6 @@
 # flake8: noqa
+import pkg_resources
+
 from .config import config
 from .type_sys import type_system
 from .type_sys.utils import list_logical_types, list_semantic_tags
@@ -13,8 +15,6 @@ from woodwork.accessor_utils import (
     init_series,
     is_schema_valid
 )
-
-import pkg_resources
 
 # Call functions registered by other libraries when woodwork is imported
 for entry_point in pkg_resources.iter_entry_points('alteryx_open_src_initialize'):


### PR DESCRIPTION
Add alteryx_open_src_update_checker functionality. The update_checker can be installed with `pip install woodwork[update_checker]` and will automatically check if there's a newer release of woodwork available.
