### PR TITLE
Add Config.with_options and fix potential issues in test suite

### DIFF
--- a/docs/source/guides/setting_config_options.ipynb
+++ b/docs/source/guides/setting_config_options.ipynb
@@ -41,7 +41,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "ww.config.set_option('categorical_threshold', 25)\n",
@@ -52,9 +54,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see from the output above, the value for the `categorical_threshold` config variable has been updated to `25`.\n",
+    "As you can see from the output above, the value for the `categorical_threshold` config variable has been updated to `25`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Temporarily Updating Config Settings\n",
     "\n",
+    "Settings can also be temporarily updated in the context of a with block by using `ww.config.with_options`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with ww.config.with_options(categorical_threshold=35):\n",
+    "    # Do something\n",
+    "    print(\"Temporary settings:\\n\")\n",
+    "    print(repr(ww.config), \"\\n\")\n",
+    "    \n",
+    "print(\"Restored settings:\\n\")\n",
+    "print(repr(ww.config))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Get Value for a Specific Config Variable\n",
+    "\n",
     "If you need access to the value that is set for a specific config variable you can access it with the `ww.config.get_option` function, passing in the name of the config variable for which you want the value."
    ]
   },

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,8 @@ Future Release
           type (:pr:`1047`)
         * Add ability to calculate outliers and the statistical info required for box and whisker plots
           to ``WoodworkColumnAccessor`` (:pr:`1048`)
+        * Add ability to change config settings in a with block with
+          ``ww.config.with_options`` (:pr:`1062`)
     * Fixes
     * Changes
         * Entirely null columns are now inferred as the Unknown logical type (:pr:`1043`)

--- a/woodwork/config.py
+++ b/woodwork/config.py
@@ -1,3 +1,5 @@
+import contextlib
+
 CONFIG_DEFAULTS = {
     'categorical_threshold': 10,
     'numeric_categorical_threshold': -1,
@@ -24,6 +26,18 @@ class Config:
         if key not in self._data.keys():
             raise KeyError(f"Invalid option specified: {key}")
         self._data[key] = self._defaults[key]
+
+    @contextlib.contextmanager
+    def with_options(self, **options):
+        old_options = {k: self.get_option(k) for k in options}
+
+        for k, v in options.items():
+            self.set_option(k, v)
+        try:
+            yield
+        finally:
+            for k, v in old_options.items():
+                self.set_option(k, v)
 
     def __repr__(self):
         output_string = "Woodwork Global Config Settings\n"

--- a/woodwork/tests/test_config.py
+++ b/woodwork/tests/test_config.py
@@ -42,6 +42,29 @@ def test_reset_option(config):
     assert config.get_option('option1') == 'value1'
 
 
+def test_with_options(config):
+    old_value_1 = config.get_option("option1")
+    old_value_2 = config.get_option("option2")
+
+    with_value_1 = "some_other_value_1"
+    with_value_2 = "some_other_value_2"
+
+    with config.with_options(option1=with_value_1, option2=with_value_2):
+        assert config.get_option("option1") == with_value_1
+        assert config.get_option("option2") == with_value_2
+
+    assert config.get_option("option1") == old_value_1
+    assert config.get_option("option2") == old_value_2
+
+    # Make sure that config gets reset when exceptions occur
+    try:
+        with config.with_options(option1="lkjasdlfkjasdf"):
+            raise RuntimeError("something went wrong!")
+    except RuntimeError:
+        pass
+    assert config.get_option("option1") == old_value_1
+
+
 def test_invalid_option_warnings(config):
     error_msg = 'Invalid option specified: invalid_option'
 

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -114,27 +114,25 @@ def test_categorical_inference(categories):
 
 
 def test_categorical_integers_inference(integers):
-    ww.config.set_option('numeric_categorical_threshold', 10)
-    dtypes = ['int8', 'int16', 'int32', 'int64', 'intp', 'int', 'Int64']
-    if ks and isinstance(integers[0], ks.Series):
-        dtypes = get_koalas_dtypes(dtypes)
-    for series in integers:
-        for dtype in dtypes:
-            inferred_type = ww.type_system.infer_logical_type(series.astype(dtype))
-            assert isinstance(inferred_type, Categorical)
-    ww.config.reset_option('numeric_categorical_threshold')
+    with ww.config.with_options(numeric_categorical_threshold=10):
+        dtypes = ['int8', 'int16', 'int32', 'int64', 'intp', 'int', 'Int64']
+        if ks and isinstance(integers[0], ks.Series):
+            dtypes = get_koalas_dtypes(dtypes)
+        for series in integers:
+            for dtype in dtypes:
+                inferred_type = ww.type_system.infer_logical_type(series.astype(dtype))
+                assert isinstance(inferred_type, Categorical)
 
 
 def test_categorical_double_inference(doubles):
-    ww.config.set_option('numeric_categorical_threshold', 10)
-    dtypes = ['float', 'float32', 'float64', 'float_']
-    if ks and isinstance(doubles[0], ks.Series):
-        dtypes = get_koalas_dtypes(dtypes)
-    for series in doubles:
-        for dtype in dtypes:
-            inferred_type = ww.type_system.infer_logical_type(series.astype(dtype))
-            assert isinstance(inferred_type, Categorical)
-    ww.config.reset_option('numeric_categorical_threshold')
+    with ww.config.with_options(numeric_categorical_threshold=10):
+        dtypes = ['float', 'float32', 'float64', 'float_']
+        if ks and isinstance(doubles[0], ks.Series):
+            dtypes = get_koalas_dtypes(dtypes)
+        for series in doubles:
+            for dtype in dtypes:
+                inferred_type = ww.type_system.infer_logical_type(series.astype(dtype))
+                assert isinstance(inferred_type, Categorical)
 
 
 def test_timedelta_inference(timedeltas):
@@ -173,13 +171,12 @@ def test_unknown_inference_with_threshhold(long_strings):
     if ks and isinstance(long_strings[0], ks.Series):
         dtypes = get_koalas_dtypes(dtypes)
 
-    ww.config.set_option('categorical_threshold', 19)
-    for dtype in dtypes:
-        inferred_type = ww.type_system.infer_logical_type(long_strings[0].astype(dtype))
-        assert isinstance(inferred_type, Unknown)
-        inferred_type = ww.type_system.infer_logical_type(long_strings[1].astype(dtype))
-        assert isinstance(inferred_type, Categorical)
-    ww.config.reset_option('categorical_threshold')
+    with ww.config.with_options(categorical_threshold=19):
+        for dtype in dtypes:
+            inferred_type = ww.type_system.infer_logical_type(long_strings[0].astype(dtype))
+            assert isinstance(inferred_type, Unknown)
+            inferred_type = ww.type_system.infer_logical_type(long_strings[1].astype(dtype))
+            assert isinstance(inferred_type, Categorical)
 
 
 def test_pdna_inference(pdnas):


### PR DESCRIPTION
Adds a new method to the `Config` object that enables setting config values temporarily inside of a with block.  Adding this functionality was necessary to fix a potential issue in the test suite.  The problem was that any test case that modifies the global config singleton with `ww.config.set_option` and then throws an `AssertionError` could cause the global config to be left in that state during the subsequent execution of further test cases.