### PR TITLE
Add option to compute extra stats with describe

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Pass additional progress information in callback functions (:pr:`979`)
+        * Add the ability to generate optional extra stats with ``DataFrame.ww.describe`` (:pr:`988`)
     * Fixes
     * Changes
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,7 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Pass additional progress information in callback functions (:pr:`979`)
-        * Add the ability to generate optional extra stats with ``DataFrame.ww.describe`` (:pr:`988`)
+        * Add the ability to generate optional extra stats with ``DataFrame.ww.describe_dict`` (:pr:`988`)
     * Fixes
     * Changes
     * Documentation Changes

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -40,11 +40,12 @@ def _get_describe_dict(dataframe, include=None, callback=None,
             for categorical columns and recent values for datetime columns. Output can be controlled by bins,
             top_x and recent_x parameters.
         bins (int): Number of bins to use when calculating histogram
-            for numeric columns. Defaults to 10.
+            for numeric columns. Defaults to 10. Will be ignored unless extra_stats=True.
         top_x (int): Number of values to get when getting the most frequent
-            values for categorical columns. Defaults to 10
+            values for categorical columns. Defaults to 10. Will be ignored unless extra_stats=True.
         recent_x (int): Number of recent values to get when getting the most recent
-            dates to calculate frequency for datetime columns. Defaults to 10.
+            dates to calculate frequency for datetime columns. Defaults to 10. Will be ignored unless
+            extra_stats=True.
 
     Returns:
         dict[str -> dict]: A dictionary with a key for each column in the data or for each column

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -377,15 +377,12 @@ def _get_top_values_categorical(series, num_x):
     return top_lt
 
 
-def _get_recent_values(column, num_x, dropna=False):
+def _get_recent_values(column, num_x):
     """Get the most frequent, recent values for a given datetime column.
 
     Args:
         column (pd.Series): data to use find most frequent
         num_x (int): the number of recent values to retrieve.
-        dropna (bool): determines whether to remove NaN values when
-            finding recent datetimes (used for frequency count).
-            Defaults to False
 
     Returns:
         recent_list (list(dict)): a list of dictionary with keys `count` and
@@ -393,7 +390,7 @@ def _get_recent_values(column, num_x, dropna=False):
     """
     datetimes = pd.to_datetime(column, infer_datetime_format=True, errors="coerce")
     datetimes = getattr(datetimes.dt, "date")
-    frequencies = datetimes.value_counts(dropna=dropna)
+    frequencies = datetimes.value_counts(dropna=False)
     values = frequencies.sort_index(ascending=True)[:num_x]
     df = values.reset_index()
     df.columns = ["value", "count"]

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -357,9 +357,8 @@ def _get_numeric_value_counts_in_range(series, _range):
             the input range.
     """
     frequencies = series.value_counts(dropna=True)
-    return [
-        {"value": i, "count": frequencies[i] if i in frequencies else 0} for i in _range
-    ]
+    value_counts = [{"value": i, "count": frequencies[i] if i in frequencies else 0} for i in _range]
+    return sorted(value_counts, key=lambda i: (-i["count"], i["value"]))
 
 
 def _get_top_values_categorical(series, num_x):

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -125,7 +125,7 @@ def _get_describe_dict(dataframe, include=None, callback=None,
         values["logical_type"] = logical_type
         values["semantic_tags"] = semantic_tags
 
-        # Calculate extra details stats, if requested
+        # Calculate extra detailed stats, if requested
         if extra_stats:
             if column.is_numeric:
                 values["histogram"] = _get_histogram_values(series, bins=bins)

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -353,8 +353,7 @@ def _get_numeric_value_counts_in_range(series, _range):
 
     Returns:
         value_counts (list(dict)): a list of dictionaries with keys `value` and
-            `count`. Output is sorted in ascending order by the values defined in
-            the input range.
+            `count`. Output is sorted in descending order based on the value counts.
     """
     frequencies = series.value_counts(dropna=True)
     value_counts = [{"value": i, "count": frequencies[i] if i in frequencies else 0} for i in _range]
@@ -370,14 +369,14 @@ def _get_top_values_categorical(series, num_x):
 
     Returns:
         top_list (list(dict)): a list of dictionary with keys `value` and `count`.
-            Output is sorted in ascending order based on the value counts.
+            Output is sorted in descending order based on the value counts.
     """
     frequencies = series.value_counts(dropna=True)
     df = frequencies.head(num_x).reset_index()
     df.columns = ["value", "count"]
-    top_lt = list(df.to_dict(orient="index").values())
-    top_lt = sorted(top_lt, key=lambda i: (i["count"], i["value"]))
-    return top_lt
+    df = df.sort_values(["count", "value"], ascending=[False, True])
+    value_counts = list(df.to_dict(orient="index").values())
+    return value_counts
 
 
 def _get_recent_value_counts(column, num_x):
@@ -389,15 +388,16 @@ def _get_recent_value_counts(column, num_x):
 
     Returns:
         value_counts (list(dict)): a list of dictionary with keys `value` and
-            `count`. Output is sorted in descending order by date.
+            `count`. Output is sorted in descending order based on the value counts.
     """
     datetimes = getattr(column.dt, "date")
     frequencies = datetimes.value_counts(dropna=False)
     values = frequencies.sort_index(ascending=False)[:num_x]
     df = values.reset_index()
     df.columns = ["value", "count"]
-
-    return list(df.to_dict(orient="index").values())
+    df = df.sort_values(["count", "value"], ascending=[False, True])
+    value_counts = list(df.to_dict(orient="index").values())
+    return value_counts
 
 
 def _get_histogram_values(series, bins=10):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -889,7 +889,6 @@ class WoodworkTableAccessor:
             'num_true',
             'num_false',
         ]
