### PR TITLE
Update dask requirements

### DIFF
--- a/dask-requirements.txt
+++ b/dask-requirements.txt
@@ -1,1 +1,1 @@
-dask[dataframe]>=2.30.0,<2021.12.0
+dask[dataframe]>=2.30.0,!=2020.12.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Future Release
         * Add the ability to generate optional extra stats with ``DataFrame.ww.describe_dict`` (:pr:`988`)
     * Fixes
     * Changes
+        * Remove version restriction for dask requirements (:pr:`998`)
     * Documentation Changes
       * Add instructions for installing the update checker (:pr:`993`)
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,7 +12,7 @@ Future Release
     * Changes
         * Remove version restriction for dask requirements (:pr:`998`)
     * Documentation Changes
-      * Add instructions for installing the update checker (:pr:`993`)
+        * Add instructions for installing the update checker (:pr:`993`)
     * Testing Changes
         * Add env setting to update checker (:pr:`978`, :pr:`994`)
 


### PR DESCRIPTION
- Update dask requirements

There was an issue with Dask version 2020.12.0 that caused issues with Woodwork serialization. However, all other versions of dask from 2.30.0 onward work fine. This PR updates the dask requirements to remove the upper bound and replace it with an exclusion of version 2020.12.0.