### PR TITLE
Add infer_datetime_format param to to_datetime calls

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,18 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Add ``infer_datetime_format`` param to speed up ``to_datetime`` calls (:pr:`1016`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
 
 v0.4.2 Jun 23, 2021
 ===================

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -184,12 +184,15 @@ class Datetime(LogicalType):
             try:
                 if dd and isinstance(series, dd.Series):
                     name = series.name
-                    series = dd.to_datetime(series, format=self.datetime_format)
+                    series = dd.to_datetime(series, format=self.datetime_format, infer_datetime_format=True)
                     series.name = name
                 elif ks and isinstance(series, ks.Series):
-                    series = ks.Series(ks.to_datetime(series.to_numpy(), format=self.datetime_format), name=series.name)
+                    series = ks.Series(ks.to_datetime(series.to_numpy(),
+                                                      format=self.datetime_format,
+                                                      infer_datetime_format=True),
+                                       name=series.name)
                 else:
-                    series = pd.to_datetime(series, format=self.datetime_format)
+                    series = pd.to_datetime(series, format=self.datetime_format, infer_datetime_format=True)
             except (TypeError, ValueError):
                 raise TypeConversionError(series, new_dtype, type(self))
         return super().transform(series)

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -26,6 +26,7 @@ from woodwork.type_sys.type_system import DEFAULT_INFERENCE_FUNCTIONS
 from woodwork.type_sys.utils import (
     _get_specified_ltype_params,
     _is_numeric_series,
+    col_is_datetime,
     list_logical_types,
     list_semantic_tags
 )
@@ -412,3 +413,37 @@ def test_parse_logical_type_errors():
     error = "Invalid logical type specified for 'col_name'"
     with pytest.raises(TypeError, match=error):
         _parse_logical_type(int, 'col_name')
+
+
+def test_col_is_datetime():
+    inputs = [
+        pd.to_datetime(pd.Series(['2020-01-01', '2021-02-02', '2022-03-03'])),
+        pd.to_datetime(pd.Series([pd.NA, '2021-02-02', '2022-03-03'])),
+        pd.Series([1, 2, 3]),
+        pd.Series([pd.NA, 2, 3]),
+        pd.Series([1.0, 2.0, 3.0]),
+        pd.Series([pd.NA, 2.0, 3.0]),
+        pd.Series(['2020-01-01', '2021-02-02', '2022-03-03']),
+        pd.Series([pd.NA, '2021-02-02', '2022-03-03']),
+        pd.Series(['a', 'b', 'c']),
+        pd.Series([pd.NA, 'b', 'c']),
+        pd.Series([pd.NA, pd.NA, pd.NA]),
+    ]
+
+    expected_values = [
+        True,
+        True,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        False,
+        False,
+        False,
+    ]
+
+    for input, expected in list(zip(inputs, expected_values)):
+        actual = col_is_datetime(input)
+        assert actual is expected

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -19,14 +19,13 @@ def col_is_datetime(col, datetime_format=None):
         return True
 
     # if it can be cast to numeric, it's not a datetime
-    dropped_na = col.dropna()
     try:
-        pd.to_numeric(dropped_na, errors='raise')
+        pd.to_numeric(col, errors='raise')
     except (ValueError, TypeError):
         # finally, try to cast to datetime
         if col.dtype.name.find('str') > -1 or col.dtype.name.find('object') > -1:
             try:
-                pd.to_datetime(dropped_na, errors='raise', format=datetime_format)
+                pd.to_datetime(col, errors='raise', format=datetime_format, infer_datetime_format=True)
             except Exception:
                 return False
             else:


### PR DESCRIPTION
- Add infer_datetime_format param to to_datetime calls
- Closes #218 

Adds `infer_datetime_format` parameter to speed up internal `to_datetime` calls during type casting and checking if a column is a datetime column or not. Also removes `dropna` call from `col_is_datetime` util function which no longer appears to be necessary. This should also improve performance.