-
         return pd.DataFrame(results).reindex(index_order)
 
     def value_counts(self, ascending=False, top_n=10, dropna=False):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -808,7 +808,7 @@ class WoodworkTableAccessor:
         mutual_info = self.mutual_information_dict(num_bins, nrows, include_index, callback)
         return pd.DataFrame(mutual_info)
 
-    def describe_dict(self, include=None, callback=None):
+    def describe_dict(self, include=None, callback=None, extra_stats=False, bins=10, top_x=10, recent_x=10):
         """Calculates statistics for data contained in the DataFrame.
 
         Args:
@@ -832,9 +832,10 @@ class WoodworkTableAccessor:
         """
         if self._schema is None:
             _raise_init_error()
-        return _get_describe_dict(self._dataframe, include=include, callback=callback)
+        return _get_describe_dict(self._dataframe, include=include, callback=callback,
+                                  extra_stats=extra_stats, bins=bins, top_x=top_x, recent_x=recent_x)
 
-    def describe(self, include=None, callback=None):
+    def describe(self, include=None, callback=None, extra_stats=False, bins=10, top_x=10, recent_x=10):
         """Calculates statistics for data contained in the DataFrame.
 
         Args:
@@ -856,7 +857,8 @@ class WoodworkTableAccessor:
             DataFrame that contains the logical types, semantic tags, or column names specified
             in ``include``.
         """
-        results = self.describe_dict(include=include, callback=callback)
+        results = self.describe_dict(include=include, callback=callback,
+                                     extra_stats=extra_stats, bins=bins, top_x=top_x, recent_x=recent_x)
         index_order = [
             'physical_type',
             'logical_type',
@@ -875,6 +877,8 @@ class WoodworkTableAccessor:
             'num_true',
             'num_false',
         ]
+        if extra_stats:
+            index_order = index_order + ['histogram', 'top_values', 'recent_values']
         return pd.DataFrame(results).reindex(index_order)
 
     def value_counts(self, ascending=False, top_n=10, dropna=False):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -808,7 +808,7 @@ class WoodworkTableAccessor:
         mutual_info = self.mutual_information_dict(num_bins, nrows, include_index, callback)
         return pd.DataFrame(mutual_info)
 
