### PR TITLE
Update ordinal validation

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Future Release
         * Add optional automatic update checker (:pr:`959`)
     * Fixes
         * Fix issue related to serialization/deserialization of data with whitespace and newline characters (:pr:`957`)
+        * Update to allow initializing a ``ColumnSchema`` object with an ``Ordinal`` logical type without order values (:pr:`972`)
     * Changes
         * Change write_dataframe to only copy dataframe if it contains LatLong (:pr:`955`)
     * Documentation Changes

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -365,18 +365,18 @@ class Ordinal(LogicalType):
     standard_tags = {'category'}
 
     def __init__(self, order=None):
-        if order is None:
-            raise TypeError("Must use an Ordinal instance with order values defined")
-        elif not isinstance(order, (list, tuple)):
-            raise TypeError("Order values must be specified in a list or tuple")
-        if len(order) != len(set(order)):
-            raise ValueError("Order values cannot contain duplicates")
-
         self.order = order
 
     def _validate_data(self, series):
-        """Confirm the supplied series does not contain any values that are not
-        in the specified order values"""
+        """Make sure order values are properly defined and confirm the supplied series
+        does not contain any values that are not in the specified order values"""
+        if self.order is None:
+            raise TypeError("Must use an Ordinal instance with order values defined")
+        elif not isinstance(self.order, (list, tuple)):
+            raise TypeError("Order values must be specified in a list or tuple")
+        if len(self.order) != len(set(self.order)):
+            raise ValueError("Order values cannot contain duplicates")
+
         if isinstance(series, pd.Series):
             missing_order_vals = set(series.dropna().values).difference(self.order)
             if missing_order_vals:

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -39,18 +39,12 @@ def test_instantiated_type_str():
 
 def test_ordinal_order_errors():
     series = pd.Series([1, 2, 3]).astype('category')
-    error = "Must use an Ordinal instance with order values defined"
-    with pytest.raises(TypeError, match=error):
-        series.ww.init(logical_type='Ordinal')
-
-    with pytest.raises(TypeError, match=error):
-        series.ww.init(logical_type=Ordinal)
 
     with pytest.raises(TypeError, match='Order values must be specified in a list or tuple'):
-        series.ww.init(logical_type=Ordinal(order='not_valid'))
+        Ordinal(order='not_valid').transform(series)
 
     with pytest.raises(ValueError, match='Order values cannot contain duplicates'):
-        series.ww.init(logical_type=Ordinal(order=['a', 'b', 'b']))
+        Ordinal(order=['a', 'b', 'b']).transform(series)
 
 
 def test_ordinal_init_with_order():

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -38,11 +38,19 @@ def test_instantiated_type_str():
 
 
 def test_ordinal_order_errors():
+    series = pd.Series([1, 2, 3]).astype('category')
+    error = "Must use an Ordinal instance with order values defined"
+    with pytest.raises(TypeError, match=error):
+        series.ww.init(logical_type='Ordinal')
+
+    with pytest.raises(TypeError, match=error):
+        series.ww.init(logical_type=Ordinal)
+
     with pytest.raises(TypeError, match='Order values must be specified in a list or tuple'):
-        Ordinal(order='not_valid')
+        series.ww.init(logical_type=Ordinal(order='not_valid'))
 
     with pytest.raises(ValueError, match='Order values cannot contain duplicates'):
-        Ordinal(order=['a', 'b', 'b'])
+        series.ww.init(logical_type=Ordinal(order=['a', 'b', 'b']))
 
 
 def test_ordinal_init_with_order():

--- a/woodwork/tests/schema/test_column_schema.py
+++ b/woodwork/tests/schema/test_column_schema.py
@@ -410,3 +410,9 @@ def test_schema_repr():
             "<ColumnSchema (Semantic Tags = ['category', 'foreign_key'])>")
     assert (repr(ColumnSchema()) ==
             "<ColumnSchema>")
+
+
+def test_ordinal_without_init():
+    schema = ColumnSchema(logical_type=Ordinal)
+    assert isinstance(schema.logical_type, Ordinal)
+    assert schema.logical_type.order is None

--- a/woodwork/tests/schema/test_table_schema_init.py
+++ b/woodwork/tests/schema/test_table_schema_init.py
@@ -10,7 +10,8 @@ from woodwork.logical_types import (
     Datetime,
     Double,
     Integer,
-    NaturalLanguage
+    NaturalLanguage,
+    Ordinal
 )
 from woodwork.table_schema import (
     TableSchema,
@@ -461,3 +462,9 @@ def test_use_standard_tags_from_dict(sample_column_names, sample_inferred_logica
                                                                  'signup_date': False})
     assert default_schema.use_standard_tags == partial_dict_default_schema.use_standard_tags
     assert default_schema == partial_dict_default_schema
+
+
+def test_ordinal_without_init():
+    schema = TableSchema(column_names=['ordinal_col'], logical_types={'ordinal_col': Ordinal})
+    assert isinstance(schema.logical_types['ordinal_col'], Ordinal)
+    assert schema.logical_types['ordinal_col'].order is None

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -556,13 +556,6 @@ def test_parse_logical_type():
 
 
 def test_parse_logical_type_errors():
-    error = "Must use an Ordinal instance with order values defined"
-    with pytest.raises(TypeError, match=error):
-        _parse_logical_type('Ordinal', 'col_name')
-
-    with pytest.raises(TypeError, match=error):
-        _parse_logical_type(Ordinal, 'col_name')
-
     error = "Invalid logical type specified for 'col_name'"
     with pytest.raises(TypeError, match=error):
         _parse_logical_type(int, 'col_name')


### PR DESCRIPTION
- Update ordinal validation
- Closes #971 

Move some validation checks for Ordinal logical type from `init` to `_validate_data` so that it is now possible to create a column schema using an Ordinal logical type without having order values defined. Attempting to use the ordinal logical type on a series or dataframe without having proper order values defined will still result in an error as before.