### PR TITLE
Raise type conversion error in datetime

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Pass additional progress information in callback functions (:pr:`979`)
         * Add the ability to generate optional extra stats with ``DataFrame.ww.describe_dict`` (:pr:`988`)
     * Fixes
+        * Raise type conversion error in ``Datetime`` logical type (:pr:`1001`)
     * Changes
         * Remove version restriction for dask requirements (:pr:`998`)
     * Documentation Changes

--- a/woodwork/exceptions.py
+++ b/woodwork/exceptions.py
@@ -34,7 +34,11 @@ class TypingInfoMismatchWarning(UserWarning):
 
 
 class TypeConversionError(Exception):
-    pass
+    def __init__(self, series, new_dtype, logical_type):
+        message = f'Error converting datatype for {series.name} from type {str(series.dtype)} '
+        message += f'to type {new_dtype}. Please confirm the underlying data is consistent with '
+        message += f'logical type {logical_type}.'
+        super().__init__(message)
 
 
 class ParametersIgnoredWarning(UserWarning):

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -47,14 +47,15 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
         new_dtype = self._get_valid_dtype(type(series))
         if new_dtype != str(series.dtype):
             # Update the underlying series
+            error = TypeConversionError(series, new_dtype, type(self))
             try:
                 series = series.astype(new_dtype)
                 if str(series.dtype) != new_dtype:
                     # Catch conditions when Panads does not error but did not
                     # convert to the specified dtype (example: 'category' -> 'bool')
-                    raise TypeConversionError(series, new_dtype, type(self))
+                    raise error
             except (TypeError, ValueError):
-                raise TypeConversionError(series, new_dtype, type(self))
+                raise error
         return series
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -47,17 +47,14 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
         new_dtype = self._get_valid_dtype(type(series))
         if new_dtype != str(series.dtype):
             # Update the underlying series
-            error_msg = f'Error converting datatype for {series.name} from type {str(series.dtype)} ' \
-                f'to type {new_dtype}. Please confirm the underlying data is consistent with ' \
-                f'logical type {type(self)}.'
             try:
                 series = series.astype(new_dtype)
                 if str(series.dtype) != new_dtype:
                     # Catch conditions when Panads does not error but did not
                     # convert to the specified dtype (example: 'category' -> 'bool')
-                    raise TypeConversionError(error_msg)
+                    raise TypeConversionError(series, new_dtype, type(self))
             except (TypeError, ValueError):
-                raise TypeConversionError(error_msg)
+                raise TypeConversionError(series, new_dtype, type(self))
         return series
 
 
@@ -193,10 +190,7 @@ class Datetime(LogicalType):
                 else:
                     series = pd.to_datetime(series, format=self.datetime_format)
             except (TypeError, ValueError):
-                message = f'Error converting datatype for {series.name} from type {str(series.dtype)} '
-                message += f'to type {new_dtype}. Please confirm the underlying data is consistent with '
-                message += f'logical type {type(self)}.'
-                raise TypeConversionError(message)
+                raise TypeConversionError(series, new_dtype, type(self))
         return super().transform(series)
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -183,14 +183,20 @@ class Datetime(LogicalType):
         """Converts the series data to a formatted datetime."""
         new_dtype = self._get_valid_dtype(type(series))
         if new_dtype != str(series.dtype):
-            if dd and isinstance(series, dd.Series):
-                name = series.name
-                series = dd.to_datetime(series, format=self.datetime_format)
-                series.name = name
-            elif ks and isinstance(series, ks.Series):
-                series = ks.Series(ks.to_datetime(series.to_numpy(), format=self.datetime_format), name=series.name)
-            else:
-                series = pd.to_datetime(series, format=self.datetime_format)
+            try:
+                if dd and isinstance(series, dd.Series):
+                    name = series.name
+                    series = dd.to_datetime(series, format=self.datetime_format)
+                    series.name = name
+                elif ks and isinstance(series, ks.Series):
+                    series = ks.Series(ks.to_datetime(series.to_numpy(), format=self.datetime_format), name=series.name)
+                else:
+                    series = pd.to_datetime(series, format=self.datetime_format)
+            except (TypeError, ValueError):
+                message = f'Error converting datatype for {series.name} from type {str(series.dtype)} '
+                message += f'to type {new_dtype}. Please confirm the underlying data is consistent with '
+                message += f'logical type {type(self)}.'
+                raise TypeConversionError(message)
         return super().transform(series)
 
 

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -3,6 +3,7 @@ import re
 import pandas as pd
 import pytest
 
+from woodwork.exceptions import TypeConversionError
 from woodwork.logical_types import (
     Boolean,
     Categorical,
@@ -108,6 +109,14 @@ def test_datetime_transform(datetimes):
         assert str(series.dtype) == 'object'
         transform = datetime.transform(series)
         assert str(transform.dtype) == 'datetime64[ns]'
+
+
+def test_datetime_conversion_error():
+    series = pd.Series(['a', 'b', 'c'])
+    match = 'Error converting datatype for None from type object to type datetime64[ns]. '
+    match += 'Please confirm the underlying data is consistent with logical type Datetime.'
+    with pytest.raises(TypeConversionError, match=re.escape(match)):
+        Datetime().transform(series)
 
 
 def test_ordinal_transform(sample_series):

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -112,8 +112,8 @@ def test_datetime_transform(datetimes):
 
 
 def test_datetime_conversion_error():
-    series = pd.Series(['a', 'b', 'c'])
-    match = 'Error converting datatype for None from type object to type datetime64[ns]. '
+    series = pd.Series(['a', 'b', 'c'], name='series')
+    match = 'Error converting datatype for series from type object to type datetime64[ns]. '
     match += 'Please confirm the underlying data is consistent with logical type Datetime.'
     with pytest.raises(TypeConversionError, match=re.escape(match)):
         Datetime().transform(series)

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -111,12 +111,15 @@ def test_datetime_transform(datetimes):
         assert str(transform.dtype) == 'datetime64[ns]'
 
 
-def test_datetime_conversion_error():
-    series = pd.Series(['a', 'b', 'c'], name='series')
-    match = 'Error converting datatype for series from type object to type datetime64[ns]. '
+def test_datetime_conversion_error(sample_series):
+    if dd and isinstance(sample_series, dd.Series):
+        pytest.xfail('Dask does not show error until compute is made.')
+
+    dtype = str(sample_series.dtype)
+    match = f'Error converting datatype for sample_series from type {dtype} to type datetime64[ns]. '
     match += 'Please confirm the underlying data is consistent with logical type Datetime.'
     with pytest.raises(TypeConversionError, match=re.escape(match)):
-        Datetime().transform(series)
+        Datetime().transform(sample_series)
 
 
 def test_ordinal_transform(sample_series):


### PR DESCRIPTION
Closes #991 by raising a type conversion error when a Datetime logical type cannot parse data to a datetime dtype.