-    def describe_dict(self, include=None, callback=None, extra_stats=False, bins=10, top_x=10, oldest_x=10):
+    def describe_dict(self, include=None, callback=None, extra_stats=False, bins=10, top_x=10, recent_x=10):
         """Calculates statistics for data contained in the DataFrame.
 
         Args:
@@ -826,17 +826,16 @@ class WoodworkTableAccessor:
                 - time_elapsed (float): total time in seconds elapsed since start of call
 
             extra_stats (bool): If True, will calculate a histogram for numeric columns, top values
-                for categorical columns and value counts for the oldest values in datetime columns. Will also
+                for categorical columns and value counts for the most recent values in datetime columns. Will also
                 calculate value counts within the range of values present for integer columns if the range of
                 values present is less than or equal to than the number of bins used to compute the histogram.
-                Output can be controlled by bins, top_x and oldest_x parameters.
+                Output can be controlled by bins, top_x and recent_x parameters.
             bins (int): Number of bins to use when calculating histogram for numeric columns. Defaults to 10.
                 Will be ignored unless extra_stats=True.
             top_x (int): Number of items to return when getting the most frequently occurring values for categorical
                 columns. Defaults to 10. Will be ignored unless extra_stats=True.
-            oldest_x (int): Number of values to get when getting the least recent
-                dates to calculate frequency for datetime columns. Defaults to 10. Will be ignored unless
-                extra_stats=True.
+            recent_x (int): Number of values to return when calculating value counts for the most recent dates in
+                datetime columns. Defaults to 10. Will be ignored unless extra_stats=True.
 
         Returns:
             dict[str -> dict]: A dictionary with a key for each column in the data or for each column
@@ -846,7 +845,7 @@ class WoodworkTableAccessor:
         if self._schema is None:
             _raise_init_error()
         return _get_describe_dict(self._dataframe, include=include, callback=callback,
-                                  extra_stats=extra_stats, bins=bins, top_x=top_x, oldest_x=oldest_x)
+                                  extra_stats=extra_stats, bins=bins, top_x=top_x, recent_x=recent_x)
 
     def describe(self, include=None, callback=None):
         """Calculates statistics for data contained in the DataFrame.

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -825,6 +825,17 @@ class WoodworkTableAccessor:
                 - unit (str): unit of measurement for progress/total
                 - time_elapsed (float): total time in seconds elapsed since start of call
 
+            extra_stats (bool): If True, will calculate a histogram and top values for numeric columns, top values
+                for categorical columns and recent values for datetime columns. Output can be controlled by bins,
+                top_x and recent_x parameters.
+            bins (int): Number of bins to use when calculating histogram
+                for numeric columns. Defaults to 10. Will be ignored unless extra_stats=True.
+            top_x (int): Number of values to get when getting the most frequent
+                values for categorical columns. Defaults to 10. Will be ignored unless extra_stats=True.
+            recent_x (int): Number of recent values to get when getting the most recent
+                dates to calculate frequency for datetime columns. Defaults to 10. Will be ignored unless
+                extra_stats=True.
+
         Returns:
             dict[str -> dict]: A dictionary with a key for each column in the data or for each column
             matching the logical types, semantic tags or column names specified in ``include``, paired
@@ -851,6 +862,17 @@ class WoodworkTableAccessor:
                 - total (int): the total number of calculations to do
                 - unit (str): unit of measurement for progress/total
                 - time_elapsed (float): total time in seconds elapsed since start of call
+
+            extra_stats (bool): If True, will calculate a histogram and top values for numeric columns, top values
+                for categorical columns and recent values for datetime columns. Output can be controlled by bins,
+                top_x and recent_x parameters.
+            bins (int): Number of bins to use when calculating histogram
+                for numeric columns. Defaults to 10. Will be ignored unless extra_stats=True.
+            top_x (int): Number of values to get when getting the most frequent
+                values for categorical columns. Defaults to 10. Will be ignored unless extra_stats=True.
+            recent_x (int): Number of recent values to get when getting the most recent
+                dates to calculate frequency for datetime columns. Defaults to 10. Will be ignored unless
+                extra_stats=True.
 
         Returns:
             pd.DataFrame: A Dataframe containing statistics for the data or the subset of the original

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -245,6 +245,10 @@ def test_get_describe_dict(describe_df):
     describe_df.ww.init(index='index_col')
 
     stats_dict = _get_describe_dict(describe_df)
