### PR TITLE
Add install workflow to test update checker 

### DIFF
--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -7,7 +7,7 @@ on:
 
 name: Install Test
 jobs:
-  install_ft_complete:
+  install_ww_complete:
     name: ${{ matrix.python_version }} install woodwork complete
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -1,0 +1,35 @@
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+name: Install Test
+jobs:
+  install_ft_complete:
+    name: ${{ matrix.python_version }} install woodwork complete
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.7", "3.8", "3.9"]
+    steps:
+      - name: Set up python ${{ matrix.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build woodwork package
+        run: make package_woodwork
+      - name: Install complete version of woodwork
+        run: |
+          pip config --site set global.progress_bar off
+          python -m pip install --upgrade pip
+          python -m pip install -e unpacked_sdist/[complete]
+      - name: Test by importing packages
+        run: |
+          python -c "import alteryx_open_src_update_checker"
+        env:
+          ALTERYX_OPEN_SRC_UPDATE_CHECKER: False

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Future Release
     * Enhancements
         * Add ``concat_columns`` util function to concatenate multiple Woodwork objects into one, retaining typing information (:pr:`932`)
         * Add option to pass progress callback function to mutual information functions (:pr:`958`)
-        * Add optional automatic update checker (:pr:`959`)
+        * Add optional automatic update checker (:pr:`959`, :pr:`970`)
     * Fixes
         * Fix issue related to serialization/deserialization of data with whitespace and newline characters (:pr:`957`)
     * Changes


### PR DESCRIPTION
- This PR tests that the update checker + other future add-ons can be properly installed, and used in WW. 