### PR TITLE
Remove lines in LogicalType.transform that raise error if dtype conflicts

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,18 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Remove lines in ``LogicalType.transform`` that raise error if dtype conflicts (:pr:`1012`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`tamargrey`
 
 v0.4.2 Jun 23, 2021
 ===================
@@ -25,7 +28,6 @@ v0.4.2 Jun 23, 2021
     * Changes
         * Remove ``make_index`` parameter from ``DataFrame.ww.init`` (:pr:`1000`)
         * Remove version restriction for dask requirements (:pr:`998`)
-        * Remove lines in ``LogicalType.transform`` that raise error if dtype conflicts (:pr:`1012`)
     * Documentation Changes
         * Add instructions for installing the update checker (:pr:`993`)
         * Disable pdf format with documentation build (:pr:`1002`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ v0.4.2 Jun 23, 2021
     * Changes
         * Remove ``make_index`` parameter from ``DataFrame.ww.init`` (:pr:`1000`)
         * Remove version restriction for dask requirements (:pr:`998`)
+        * Remove lines in ``LogicalType.transform`` that raise error if dtype conflicts (:pr:`1012`)
     * Documentation Changes
         * Add instructions for installing the update checker (:pr:`993`)
         * Disable pdf format with documentation build (:pr:`1002`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas>=1.2.0,<1.2.5
+pandas>=1.2.5
 scikit-learn>=0.22

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -47,15 +47,10 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
         new_dtype = self._get_valid_dtype(type(series))
         if new_dtype != str(series.dtype):
             # Update the underlying series
-            error = TypeConversionError(series, new_dtype, type(self))
             try:
                 series = series.astype(new_dtype)
-                if str(series.dtype) != new_dtype:
-                    # Catch conditions when Panads does not error but did not
-                    # convert to the specified dtype (example: 'category' -> 'bool')
-                    raise error
             except (TypeError, ValueError):
-                raise error
+                raise TypeConversionError(series, new_dtype, type(self))
         return series
 
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -935,18 +935,6 @@ def test_invalid_dtype_casting():
     with pytest.raises(TypeConversionError, match=err_msg):
         df.ww.init(logical_types=ltypes)
 
-    # pandas >=1.2.0 converts to an object dtype when converting a series with missing
-    # values with `.astype('bool')` but does not error. Woodwork should not allow this to succeed.
-    series = pd.Series(['a', 'b', None], name=column_name, dtype='category')
-    ltypes = {
-        column_name: Boolean,
-    }
-    err_msg = 'Error converting datatype for test_series from type category to type ' \
-        'bool. Please confirm the underlying data is consistent with logical type Boolean.'
-    df = pd.DataFrame(series)
-    with pytest.raises(TypeConversionError, match=err_msg):
-        df.ww.init(logical_types=ltypes)
-
 
 def test_underlying_index_set_no_index_on_init(sample_df):
     if dd and isinstance(sample_df, dd.DataFrame):


### PR DESCRIPTION
- With pandas 1.2.5 and on, the `astype(bool)` call on a categorical Series with nans no longer gets converted to `object` dtype, so the lines in transform and the corresponding test are no longer needed.
- Closes #1006