+    stats_dict_to_df = pd.DataFrame(stats_dict)
+    for extra in ['histogram', 'top_values', 'recent_values']:
+        assert extra not in stats_dict_to_df.index
+
     index_order = ['physical_type',
                    'logical_type',
                    'semantic_tags',
@@ -261,7 +265,8 @@ def test_get_describe_dict(describe_df):
                    'max',
                    'num_true',
                    'num_false']
-    stats_dict_to_df = pd.DataFrame(stats_dict).reindex(index_order)
+
+    stats_dict_to_df = stats_dict_to_df.reindex(index_order)
     stats_df = describe_df.ww.describe()
     pd.testing.assert_frame_equal(stats_df, stats_dict_to_df)
 

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -34,7 +34,7 @@ from woodwork.statistics_utils import (
     _get_histogram_values,
     _get_mode,
     _get_numeric_value_counts_in_range,
-    _get_oldest_value_counts,
+    _get_recent_value_counts,
     _get_top_values_categorical,
     _make_categorical_for_mutual_info,
     _replace_nans_for_mutual_info
@@ -735,28 +735,24 @@ def test_value_counts(categorical_df):
         assert len(val_cts_2[col]) == 2
 
 
-def test_datetime_get_oldest_value_counts():
-    times = [
+def test_datetime_get_recent_value_counts():
+    times = pd.Series([
         datetime(2019, 2, 2, 1, 10, 0, 1),
-        datetime(2019, 2, 2, 2, 20, 1, 0),
+        datetime(2019, 4, 2, 2, 20, 1, 0),
         datetime(2019, 3, 1, 3, 30, 1, 0),
-        datetime(2019, 1, 1, 4, 40, 1, 0),
+        datetime(2019, 5, 1, 4, 40, 1, 0),
         datetime(2019, 1, 1, 5, 50, 1, 0),
-        datetime(2019, 2, 2, 6, 10, 1, 0),
-        datetime(2019, 4, 1, 7, 20, 1, 0),
+        datetime(2019, 4, 2, 6, 10, 1, 0),
+        datetime(2019, 4, 2, 7, 20, 1, 0),
         datetime(2019, 5, 1, 8, 30, 0, 0),
-    ]
-    # Verify NaNs, strings, empty string don't break
-    times.extend([np.nan, pd.NaT, " ", "test"])
-    clipped_times = [x.date() for x in times[:-4]]
-    values = _get_oldest_value_counts(pd.Series(times), num_x=3)
+        pd.NaT,
+    ])
+    values = _get_recent_value_counts(times, num_x=3)
     expected_values = [
-        {"value": datetime(2019, 1, 1).date(), "count": 2},
-        {"value": datetime(2019, 2, 2).date(), "count": 3},
+        {"value": datetime(2019, 5, 1).date(), "count": 2},
+        {"value": datetime(2019, 4, 2).date(), "count": 3},
         {"value": datetime(2019, 3, 1).date(), "count": 1},
     ]
-    for val in values:
-        assert val["value"] in clipped_times
     assert values == expected_values
 
 

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from inspect import isclass
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from woodwork.logical_types import (
     URL,
@@ -29,7 +31,11 @@ from woodwork.logical_types import (
 )
 from woodwork.statistics_utils import (
     _get_describe_dict,
+    _get_histogram_values,
     _get_mode,
+    _get_recent_values,
+    _get_top_values_categorical,
+    _get_top_values_numeric,
     _make_categorical_for_mutual_info,
     _replace_nans_for_mutual_info
 )
@@ -648,6 +654,48 @@ def test_describe_callback(describe_df):
     assert mock_callback.total_elapsed_time > 0
 
 
+def test_describe_extra_stats(describe_df):
+    describe_df = describe_df.drop(columns=['boolean_col', 'natural_language_col', 'formatted_datetime_col',
+                                            'timedelta_col', 'latlong_col'])
+    describe_df['nullable_integer_col'] = describe_df['numeric_col']
+    describe_df['integer_col'] = describe_df['numeric_col'].fillna(0)
+    describe_df['small_range_col'] = describe_df['numeric_col'].fillna(0) // 10
+
+    ltypes = {
+        'category_col': 'Categorical',
+        'datetime_col': 'Datetime',
+        'numeric_col': 'Double',
+        'nullable_integer_col': 'IntegerNullable',
+        'integer_col': 'Integer',
+        'small_range_col': 'Integer',
+    }
+    describe_df.ww.init(index='index_col', logical_types=ltypes)
+    df = describe_df.ww.describe(extra_stats=True)
+
+    for val in ['histogram', 'top_values', 'recent_values']:
+        assert val in df.index
+
+    # category columns should have top_values
+    assert isinstance(df['category_col']['top_values'], list)
+    assert pd.isnull(df['category_col']['histogram'])
+    assert pd.isnull(df['category_col']['recent_values'])
+
+    # datetime columns should have recent_values
+    assert isinstance(df['datetime_col']['recent_values'], list)
+    assert pd.isnull(df['datetime_col']['histogram'])
+    assert pd.isnull(df['datetime_col']['top_values'])
+
+    # numeric columns should have histogram
+    for col in ['numeric_col', 'nullable_integer_col', 'integer_col', 'small_range_col']:
+        assert isinstance(df[col]['histogram'], list)
+        assert pd.isnull(df[col]['recent_values'])
+        if col == 'small_range_col':
+            # If values are in a narrow range, top values should be present
+            assert isinstance(df[col]['top_values'], list)
+        else:
+            assert pd.isnull(df[col]['top_values'])
+
+
 def test_value_counts(categorical_df):
     logical_types = {
         'ints': IntegerNullable,
@@ -688,3 +736,101 @@ def test_value_counts(categorical_df):
     val_cts_2 = categorical_df.ww.value_counts(top_n=2)
     for col in val_cts_2:
         assert len(val_cts_2[col]) == 2
+
+
+def test_datetime_recent():
+    times = [
+        datetime(2019, 1, 1, 1, 10, 0, 1),
+        datetime(2019, 2, 2, 2, 20, 1, 0),
+        datetime(2019, 3, 1, 3, 30, 1, 0),
+        datetime(2019, 1, 1, 4, 40, 1, 0),
+        datetime(2019, 1, 1, 5, 50, 1, 0),
+        datetime(2019, 2, 2, 6, 10, 1, 0),
+        datetime(2019, 4, 1, 7, 20, 1, 0),
+        datetime(2019, 5, 1, 8, 30, 0, 0),
+    ]
+    # Verify NaNs, strings, empty string don't break
+    times.extend([np.nan, pd.NaT, " ", "test"])
+    clipped_times = [x.date() for x in times[:-4]]
+    values = _get_recent_values(pd.Series(times), num_x=3)
+    expected_values = [
+        {"value": datetime(2019, 1, 1), "count": 3},
+        {"value": datetime(2019, 2, 2), "count": 2},
+        {"value": datetime(2019, 3, 1), "count": 1},
+    ]
+    for val in values:
+        assert val["value"] in clipped_times
+    assert len(values) == len(expected_values)
+
+
+def test_numeric_histogram():
+    column = pd.Series(np.random.randn(1000))
+    column.append(pd.Series([np.nan, " ", "test"]))
+    bins = 7
+    values = _get_histogram_values(column, bins=bins)
+    assert len(values) == bins
+    total = 0
+    for info in values:
+        assert "bins" in info
+        assert "frequency" in info
+        freq = info["frequency"]
+        total += freq
+    assert total == 1000
+
+
+@pytest.mark.parametrize(
+    "input_series, expected",
+    [
+        (
+            ["a", "b", "b", "c", "c", "c", np.nan],
+            [
+                {"count": 1, "value": "a"},
+                {"count": 2, "value": "b"},
+                {"count": 3, "value": "c"},
+            ],
+        ),
+        (
+            [1, 2, 2, 3],
+            [
+                {"count": 1, "value": 1},
+                {"count": 1, "value": 3},
+                {"count": 2, "value": 2},
+            ],
+        ),
+    ],
+)
+def test_get_top_values_categorical(input_series, expected):
+    column = pd.Series(input_series)
+    top_values = _get_top_values_categorical(column, 10)
+    for x in top_values:
+        assert x in expected
+
+
+@pytest.mark.parametrize(
+    "input_series, expected",
+    [
+        (
+            [1, 2, 2, 3, 3, 3, np.nan],
+            [
+                {"count": 0, "value": 0},
+                {"count": 1, "value": 1},
+                {"count": 2, "value": 2},
+                {"count": 3, "value": 3},
+            ],
+        ),
+        (
+            [1, 2, 2, 3],
+            [
+                {"count": 0, "value": 0},
+                {"count": 1, "value": 1},
+                {"count": 1, "value": 3},
+                {"count": 2, "value": 2},
+            ],
+        ),
+    ],
+)
+def test_get_top_values_numeric(input_series, expected):
+    column = pd.Series(input_series)
+    top_values = _get_top_values_numeric(column, range(4))
+    for x in top_values:
+        assert x in expected

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -807,26 +807,26 @@ def test_get_top_values_categorical(input_series, expected):
     "input_series, expected",
     [
         (
-            [1, 2, 2, 3, 3, 3, np.nan],
+            pd.Series([1, 2, 2, 3, 3, 3, pd.NA], dtype='Int64'),
             [
-                {"value": 0, "count": 0},
-                {"value": 1, "count": 1},
-                {"value": 2, "count": 2},
                 {"value": 3, "count": 3},
+                {"value": 2, "count": 2},
+                {"value": 1, "count": 1},
+                {"value": 0, "count": 0},
             ],
         ),
         (
-            [1, 2, 2, 3],
+            pd.Series([1, 2, 2, 3], dtype='int64'),
             [
-                {"value": 0, "count": 0},
-                {"value": 1, "count": 1},
                 {"value": 2, "count": 2},
+                {"value": 1, "count": 1},
                 {"value": 3, "count": 1},
+                {"value": 0, "count": 0},
             ],
         ),
     ],
 )
 def test_get_numeric_value_counts_in_range(input_series, expected):
-    column = pd.Series(input_series)
+    column = input_series
     top_values = _get_numeric_value_counts_in_range(column, range(4))
     assert top_values == expected

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -754,8 +754,8 @@ def test_datetime_get_recent_value_counts():
     ])
     values = _get_recent_value_counts(times, num_x=3)
     expected_values = [
-        {"value": datetime(2019, 5, 1).date(), "count": 2},
         {"value": datetime(2019, 4, 2).date(), "count": 3},
+        {"value": datetime(2019, 5, 1).date(), "count": 2},
         {"value": datetime(2019, 3, 1).date(), "count": 1},
     ]
     assert values == expected_values
