### PR TITLE
Update callback function arguments

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,11 +19,10 @@ Future Release
 Breaking Changes
 ++++++++++++++++
     * Progress callback functions are now expected to accept five parameters: progress increment since last call,
-    progress units complete so far, total units to complete, the progress unit of measurement, and time elapsed
-    since start of calculation. Additionally, progress is now being reported in the units specified by the unit of
-    measurement parameter instead of percentage of total.
+      progress units complete so far, total units to complete, the progress unit of measurement, and time elapsed
+      since start of calculation. Additionally, progress is now being reported in the units specified by the unit of
+      measurement parameter instead of percentage of total.
 
-    
 v0.4.1 Jun 9, 2021
 ==================
     * Enhancements
@@ -39,7 +38,7 @@ v0.4.1 Jun 9, 2021
         * Fix bug in ``test_list_logical_types_default`` (:pr:`954`)
         * Update minimum unit tests to run on all pull requests (:pr:`952`)
         * Pass token to authorize uploading of codecov reports (:pr:`969`)
-        
+
     Thanks to the following people for contributing to this release:
     :user:`frances-h`, :user:`gsheni`, :user:`tamargrey`, :user:`thehomebrewnerd`
     

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Pass additional progress information in callback functions (:pr:`979`)
     * Fixes
     * Changes
     * Documentation Changes
