### PR TITLE
Remove update checker to fix docs warnings

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Future Release
         * Add instructions for installing the update checker (:pr:`993`)
         * Disable pdf format with documentation build (:pr:`1002`)
         * Silence deprecation warnings in documentation build (:pr:`1008`)
+        * Temporarily remove update checker to fix docs warnings (:pr:`1011`)
     * Testing Changes
         * Add env setting to update checker (:pr:`978`, :pr:`994`)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,4 +7,3 @@ boto3>=1.10.45
 moto[all]>=1.3.14
 smart-open>=5.0.0
 pyarrow>=4.0.1
-alteryx-open-src-update-checker>=2.0.0

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -17,10 +17,10 @@ from woodwork.accessor_utils import (
 )
 
 # Call functions registered by other libraries when woodwork is imported
-for entry_point in pkg_resources.iter_entry_points('alteryx_open_src_initialize'):
+for entry_point in pkg_resources.iter_entry_points('alteryx_open_src_initialize'): # pragma: no cover
     try:
         method = entry_point.load()
         if callable(method):
             method('woodwork')
-    except Exception:  # pragma: no cover
+    except Exception:  
         pass


### PR DESCRIPTION
Removing update checker from test requirements to fix docs warnings until better solution can be identified.