### PR TITLE
Disable pdf documentation build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,9 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: []
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.7

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,10 +10,6 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - pdf
-
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,10 +7,10 @@ nbsphinx==0.8.5
 pydata-sphinx-theme==0.4.0
 Sphinx==3.2.1
 nbconvert==6.0.2
-ipython==7.18.1
+ipython==7.24.1
 pygments==2.8.1
 jupyter==1.0.0
 pandoc==1.0.2
-ipykernel==5.3.4
+ipykernel==5.5.5
 -r dask-requirements.txt
 -r koalas-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,10 +7,10 @@ nbsphinx==0.8.5
 pydata-sphinx-theme==0.4.0
 Sphinx==3.2.1
 nbconvert==6.0.2
-ipython==7.24.1
+ipython==7.18.1
 pygments==2.8.1
 jupyter==1.0.0
 pandoc==1.0.2
-ipykernel==5.5.5
+ipykernel==5.3.4
 -r dask-requirements.txt
 -r koalas-requirements.txt

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Remove version restriction for dask requirements (:pr:`998`)
     * Documentation Changes
         * Add instructions for installing the update checker (:pr:`993`)
+        * Disable pdf format with documentation build (:pr:`1002`)
     * Testing Changes
         * Add env setting to update checker (:pr:`978`, :pr:`994`)
 


### PR DESCRIPTION
- PDF documentation building is not used, and is currently raising an error on ReadTheDocs
```
Rule 'pdflatex': Rules & subrules not known to be previously run:
   pdflatex
Rule 'pdflatex': The following rules & subrules became out-of-date:
      'pdflatex'
------------
Run number 1 of rule 'pdflatex'
------------
------------
Running 'pdflatex   -interaction=nonstopmode -recorder --jobname="feature-labs-inc-datatables"  "Woodwork.tex"'
------------
Latexmk: applying rule 'pdflatex'...
This is pdfTeX, Version 3.14159265-2.6-1.40.18 (TeX Live 2017/Debian) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
(./Woodwork.tex
....
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on feature-labs-inc-datatables.log.
Latexmk: Index file 'feature-labs-inc-datatables.idx' was written
Failure to make 'feature-labs-inc-datatables.pdf'
Collected error summary (may duplicate other messages):
  pdflatex: Command for 'pdflatex' gave return code 256
Latexmk: Errors, in force_mode: so I tried finishing targets
```