@@ -13,7 +14,14 @@ Future Release
         * Add env setting to update checker (:pr:`978`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`thehomebrewnerd`
+
+Breaking Changes
+++++++++++++++++
+    * Progress callback functions are now expected to accept five parameters: progress increment since last call,
+    progress units complete so far, total units to complete, the progress unit of measurement, and time elapsed
+    since start of calculation. Additionally, progress is now being reported in the units specified by the unit of
+    measurement parameter instead of percentage of total.
     
 v0.4.1 Jun 9, 2021
 ==================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -22,6 +22,7 @@ Breaking Changes
     progress units complete so far, total units to complete, the progress unit of measurement, and time elapsed
     since start of calculation. Additionally, progress is now being reported in the units specified by the unit of
     measurement parameter instead of percentage of total.
+
     
 v0.4.1 Jun 9, 2021
 ==================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,15 +18,16 @@ Future Release
 
 Breaking Changes
 ++++++++++++++++
-    Progress callback functions are now expected to accept five parameters: 
-    
+    * Progress callback functions parameters have changed and progress is now being reported in the units
+      specified by the unit of measurement parameter instead of percentage of total. Progress callback
+      functions now are expected to accept the following five parameters:
+
         * progress increment since last call
         * progress units complete so far
         * total units to complete
         * the progress unit of measurement
         * time elapsed since start of calculation
-        
-    Additionally, progress is now being reported in the units specified by the unit of measurement parameter instead of percentage of total.
+
 
 v0.4.1 Jun 9, 2021
 ==================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Future Release
 
 Breaking Changes
 ++++++++++++++++
-    * Progress callback functions are now expected to accept five parameters: 
+    Progress callback functions are now expected to accept five parameters: 
     
         * progress increment since last call
         * progress units complete so far

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,10 +18,15 @@ Future Release
 
 Breaking Changes
 ++++++++++++++++
-    * Progress callback functions are now expected to accept five parameters: progress increment since last call,
-      progress units complete so far, total units to complete, the progress unit of measurement, and time elapsed
-      since start of calculation. Additionally, progress is now being reported in the units specified by the unit of
-      measurement parameter instead of percentage of total.
+    * Progress callback functions are now expected to accept five parameters: 
+    
+        * progress increment since last call
+        * progress units complete so far
+        * total units to complete
+        * the progress unit of measurement
+        * time elapsed since start of calculation
+        
+    Additionally, progress is now being reported in the units specified by the unit of measurement parameter instead of percentage of total.
 
 v0.4.1 Jun 9, 2021
 ==================

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -26,8 +26,8 @@ def _get_describe_dict(dataframe, include=None, callback=None):
             - update (int): change in progress since last call
             - progress (int): the progress so far in the calculations
             - total (int): the total number of calculations to do
-            - unit (str): what is the units of progress/total
-            - time_elapsed: total time in seconds that has elapsed since start of call
+            - unit (str): unit of measurement for progress/total
+            - time_elapsed (float): total time in seconds elapsed since start of call
 
     Returns:
         dict[str -> dict]: A dictionary with a key for each column in the data or for each column
@@ -198,8 +198,8 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None, include_ind
             - update (int): change in progress since last call
             - progress (int): the progress so far in the calculations
             - total (int): the total number of calculations to do
-            - unit (str): what is the units of progress/total
-            - time_elapsed: total time in seconds that has elapsed since start of call
+            - unit (str): unit of measurement for progress/total
+            - time_elapsed (float): total time in seconds elapsed since start of call
 
     Returns:
         list(dict): A list containing dictionaries that have keys `column_1`,

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -23,9 +23,9 @@ def _get_describe_dict(dataframe, include=None, callback=None):
             will be returned.
         callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-            - update (int/float): change in progress since last call
-            - progress (int/float): the progress so far in the calculations
-            - total (int/float): the total number of calculations to do
+            - update (int): change in progress since last call
+            - progress (int): the progress so far in the calculations
+            - total (int): the total number of calculations to do
             - unit (str): what is the units of progress/total
             - time_elapsed: total time in seconds that has elapsed since start of call
 
@@ -195,9 +195,9 @@ def _get_mutual_information_dict(dataframe, num_bins=10, nrows=None, include_ind
             Defaults to False.
         callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-            - update (int/float): change in progress since last call
-            - progress (int/float): the progress so far in the calculations
-            - total (int/float): the total number of calculations to do
+            - update (int): change in progress since last call
+            - progress (int): the progress so far in the calculations
+            - total (int): the total number of calculations to do
             - unit (str): what is the units of progress/total
             - time_elapsed: total time in seconds that has elapsed since start of call
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -759,9 +759,9 @@ class WoodworkTableAccessor:
                 Defaults to False.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update (int/float): change in progress since last call
-                - progress (int/float): the progress so far in the calculations
-                - total (int/float): the total number of calculations to do
+                - update (int): change in progress since last call
+                - progress (int): the progress so far in the calculations
+                - total (int): the total number of calculations to do
                 - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 
@@ -793,9 +793,9 @@ class WoodworkTableAccessor:
                 Defaults to False.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update (int/float): change in progress since last call
-                - progress (int/float): the progress so far in the calculations
-                - total (int/float): the total number of calculations to do
+                - update (int): change in progress since last call
+                - progress (int): the progress so far in the calculations
+                - total (int): the total number of calculations to do
                 - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 
@@ -819,9 +819,9 @@ class WoodworkTableAccessor:
                 will be returned.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update (int/float): change in progress since last call
-                - progress (int/float): the progress so far in the calculations
-                - total (int/float): the total number of calculations to do
+                - update (int): change in progress since last call
+                - progress (int): the progress so far in the calculations
+                - total (int): the total number of calculations to do
                 - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 
@@ -845,9 +845,9 @@ class WoodworkTableAccessor:
                 will be returned.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update (int/float): change in progress since last call
-                - progress (int/float): the progress so far in the calculations
-                - total (int/float): the total number of calculations to do
+                - update (int): change in progress since last call
+                - progress (int): the progress so far in the calculations
+                - total (int): the total number of calculations to do
                 - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -762,8 +762,8 @@ class WoodworkTableAccessor:
                 - update (int): change in progress since last call
                 - progress (int): the progress so far in the calculations
                 - total (int): the total number of calculations to do
-                - unit (str): what is the units of progress/total
-                - time_elapsed: total time in seconds that has elapsed since start of call
+                - unit (str): unit of measurement for progress/total
+                - time_elapsed (float): total time in seconds elapsed since start of call
 
         Returns:
             list(dict): A list containing dictionaries that have keys `column_1`,
@@ -796,8 +796,8 @@ class WoodworkTableAccessor:
                 - update (int): change in progress since last call
                 - progress (int): the progress so far in the calculations
                 - total (int): the total number of calculations to do
-                - unit (str): what is the units of progress/total
-                - time_elapsed: total time in seconds that has elapsed since start of call
+                - unit (str): unit of measurement for progress/total
+                - time_elapsed (float): total time in seconds elapsed since start of call
 
         Returns:
             pd.DataFrame: A DataFrame containing mutual information with columns `column_1`,
@@ -822,8 +822,8 @@ class WoodworkTableAccessor:
                 - update (int): change in progress since last call
                 - progress (int): the progress so far in the calculations
                 - total (int): the total number of calculations to do
-                - unit (str): what is the units of progress/total
-                - time_elapsed: total time in seconds that has elapsed since start of call
+                - unit (str): unit of measurement for progress/total
+                - time_elapsed (float): total time in seconds elapsed since start of call
 
         Returns:
             dict[str -> dict]: A dictionary with a key for each column in the data or for each column
@@ -848,8 +848,8 @@ class WoodworkTableAccessor:
                 - update (int): change in progress since last call
                 - progress (int): the progress so far in the calculations
                 - total (int): the total number of calculations to do
-                - unit (str): what is the units of progress/total
-                - time_elapsed: total time in seconds that has elapsed since start of call
+                - unit (str): unit of measurement for progress/total
+                - time_elapsed (float): total time in seconds elapsed since start of call
 
         Returns:
             pd.DataFrame: A Dataframe containing statistics for the data or the subset of the original

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -759,8 +759,10 @@ class WoodworkTableAccessor:
                 Defaults to False.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update: percentage change (float between 0 and 100) in progress since last call
-                - progress_percent: percentage (float between 0 and 100) of total computation completed
+                - update (int/float): change in progress since last call
+                - progress (int/float): the progress so far in the calculations
+                - total (int/float): the total number of calculations to do
+                - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 
         Returns:
@@ -791,8 +793,10 @@ class WoodworkTableAccessor:
                 Defaults to False.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update: percentage change (float between 0 and 100) in progress since last call
-                - progress_percent: percentage (float between 0 and 100) of total computation completed
+                - update (int/float): change in progress since last call
+                - progress (int/float): the progress so far in the calculations
+                - total (int/float): the total number of calculations to do
+                - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 
         Returns:
@@ -815,8 +819,10 @@ class WoodworkTableAccessor:
                 will be returned.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update: percentage change (float between 0 and 100) in progress since last call
-                - progress_percent: percentage (float between 0 and 100) of total computation completed
+                - update (int/float): change in progress since last call
+                - progress (int/float): the progress so far in the calculations
+                - total (int/float): the total number of calculations to do
+                - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 
         Returns:
@@ -839,8 +845,10 @@ class WoodworkTableAccessor:
                 will be returned.
             callback (callable, optional): function to be called with incremental updates. Has the following parameters:
 
-                - update: percentage change (float between 0 and 100) in progress since last call
-                - progress_percent: percentage (float between 0 and 100) of total computation completed
+                - update (int/float): change in progress since last call
+                - progress (int/float): the progress so far in the calculations
+                - total (int/float): the total number of calculations to do
+                - unit (str): what is the units of progress/total
                 - time_elapsed: total time in seconds that has elapsed since start of call
 
         Returns:

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -206,13 +206,13 @@ def test_mutual_info_callback(df_mi):
         def __init__(self):
             self.progress_history = []
             self.total_update = 0
-            self.total_progress_percent = 0
             self.total_elapsed_time = 0
 
-        def __call__(self, update, progress_percent, time_elapsed):
+        def __call__(self, update, progress, total, unit, time_elapsed):
             self.total_update += update
-            self.total_progress_percent = progress_percent
-            self.progress_history.append(progress_percent)
+            self.total = total
+            self.progress_history.append(progress)
+            self.unit = unit
             self.total_elapsed_time = time_elapsed
 
     mock_callback = MockCallback()
@@ -222,14 +222,16 @@ def test_mutual_info_callback(df_mi):
     # Should be 18 total calls
     assert len(mock_callback.progress_history) == 18
 
-    # First call should be 1 of 26 units complete
-    assert np.isclose(mock_callback.progress_history[0], 1 / 26 * 100)
+    assert mock_callback.unit == 'calculations'
+    # First call should be 1 of 26 calculations complete
+    assert mock_callback.progress_history[0] == 1
     # After second call should be 6 of 26 units complete
-    assert np.isclose(mock_callback.progress_history[1], 6 / 26 * 100)
+    assert mock_callback.progress_history[1] == 6
 
-    # Should be 100% at end with a positive elapsed time
-    assert np.isclose(mock_callback.total_update, 100.0)
-    assert np.isclose(mock_callback.total_progress_percent, 100.0)
+    # Should be 26 calculations at end with a positive elapsed time
+    assert mock_callback.total == 26
+    assert mock_callback.total_update == 26
+    assert mock_callback.progress_history[-1] == 26
     assert mock_callback.total_elapsed_time > 0
 
 
@@ -612,19 +614,20 @@ def test_describe_callback(describe_df):
         def __init__(self):
             self.progress_history = []
             self.total_update = 0
-            self.total_progress_percent = 0
             self.total_elapsed_time = 0
 
-        def __call__(self, update, progress_percent, time_elapsed):
+        def __call__(self, update, progress, total, unit, time_elapsed):
             self.total_update += update
-            self.total_progress_percent = progress_percent
-            self.progress_history.append(progress_percent)
+            self.total = total
+            self.progress_history.append(progress)
+            self.unit = unit
             self.total_elapsed_time = time_elapsed
 
     mock_callback = MockCallback()
 
     describe_df.ww.describe(callback=mock_callback)
 
+    assert mock_callback.unit == 'calculations'
     # Koalas df does not have timedelta column
     if ks and isinstance(describe_df, ks.DataFrame):
         ncalls = 9
@@ -634,13 +637,14 @@ def test_describe_callback(describe_df):
     assert len(mock_callback.progress_history) == ncalls
 
     # First call should be 1 unit complete
-    assert np.isclose(mock_callback.progress_history[0], 1 / ncalls * 100)
+    assert mock_callback.progress_history[0] == 1
     # After second call should be 2 unit complete
-    assert np.isclose(mock_callback.progress_history[1], 2 / ncalls * 100)
+    assert mock_callback.progress_history[1] == 2
 
-    # Should be 100% at end with a positive elapsed time
-    assert np.isclose(mock_callback.total_update, 100.0)
-    assert np.isclose(mock_callback.total_progress_percent, 100.0)
+    # Should be ncalls at end with a positive elapsed time
+    assert mock_callback.total == ncalls
+    assert mock_callback.total_update == ncalls
+    assert mock_callback.progress_history[-1] == ncalls
     assert mock_callback.total_elapsed_time > 0
 
 

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -423,9 +423,12 @@ def _update_progress(start_time, current_time, progress_increment,
     updated progress amount.
 
     If provided, the callback function should accept the following parameters:
-        update: percentage change (float between 0 and 100) in progress since last call
-        progress_percent: percentage (float between 0 and 100) of total computation completed
-        time_elapsed: total time in seconds that has elapsed since start of call"""
+        - update (int): change in progress since last call
+        - progress (int): the progress so far in the calculations
+        - total (int): the total number of calculations to do
+        - unit (str): unit of measurement for progress/total
+        - time_elapsed (float): total time in seconds elapsed since start of call
+    """
     if callback_function is not None:
         new_progress = current_progress + progress_increment
         elapsed_time = current_time - start_time

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -417,7 +417,7 @@ def concat_columns(objs, validate_schema=True):
 
 
 def _update_progress(start_time, current_time, progress_increment,
-                     current_progress, total, callback_function):
+                     current_progress, total, unit, callback_function):
     """Helper function for updating progress of a function and making a call to the progress callback
     function, if provided. Adds the progress increment to the current progress amount and returns the
     updated progress amount.
@@ -429,6 +429,6 @@ def _update_progress(start_time, current_time, progress_increment,
     if callback_function is not None:
         new_progress = current_progress + progress_increment
         elapsed_time = current_time - start_time
-        callback_function((progress_increment / total) * 100, (new_progress / total) * 100, elapsed_time)
+        callback_function(progress_increment, new_progress, total, unit, elapsed_time)
 
         return new_progress


### PR DESCRIPTION
- Update callback function arguments
- Closes #966
- Closes #967 

This PR updates the required arguments for the progress callback function that can be passed to the `describe` or `mutual_information` methods. 

The measurements were changed from percentage complete to total units. Callback functions should now accept the following:
- update: change since last call
- progress: total progress so far
- total: total units of calculations to perform
- unit: the measurement unit for the progress
- time_elapsed: total time elapsed since call started