@@ -782,17 +782,17 @@ def test_numeric_histogram():
         (
             ["a", "b", "b", "c", "c", "c", np.nan],
             [
-                {"value": "a", "count": 1},
-                {"value": "b", "count": 2},
                 {"value": "c", "count": 3},
+                {"value": "b", "count": 2},
+                {"value": "a", "count": 1},
             ],
         ),
         (
             [1, 2, 2, 3],
             [
+                {"value": 2, "count": 2},
                 {"value": 1, "count": 1},
                 {"value": 3, "count": 1},
-                {"value": 2, "count": 2},
             ],
         ),
     ],

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -681,6 +681,7 @@ def test_describe_dict_extra_stats(describe_df):
     assert isinstance(desc_dict['datetime_col']['recent_values'], list)
     assert desc_dict['datetime_col'].get('histogram') is None
     assert desc_dict['datetime_col'].get('top_values') is None
+
     # numeric columns should have histogram
     for col in ['numeric_col', 'nullable_integer_col', 'integer_col', 'small_range_col']:
         assert isinstance(desc_dict[col]['histogram'], list)


### PR DESCRIPTION
- Add option to compute extra stats to describe
- Closes #960

Adds the ability to compute extra optional stats with the `describe` method by passing `extra_stats=True` along with other optional parameter to control the calculations. Extra stats include:
- histogram (numeric cols)
- top_values (categorical and certain integer cols)
- most_recent (datetime cols)