### PR TITLE
Remove make_index from Woodwork init and all references to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import pandas as pd
 import woodwork as ww
 
 df = pd.read_csv("https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv")
-df.ww.init(name='retail', make_index=True, index='order_product_id')
+df.ww.init(name='retail')
 df.ww.set_types(logical_types={
     'quantity': 'Integer',
     'customer_name': 'PersonFullName',
@@ -68,7 +68,6 @@ df.ww
 ```
                    Physical Type     Logical Type Semantic Tag(s)
 Column
-order_product_id           int64          Integer       ['index']
 order_id                category      Categorical    ['category']
 product_id              category      Categorical    ['category']
 description               string  NaturalLanguage              []

--- a/docs/source/guides/using_woodwork_with_dask_and_koalas.ipynb
+++ b/docs/source/guides/using_woodwork_with_dask_and_koalas.ipynb
@@ -310,12 +310,7 @@
     "Woodwork allows column names of any format that is supported by the DataFrame. However, Dask DataFrames do not currently support integer column names.\n",
     "\n",
     "### Setting DataFrame Index\n",
-    "When specifying a Woodwork index with a pandas DataFrame, the underlying index of the DataFrame will be updated to match the column specified as the Woodwork index. When specifying a Woodwork index on a Dask or Koalas DataFrame, however, the underlying index will remain unchanged.\n",
-    "\n",
-    "### Make Index\n",
-    "When using `make_index` during Woodwork initialization, a new index column is added in-place to the existing DataFrame. Because this type of in-place operation is not currently possible with Koalas, Woodwork does not support `make_index` when working with a Koalas DataFrame. \n",
-    "\n",
-    "If a new index column is needed, this should be added by the user prior to initializing Woodwork. This can be done easily with an operation such as this:"
+    "When specifying a Woodwork index with a pandas DataFrame, the underlying index of the DataFrame will be updated to match the column specified as the Woodwork index. When specifying a Woodwork index on a Dask or Koalas DataFrame, however, the underlying index will remain unchanged.\n"
    ]
   },
   {

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,13 +10,14 @@ Future Release
         * Add the ability to generate optional extra stats with ``DataFrame.ww.describe_dict`` (:pr:`988`)
     * Fixes
     * Changes
+        * Remove ``make_index`` parameter from ``DataFrame.ww.init`` :pr:`1000`)
     * Documentation Changes
       * Add instructions for installing the update checker (:pr:`993`)
     * Testing Changes
         * Add env setting to update checker (:pr:`978`, :pr:`994`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`jeff-hernandez`, :user:`thehomebrewnerd`, :user:`frances-h`
+    :user:`gsheni`, :user:`jeff-hernandez`, :user:`thehomebrewnerd`, :user:`frances-h`, :user:`tuethan1999`
 
 Breaking Changes
 ++++++++++++++++
@@ -29,6 +30,7 @@ Breaking Changes
         * total units to complete
         * the progress unit of measurement
         * time elapsed since start of calculation
+    * ``DataFrame.ww.init`` no longer accepts the make_index parameter
 
 
 v0.4.1 Jun 9, 2021

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -58,7 +58,7 @@
    "source": [
     "import woodwork as ww\n",
     "\n",
-    "df.ww.init(name=\"retail\", make_index=True, index=\"order_product_id\")\n",
+    "df.ww.init(name=\"retail\")\n",
     "df.ww"
    ]
   },
@@ -66,7 +66,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using just this simple call, Woodwork was able to infer the logical types present in the data by analyzing the DataFrame dtypes as well as the information contained in the columns. In addition, Woodwork also added semantic tags to some of the columns based on the logical types that were inferred. Because the original data did not contain an index column, Woodwork's `make_index` parameter was used to create a new index column in the DataFrame."
+    "Using just this simple call, Woodwork was able to infer the logical types present in the data by analyzing the DataFrame dtypes as well as the information contained in the columns. In addition, Woodwork also added semantic tags to some of the columns based on the logical types that were inferred."
    ]
   },
   {

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -32,6 +32,7 @@
     "import pandas as pd\n",
     "\n",
     "df = pd.read_csv(\"https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv\")\n",
+    "df['order_product_id'] = range(df.shape[0])\n",
     "df.head(5)"
    ]
   },
@@ -504,9 +505,8 @@
  "metadata": {
   "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.8.5 64-bit ('venv': venv)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -519,6 +519,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
+  },
+  "interpreter": {
+   "hash": "abf2ddccffc05ca377fc3374e52ade6b6ea528b31146d89257365ea0ab0904ce"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas>=1.2.0
+pandas>=1.2.0,<1.2.5
 scikit-learn>=0.22

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -61,7 +61,7 @@ ks = import_or_none('databricks.koalas')
 
 
 def test_check_index_errors(sample_df):
-    error_message = 'Specified index column `foo` not found in dataframe. To create a new index column, set make_index to True.'
+    error_message = 'Specified index column `foo` not found in dataframe'
     with pytest.raises(ColumnNotPresentError, match=error_message):
         _check_index(dataframe=sample_df, index='foo')
 
@@ -70,14 +70,6 @@ def test_check_index_errors(sample_df):
         error_message = 'Index column must be unique'
         with pytest.raises(LookupError, match=error_message):
             _check_index(sample_df, index='age')
-
-    error_message = 'When setting make_index to True, the name specified for index cannot match an existing column name'
-    with pytest.raises(IndexError, match=error_message):
-        _check_index(sample_df, index='id', make_index=True)
-
-    error_message = 'When setting make_index to True, the name for the new index must be specified in the index parameter'
-    with pytest.raises(IndexError, match=error_message):
-        _check_index(sample_df, index=None, make_index=True)
 
 
 def test_check_logical_types_errors(sample_df):
@@ -350,11 +342,11 @@ def test_accessor_with_schema_parameter_warning(sample_df):
 
     head_df = schema_df.head(2)
 
-    warning = "A schema was provided and the following parameters were ignored: index, make_index, " \
+    warning = "A schema was provided and the following parameters were ignored: index, " \
               "time_index, logical_types, already_sorted, use_standard_tags, semantic_tags"
     with pytest.warns(ParametersIgnoredWarning, match=warning):
         head_df.ww.init(index='ignored_id', time_index="ignored_time_index", logical_types={'ignored': 'ltypes'},
-                        make_index=True, already_sorted=True, semantic_tags={'ignored_id': 'ignored_test_tag'},
+                        already_sorted=True, semantic_tags={'ignored_id': 'ignored_test_tag'},
                         use_standard_tags={'id': True, 'age': False}, schema=schema)
 
     assert head_df.ww.name == 'test_schema'
@@ -464,19 +456,6 @@ def test_accessor_equality(sample_df):
         assert schema_df.ww != loc_df
     else:
         assert schema_df.ww == loc_df
-
-
-def test_accessor_equality_make_index(sample_df_pandas):
-    made_index_df = sample_df_pandas.copy()
-    made_index_df.insert(0, 'new_index', range(len(made_index_df)))
-    made_index_df.ww.init(index='new_index', make_index=False)
-
-    schema_df = sample_df_pandas.copy()
-    schema_df.ww.init(index='new_index', make_index=True)
-
-    pd.testing.assert_frame_equal(schema_df, made_index_df)
-
-    assert made_index_df.ww != schema_df.ww
 
 
 def test_accessor_shallow_equality(sample_df):
@@ -969,36 +948,6 @@ def test_invalid_dtype_casting():
         df.ww.init(logical_types=ltypes)
 
 
-def test_make_index(sample_df):
-    if ks and isinstance(sample_df, ks.DataFrame):
-        error_msg = "Cannot make index on a Koalas DataFrame."
-        with pytest.raises(TypeError, match=error_msg):
-            sample_df.ww.init(index='new_index', make_index=True)
-    else:
-        schema_df = sample_df.copy()
-        schema_df.ww.init(index='new_index', make_index=True)
-
-        assert schema_df.ww.make_index is True
-
-        assert schema_df.ww.index == 'new_index'
-        assert 'new_index' in schema_df.ww.columns
-        assert 'new_index' in schema_df.ww.columns
-        assert to_pandas(schema_df)['new_index'].unique
-        assert to_pandas(schema_df['new_index']).is_monotonic
-        assert 'index' in schema_df.ww.columns['new_index'].semantic_tags
-
-        copied_df = schema_df.ww.copy()
-        assert copied_df.ww.make_index is True
-
-        own_index_df = sample_df.copy()
-        own_index_df.ww.init(index='id')
-
-        assert own_index_df.ww.make_index is False
-
-        copied_df = own_index_df.ww.copy()
-        assert copied_df.ww.make_index is False
-
-
 def test_underlying_index_set_no_index_on_init(sample_df):
     if dd and isinstance(sample_df, dd.DataFrame):
         pytest.xfail('Setting underlying index is not supported with Dask input')
@@ -1046,13 +995,6 @@ def test_underlying_index_set(sample_df):
     schema_df.ww.set_index(None)
     assert schema_df.ww.index is None
     assert (schema_df.index == schema_df['full_name']).all()
-
-    # Sets underlying index for made index
-    schema_df = sample_df.copy()
-    schema_df.ww.init(index='made_index', make_index=True)
-    assert 'made_index' in schema_df
-    assert (schema_df.index == [0, 1, 2, 3]).all()
-    assert schema_df.index.name is None
 
 
 def test_underlying_index_reset(sample_df):


### PR DESCRIPTION
- Remove `make_index` from `WoodworkTableAccessor` and all references to it
- Closes #984 