### PR TITLE
Retain schema on series.ww.to_frame call

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Enhancements
         * Pass additional progress information in callback functions (:pr:`979`)
         * Add the ability to generate optional extra stats with ``DataFrame.ww.describe_dict`` (:pr:`988`)
+        * Retain schema when calling ``series.ww.to_frame()`` (:pr:`1004`)
     * Fixes
     * Changes
         * Remove version restriction for dask requirements (:pr:`998`)

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -3,9 +3,13 @@ import warnings
 import weakref
 
 import pandas as pd
-from woodwork import logical_types
 
-from woodwork.accessor_utils import _is_series, init_series, _is_dataframe, is_schema_valid
+from woodwork.accessor_utils import (
+    _is_dataframe,
+    _is_series,
+    init_series,
+    is_schema_valid
+)
 from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
     ParametersIgnoredWarning,

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -3,8 +3,9 @@ import warnings
 import weakref
 
 import pandas as pd
+from woodwork import logical_types
 
-from woodwork.accessor_utils import _is_series, init_series
+from woodwork.accessor_utils import _is_series, init_series, _is_dataframe, is_schema_valid
 from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
     ParametersIgnoredWarning,
@@ -13,6 +14,7 @@ from woodwork.exceptions import (
 )
 from woodwork.indexers import _iLocIndexer, _locIndexer
 from woodwork.logical_types import LatLong, Ordinal
+from woodwork.table_schema import TableSchema
 from woodwork.utils import (
     _get_column_logical_type,
     _is_valid_latlong_series,
@@ -246,6 +248,18 @@ class WoodworkColumnAccessor:
                                                                                           invalid_schema_message,
                                                                                           'Series')
                         warnings.warn(warning_message, TypingInfoMismatchWarning)
+                elif _is_dataframe(result):
+                    # Initialize Woodwork if a valid table schema can be created from the original column schema
+                    col_schema = self.schema
+                    table_schema = TableSchema(column_names=[self.name],
+                                               logical_types={self.name: col_schema.logical_type},
+                                               semantic_tags={self.name: col_schema.semantic_tags},
+                                               column_metadata={self.name: col_schema.metadata},
+                                               use_standard_tags={self.name: col_schema.use_standard_tags},
+                                               column_descriptions={self.name: col_schema.description},
+                                               validate=False)
+                    if is_schema_valid(result, table_schema):
+                        result.ww.init(schema=table_schema)
                 # Always return the results of the Series operation whether or not Woodwork is initialized
                 return result
             return wrapper

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from mock import patch
 
-from woodwork.accessor_utils import init_series
+from woodwork.accessor_utils import _is_dataframe, init_series
 from woodwork.column_accessor import WoodworkColumnAccessor
 from woodwork.column_schema import ColumnSchema
 from woodwork.exceptions import (
@@ -757,11 +757,16 @@ def test_validation_methods_called_init_with_schema(mock_validate_schema, sample
     pd.testing.assert_series_equal(to_pandas(validated), to_pandas(not_validated))
 
 
-def test_to_frame_maintains_schema(sample_series):
+def test_series_methods_returning_frame(sample_series):
     sample_series.ww.init(semantic_tags={'test_tag'},
                           description='custom description',
                           metadata={'custom key': 'custom value'})
     sample_frame = sample_series.ww.to_frame()
 
+    assert _is_dataframe(sample_frame)
     assert sample_frame.ww.schema is not None
     assert sample_frame.ww.columns['sample_series'] == sample_series.ww.schema
+
+    reset_index_frame = sample_series.ww.reset_index(drop=False)
+    assert _is_dataframe(reset_index_frame)
+    assert reset_index_frame.ww.schema is None

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -755,3 +755,13 @@ def test_validation_methods_called_init_with_schema(mock_validate_schema, sample
     assert mock_validate_schema.called
     assert validated.ww == not_validated.ww
     pd.testing.assert_series_equal(to_pandas(validated), to_pandas(not_validated))
+
+
+def test_to_frame_maintains_schema(sample_series):
+    sample_series.ww.init(semantic_tags={'test_tag'},
+                          description='custom description',
+                          metadata={'custom key': 'custom value'})
+    sample_frame = sample_series.ww.to_frame()
+
+    assert sample_frame.ww.schema is not None
+    assert sample_frame.ww.columns['sample_series'] == sample_series.ww.schema


### PR DESCRIPTION
- Retain schema on series.ww.to_frame call
- Closes #974

Implements changes to `WoodworkColumnAccessor._make_series_call` to retain schema information when possible if a dataframe is returned from the series call, for example when calling `series.ww.to_frame()`.