### PR TITLE
Update to preserve column ordering during select

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,12 +10,13 @@ Future Release
     * Fixes
     * Changes
         * Entirely null columns are now inferred as the Unknown logical type (:pr:`1043`)
+        * ``TableAccessor.select`` method will now maintain dataframe column ordering (:pr:`1052`)
     * Documentation Changes
         * Add supported types to metadata docstring (:pr:`1049`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`, :user:`jeff-hernandez`, :user:`davesque`
+    :user:`frances-h`, :user:`jeff-hernandez`, :user:`davesque`, :user:`thehomebrewnerd`
 
 v0.5.0 Jul 7, 2021
 ==================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
     * Fixes
     * Changes
         * Entirely null columns are now inferred as the Unknown logical type (:pr:`1043`)
-        * ``TableAccessor.select`` method will now maintain dataframe column ordering (:pr:`1052`)
+        * ``TableAccessor.select`` method will now maintain dataframe column ordering in TableSchema columns (:pr:`1052`)
     * Documentation Changes
         * Add supported types to metadata docstring (:pr:`1049`)
     * Testing Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -177,7 +177,7 @@ class WoodworkTableAccessor:
             if diff:
                 raise ColumnNotPresentError(sorted(diff))
 
-            return self._get_subset_df_with_schema(key, use_dataframe_order=False)
+            return self._get_subset_df_with_schema(key)
 
         if key not in self._dataframe:
             raise ColumnNotPresentError(key)
@@ -623,7 +623,7 @@ class WoodworkTableAccessor:
         # Directly return non-callable DataFrame attributes
         return dataframe_attr
 
-    def _get_subset_df_with_schema(self, cols_to_include, use_dataframe_order=True, inplace=False):
+    def _get_subset_df_with_schema(self, cols_to_include, inplace=False):
         """Creates a new DataFrame from a list of column names with Woodwork initialized,
         retaining all typing information and maintaining the DataFrame's column order."""
         if inplace:
@@ -633,11 +633,6 @@ class WoodworkTableAccessor:
                 raise ValueError('Drop inplace not supported for Koalas')
 
         assert all([col_name in self._schema.columns for col_name in cols_to_include])
-
-        if use_dataframe_order:
-            cols_to_include = [col_name for col_name in self._dataframe.columns if col_name in cols_to_include]
-        else:
-            cols_to_include = [col_name for col_name in cols_to_include if col_name in self._dataframe.columns]
 
         new_schema = self._schema._get_subset_schema(cols_to_include)
         if inplace:

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -471,14 +471,17 @@ class TableSchema(object):
                 col_name_matches.add(selector)
 
         cols_to_return = []
+        cols_seen = set()
         for col_name, col in self.columns.items():
             is_match = (type(col.logical_type) in ltypes_used or
                         col.semantic_tags.intersection(tags_used) or
                         col_name in col_name_matches)
-            if include is not None and is_match and col_name not in cols_to_return:
+            if include is not None and is_match and col_name not in cols_seen:
                 cols_to_return.append(col_name)
-            elif exclude is not None and not is_match and col_name not in cols_to_return:
+                cols_seen.add(col_name)
+            elif exclude is not None and not is_match and col_name not in cols_seen:
                 cols_to_return.append(col_name)
+                cols_seen.add(col_name)
 
         return list(cols_to_return)
 

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -470,15 +470,15 @@ class TableSchema(object):
             if col_names and selector in self.columns:
                 col_name_matches.add(selector)
 
-        cols_to_return = set()
+        cols_to_return = []
         for col_name, col in self.columns.items():
             is_match = (type(col.logical_type) in ltypes_used or
                         col.semantic_tags.intersection(tags_used) or
                         col_name in col_name_matches)
-            if include is not None and is_match:
-                cols_to_return.add(col_name)
-            elif exclude is not None and not is_match:
-                cols_to_return.add(col_name)
+            if include is not None and is_match and col_name not in cols_to_return:
+                cols_to_return.append(col_name)
+            elif exclude is not None and not is_match and col_name not in cols_to_return:
+                cols_to_return.append(col_name)
 
         return list(cols_to_return)
 

--- a/woodwork/table_schema.py
+++ b/woodwork/table_schema.py
@@ -483,7 +483,7 @@ class TableSchema(object):
                 cols_to_return.append(col_name)
                 cols_seen.add(col_name)
 
-        return list(cols_to_return)
+        return cols_to_return
 
     def _get_subset_schema(self, subset_cols):
         """Creates a new TableSchema with specified columns, retaining typing information.

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1357,18 +1357,6 @@ def test_get_subset_df_with_schema(sample_df):
     validate_subset_schema(transfer_schema.ww.schema, schema)
 
 
-def test_get_subset_df_use_dataframe_order(sample_df):
-    df = sample_df
-    columns = list(df.columns)
-    df.ww.init()
-
-    reverse = list(reversed(columns))
-    actual = df.ww._get_subset_df_with_schema(reverse, use_dataframe_order=True)
-    assert list(actual.columns) == columns
-    actual = df.ww._get_subset_df_with_schema(reverse, use_dataframe_order=False)
-    assert list(actual.columns) == reverse
-
-
 def test_select_ltypes_no_match_and_all(sample_df):
     schema_df = sample_df.copy()
     schema_df.ww.init(logical_types={'full_name': PersonFullName,

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -1732,6 +1732,23 @@ def test_select_return_schema(sample_df):
     assert len(empty_schema.columns) == 0
 
 
+@pytest.mark.parametrize(
+    "ww_type, pandas_type",
+    [(["Integer", "IntegerNullable"], "int"),
+     (["Double"], "float"),
+     (["Datetime"], "datetime"),
+     (["Unknown", "EmailAddress"], "string"),
+     (["Categorical"], "category"),
+     (["BooleanNullable"], "boolean")]
+)
+def test_select_retains_column_order(ww_type, pandas_type, sample_df):
+    sample_df.ww.init()
+
+    ww_schema_column_order = [x for x in sample_df.ww.select(ww_type, return_schema=True).columns.keys()]
+    pandas_column_order = [x for x in sample_df.select_dtypes(include=pandas_type).columns]
+    assert ww_schema_column_order == pandas_column_order
+
+
 def test_select_include_and_exclude_error(sample_df):
     sample_df.ww.init()
     err_msg = "Cannot specify values for both 'include' and 'exclude' in a single call."


### PR DESCRIPTION
- Update to preserve column ordering during select
- Closes #1039 

This PR implements changes to `TableSchema._filter_cols` to use a list in place of a set, thus guaranteeing that the column order returned by the method will match the column order on the dataframe to which the schema belongs.