### PR TITLE
Change categorical inference to look at sample of 10K rows and 80% non-unique

### DIFF
--- a/docs/source/guides/custom_types_and_type_inference.ipynb
+++ b/docs/source/guides/custom_types_and_type_inference.ipynb
@@ -137,7 +137,7 @@
     "import pandas as pd\n",
     "df = pd.DataFrame({\n",
     "    'id': [0, 1, 2, 3],\n",
-    "    'code': ['012345412359', '122345712358', '012345412359', '022323413459'],\n",
+    "    'code': ['012345412359', '122345712358', '012345412359', '012345412359'],\n",
     "    'not_upc': ['abcdefghijkl', '122345712358', '012345412359', '022323413459']\n",
     "})"
    ]
@@ -146,7 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before using this dataframe, update Woodwork's default threshold for differentiating between a `Unknown` and `Categorical` column so that Woodwork will correctly recognize the `code` column as a `Categorical` column. After setting the threshold, initialize Woodwork and verify that Woodwork has identified our column as `Categorical`."
+    "Use a with block setting override to update Woodwork's default threshold for differentiating between a `Unknown` and `Categorical` column so that Woodwork will correctly recognize the `code` column as a `Categorical` column. After setting the threshold, initialize Woodwork and verify that Woodwork has identified our column as `Categorical`."
    ]
   },
   {
@@ -155,8 +155,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ww.config.set_option('categorical_threshold', 12)\n",
-    "df.ww.init()\n",
+    "with ww.config.with_options(categorical_threshold=0.5):\n",
+    "    df.ww.init()\n",
     "df.ww"
    ]
   },

--- a/docs/source/guides/setting_config_options.ipynb
+++ b/docs/source/guides/setting_config_options.ipynb
@@ -29,13 +29,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output of `ww.config` lists each of the available config variables followed by it's current setting. In the output above, the `categorical_threshold` config variable has been set to `10` and the `numeric_categorical_threshold` has been set to `-1`. \n",
+    "The output of `ww.config` lists each of the available config variables followed by its current setting. In the output above, the settings for the `categorical_threshold` and `numeric_categorical_threshold` config variables are visible.\n",
     "\n",
     "## Updating Config Settings\n",
     "\n",
     "Updating a config variable is done simply with a call to the `ww.config.set_option` function. This function requires two arguments: the name of the config variable to update and the new value to set.\n",
     "\n",
-    "As an example, update the `categorical_threshold` config variable to have a value of `25` instead of the default value of `10`."
+    "As an example, update the `categorical_threshold` config variable to have a value of `0.5` instead of the default value."
    ]
   },
   {
@@ -46,7 +46,7 @@
    },
    "outputs": [],
    "source": [
-    "ww.config.set_option('categorical_threshold', 25)\n",
+    "ww.config.set_option('categorical_threshold', 0.5)\n",
     "ww.config"
    ]
   },
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see from the output above, the value for the `categorical_threshold` config variable has been updated to `25`."
+    "As you can see from the output above, the value for the `categorical_threshold` config variable has been updated to `0.5`."
    ]
   },
   {
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with ww.config.with_options(categorical_threshold=35):\n",
+    "with ww.config.with_options(categorical_threshold=0.7):\n",
     "    # Do something\n",
     "    print(\"Temporary settings:\\n\")\n",
     "    print(repr(ww.config), \"\\n\")\n",
@@ -130,11 +130,11 @@
     "\n",
     "### Categorical Threshold\n",
     "\n",
-    "The `categorical_threshold` config variable helps control the distinction between `Categorical` and `Unknown` logical types during type inference. More specifically, this threshold represents the average string length that is used to distinguish between these two types. If the average string length in a column is greater than this threshold, the column is inferred as a `Unknown` column; otherwise, it is inferred as a `Categorical` column. The `categorical_threshold` config variable defaults to `10`.\n",
+    "The `categorical_threshold` config variable helps control the distinction between `Categorical` and other logical types during type inference.  More specifically, this threshold represents the maximum acceptable ratio of unique value count to total value count (excluding nan values from either count) in a series for that series to be inferred as categorical.  In other words, if the values in a series are fully accounted for by a relatively small collection of unique values, then the series is categorical.  The `categorical_threshold` config variable defaults to `0.2`.  This indicates that, by default, a series for which the unique value count is 20% of the total value count could be inferred as categorical.\n",
     "\n",
     "### Numeric Categorical Threshold\n",
     "\n",
-    "Woodwork provides the option to infer numeric columns as the `Categorical` logical type if they have few enough unique values. The `numeric_categorical_threshold` config variable allows users to set the threshold of unique values below which numeric columns are inferred as categorical. The default threshold is `-1`, meaning that numeric columns are not inferred to be categorical by default (because the fewest number of unique values a column can have is zero).\n",
+    "Woodwork provides the option to infer numeric columns as the `Categorical` logical type if they have few enough unique values. The `numeric_categorical_threshold` controls this behavior.  The default value for `numeric_categorical_threshold` is `None`, meaning that by default numeric columns should never be inferred to be categorical.  If the setting is given a float between `0` and `1` as a value, then it behaves in the same manner as the `categorical_threshold` setting except that it only applies to columns with a numeric dtype (float or integer).\n",
     "\n",
     "### Email Inference Regex\n",
     "\n",

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -29,6 +29,9 @@ v0.5.1 Jul 22, 2021
         * Entirely null columns are now inferred as the Unknown logical type (:pr:`1043`)
         * Add helper functions that check for whether an object is a koalas/dask series or dataframe (:pr:`1055`)
         * ``TableAccessor.select`` method will now maintain dataframe column ordering in TableSchema columns (:pr:`1052`)
+        * The criteria for categorical type inference have changed (:pr:`1065`)
+        * The meaning of both the ``categorical_threshold`` and
+          ``numeric_categorical_threshold`` settings have changed (:pr:`1065`)
     * Documentation Changes
         * Add supported types to metadata docstring (:pr:`1049`)
 
@@ -37,7 +40,23 @@ v0.5.1 Jul 22, 2021
 
 Breaking Changes
 ++++++++++++++++
-    * The criteria for categorical type inference have changed (:pr:`1065`)
+    * :pr:`1065`: The criteria for categorical type inference have changed.
+      Relatedly, the meaning of both the ``categorical_threshold`` and
+      ``numeric_categorical_threshold`` settings have changed.  Now, a
+      categorical match is signaled when a series either has the "categorical"
+      pandas dtype *or* if the ratio of unique value count (nan excluded) and
+      total value count (nan also excluded) is below or equal to some fraction.
+      The value used for this fraction is set by the ``categorical_threshold``
+      setting which now has a default value of ``0.2``.  If a fraction is set
+      for the ``numeric_categorical_threshold`` setting, then series with
+      either a float or integer dtype may be inferred as categorical by
+      applying the same logic described above with the
+      ``numeric_categorical_threshold`` fraction.  Otherwise, the
+      ``numeric_categorical_threshold`` setting defaults to ``None`` which
+      indicates that series with a numerical type should not be inferred as
+      categorical.  Users who have overridden either the
+      ``categorical_threshold`` or ``numeric_categorical_threshold`` settings
+      will need to adjust their settings accordingly.
 
 v0.5.0 Jul 7, 2021
 ==================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -35,6 +35,10 @@ v0.5.1 Jul 22, 2021
     Thanks to the following people for contributing to this release:
     :user:`davesque`, :user:`frances-h`, :user:`jeff-hernandez`, :user:`simha104`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
+Breaking Changes
+++++++++++++++++
+    * The criteria for categorical type inference have changed (:pr:`1065`)
+
 v0.5.0 Jul 7, 2021
 ==================
     * Enhancements

--- a/woodwork/config.py
+++ b/woodwork/config.py
@@ -1,7 +1,7 @@
 import contextlib
 
 CONFIG_DEFAULTS = {
-    'categorical_threshold': 10,
+    'categorical_threshold': 0.2,
     'numeric_categorical_threshold': None,
     'email_inference_regex': r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)",
 }

--- a/woodwork/config.py
+++ b/woodwork/config.py
@@ -2,7 +2,7 @@ import contextlib
 
 CONFIG_DEFAULTS = {
     'categorical_threshold': 10,
-    'numeric_categorical_threshold': -1,
+    'numeric_categorical_threshold': None,
     'email_inference_regex': r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)",
 }
 

--- a/woodwork/tests/accessor/test_column_accessor.py
+++ b/woodwork/tests/accessor/test_column_accessor.py
@@ -476,7 +476,7 @@ def test_series_methods_on_accessor_inplace(sample_series):
 
     val = sample_series.ww.pop(0)
     assert sample_series.ww._schema == comparison_series.ww._schema
-    assert len(sample_series) == 3
+    assert len(sample_series) == len(comparison_series) - 1
     assert val == 'a'
 
 
@@ -508,7 +508,7 @@ def test_series_methods_on_accessor_other_returns(sample_series):
     if _is_dask_series(sample_series):
         col_shape = (col_shape[0].compute(),)
         series_shape = (series_shape[0].compute())
-    assert col_shape == (4,)
+    assert col_shape == (len(sample_series),)
     assert col_shape == series_shape
 
     assert sample_series.name == sample_series.ww.name

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -80,7 +80,8 @@ def test_accessor_replace_nans_for_mutual_info():
         'str_no_nan': pd.Series(['test', 'test2', 'test2', 'test']),
         'dates': pd.Series(['2020-01-01', None, '2020-01-02', '2020-01-03'])
     })
-    df_nans.ww.init()
+    df_nans.ww.init(logical_types={"bools": "Categorical", "str":
+                                   "Categorical", "str_no_nan": "Categorical"})
     formatted_df = _replace_nans_for_mutual_info(df_nans.ww.schema, df_nans.copy())
 
     assert isinstance(formatted_df, pd.DataFrame)

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -612,6 +612,7 @@ def test_int_dtype_inference_on_init():
         'ints_nan': pd.Series([1, np.nan]),
         'ints_NA': pd.Series([1, pd.NA]),
         'ints_NA_specified': pd.Series([1, pd.NA], dtype='Int64')})
+    df = df.loc[df.index.repeat(5)].reset_index(drop=True)
     df.ww.init()
 
     assert df['ints_no_nans'].dtype == 'int64'
@@ -626,6 +627,7 @@ def test_bool_dtype_inference_on_init():
         'bool_nan': pd.Series([True, np.nan]),
         'bool_NA': pd.Series([True, pd.NA]),
         'bool_NA_specified': pd.Series([True, pd.NA], dtype="boolean")})
+    df = df.loc[df.index.repeat(5)].reset_index(drop=True)
     df.ww.init()
 
     assert df['bools_no_nans'].dtype == 'bool'
@@ -640,17 +642,14 @@ def test_str_dtype_inference_on_init():
         'str_nan': pd.Series(['a', np.nan]),
         'str_NA': pd.Series(['a', pd.NA]),
         'str_NA_specified': pd.Series([1, pd.NA], dtype="string"),
-        'long_str_NA_specified': pd.Series(['this is a very long sentence inferred as a string', pd.NA], dtype="string"),
-        'long_str_NA': pd.Series(['this is a very long sentence inferred as a string', pd.NA])
     })
+    df = df.loc[df.index.repeat(5)].reset_index(drop=True)
     df.ww.init()
 
     assert df['str_no_nans'].dtype == 'category'
     assert df['str_nan'].dtype == 'category'
     assert df['str_NA'].dtype == 'category'
     assert df['str_NA_specified'].dtype == 'category'
-    assert df['long_str_NA_specified'].dtype == 'string'
-    assert df['long_str_NA'].dtype == 'string'
 
 
 def test_float_dtype_inference_on_init():
@@ -659,6 +658,7 @@ def test_float_dtype_inference_on_init():
         'floats_nan': pd.Series([1.1, np.nan]),
         'floats_NA': pd.Series([1.1, pd.NA]),
         'floats_nan_specified': pd.Series([1.1, np.nan], dtype='float')})
+    df = df.loc[df.index.repeat(5)].reset_index(drop=True)
     df.ww.init()
 
     assert df['floats_no_nans'].dtype == 'float64'
@@ -712,6 +712,7 @@ def test_datetime_inference_with_format_param():
     df = pd.DataFrame({
         'mdy_special': pd.Series(['3&11&2000', '3&12&2000', '3&13&2000'], dtype='string'),
     })
+    df = df.loc[df.index.repeat(5)].reset_index(drop=True)
     df.ww.init()
     assert df['mdy_special'].dtype == 'category'
 
@@ -2271,7 +2272,7 @@ def test_setitem_new_column(sample_df):
     else:
         dtype = 'category'
 
-    new_series = init_series(new_series)
+    new_series = init_series(new_series, logical_type="Categorical")
     df.ww['test_col'] = new_series
     assert 'test_col' in df.ww.columns
     assert isinstance(df.ww['test_col'].ww.logical_type, Categorical)

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -98,7 +98,7 @@ def sample_series(request):
 
 @pytest.fixture()
 def sample_series_pandas():
-    return pd.Series(['a', 'b', 'c', 'a'], name='sample_series').astype('category')
+    return pd.Series(['a', 'b', 'c'] + 10 * ['a', 'a', 'a'], name='sample_series').astype('category')
 
 
 @pytest.fixture()
@@ -295,13 +295,15 @@ def df_same_mi(request):
 
 @pytest.fixture()
 def df_mi_pandas():
-    return pd.DataFrame({
+    df = pd.DataFrame({
         'ints': pd.Series([1, 2, 1]),
         'bools': pd.Series([True, False, True]),
         'strs2': pd.Series(['bye', 'hi', 'bye']),
         'strs': pd.Series(['hi', 'hi', 'hi']),
         'dates': pd.Series(['2020-01-01', '2020-01-01', '1997-01-04'])
     })
+    df = df.loc[df.index.repeat(4)].reset_index(drop=True)
+    return df
 
 
 @pytest.fixture()
@@ -323,12 +325,14 @@ def df_mi(request):
 
 @pytest.fixture()
 def df_mi_unique_pandas():
-    return pd.DataFrame({
+    df = pd.DataFrame({
         'unique': pd.Series(['hi', 'bye', 'hello', 'goodbye']),
         'unique_with_one_nan': pd.Series(['hi', 'bye', None, 'goodbye']),
         'unique_with_nans': pd.Series([1, None, None, 2]),
         'ints': pd.Series([1, 2, 1, 2]),
     })
+    df = df.loc[df.index.repeat(5)].reset_index(drop=True)
+    return df
 
 
 @pytest.fixture()

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -32,8 +32,8 @@ def pd_to_koalas(series):
 @pytest.fixture
 def pandas_integers():
     return [
-        pd.Series([-1, 2, 1, 7]),
-        pd.Series([-1, 0, 5, 3]),
+        pd.Series(4 * [-1, 2, 1, 7]),
+        pd.Series(4 * [-1, 0, 5, 3]),
     ]
 
 
@@ -56,8 +56,8 @@ def integers(request):
 @pytest.fixture
 def pandas_doubles():
     return [
-        pd.Series([-1, 2.5, 1, 7]),
-        pd.Series([1.5, np.nan, 1, 3])
+        pd.Series(4 * [-1, 2.5, 1, 7]),
+        pd.Series(4 * [1.5, np.nan, 1, 3])
     ]
 
 
@@ -178,10 +178,10 @@ def bad_emails(request):
 @pytest.fixture
 def pandas_categories():
     return [
-        pd.Series(['a', 'b', 'a', 'b']),
-        pd.Series(['1', '2', '1', '2']),
-        pd.Series(['a', np.nan, 'b', 'b']),
-        pd.Series([1, 2, 1, 2])
+        pd.Series(10 * ['a', 'b', 'a', 'b']),
+        pd.Series(10 * ['1', '2', '1', '2']),
+        pd.Series(10 * ['a', np.nan, 'b', 'b']),
+        pd.Series(10 * [1, 2, 1, 2])
     ]
 
 
@@ -239,37 +239,6 @@ def koalas_strings(pandas_strings):
 
 @pytest.fixture(params=['pandas_strings', 'dask_strings', 'koalas_strings'])
 def strings(request):
-    return request.getfixturevalue(request.param)
-
-
-# Categorical Inference with Threshold
-@pytest.fixture
-def pandas_long_strings():
-    unknown_series = pd.Series([
-        '01234567890123456789',
-        '01234567890123456789',
-        '01234567890123456789',
-        '01234567890123456789'])
-    category_series = pd.Series([
-        '0123456789012345678',
-        '0123456789012345678',
-        '0123456789012345678',
-        '0123456789012345678'])
-    return [unknown_series, category_series]
-
-
-@pytest.fixture
-def dask_long_strings(pandas_long_strings):
-    return [pd_to_dask(series) for series in pandas_long_strings]
-
-
-@pytest.fixture
-def koalas_long_strings(pandas_long_strings):
-    return [pd_to_koalas(series) for series in pandas_long_strings]
-
-
-@pytest.fixture(params=['pandas_long_strings', 'dask_long_strings', 'koalas_long_strings'])
-def long_strings(request):
     return request.getfixturevalue(request.param)
 
 

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -200,6 +200,26 @@ def categories(request):
     return request.getfixturevalue(request.param)
 
 
+@pytest.fixture
+def pandas_categories_dtype():
+    return pd.DataFrame({
+        "cat": pd.Series(["a", "b", "c", "d"], dtype="category"),
+        "non_cat": pd.Series(["a", "b", "c", "d"], dtype="string"),
+    })
+
+
+@pytest.fixture
+def dask_categories_dtype(pandas_categories_dtype):
+    return pd_to_dask(pandas_categories_dtype)
+
+
+@pytest.fixture(params=['pandas_categories_dtype', 'dask_categories_dtype'])
+def categories_dtype(request):
+    # Koalas doesn't support the "category" dtype.  We just leave it out for
+    # now.
+    return request.getfixturevalue(request.param)
+
+
 # Timedelta Inference Fixtures
 @pytest.fixture
 def pandas_timedeltas():

--- a/woodwork/tests/type_system/test_custom_types.py
+++ b/woodwork/tests/type_system/test_custom_types.py
@@ -18,7 +18,7 @@ def test_register_custom_logical_type(type_sys):
     assert CustomLogicalType in type_sys.registered_types
     assert (Categorical, CustomLogicalType) in type_sys.relationships
     assert type_sys.inference_functions[CustomLogicalType] is custom_func
-    assert isinstance(type_sys.infer_logical_type(pd.Series(['a', 'b', 'a'])), CustomLogicalType)
+    assert isinstance(type_sys.infer_logical_type(pd.Series(['a', 'b'] + 10 * ['a'])), CustomLogicalType)
 
 
 def test_custom_type_with_accessor(sample_df):

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -114,6 +114,19 @@ def test_categorical_inference(categories):
             assert isinstance(inferred_type, Categorical)
 
 
+def test_categorical_inference_based_on_dtype(categories_dtype):
+    """
+    This test specifically targets the case in which a series can be inferred
+    to be categorical strictly from its pandas dtype, but would otherwise be
+    inferred as some other type.
+    """
+    inferred_type = ww.type_system.infer_logical_type(categories_dtype["cat"])
+    assert isinstance(inferred_type, Categorical)
+
+    inferred_type = ww.type_system.infer_logical_type(categories_dtype["non_cat"])
+    assert not isinstance(inferred_type, Categorical)
+
+
 def test_categorical_integers_inference(integers):
     with ww.config.with_options(numeric_categorical_threshold=0.5):
         dtypes = ['int8', 'int16', 'int32', 'int64', 'intp', 'int', 'Int64']

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -115,7 +115,7 @@ def test_categorical_inference(categories):
 
 
 def test_categorical_integers_inference(integers):
-    with ww.config.with_options(numeric_categorical_threshold=10):
+    with ww.config.with_options(numeric_categorical_threshold=0.5):
         dtypes = ['int8', 'int16', 'int32', 'int64', 'intp', 'int', 'Int64']
         if _is_koalas_series(integers[0]):
             dtypes = get_koalas_dtypes(dtypes)
@@ -126,7 +126,7 @@ def test_categorical_integers_inference(integers):
 
 
 def test_categorical_double_inference(doubles):
-    with ww.config.with_options(numeric_categorical_threshold=10):
+    with ww.config.with_options(numeric_categorical_threshold=0.5):
         dtypes = ['float', 'float32', 'float64', 'float_']
         if _is_koalas_series(doubles[0]):
             dtypes = get_koalas_dtypes(dtypes)
@@ -165,19 +165,6 @@ def test_unknown_inference_all_null(nulls):
             inferred_type = ww.type_system.infer_logical_type(series.astype(dtype))
             inferred_type.transform(series)
             assert isinstance(inferred_type, Unknown)
-
-
-def test_unknown_inference_with_threshhold(long_strings):
-    dtypes = ['object', 'string']
-    if _is_koalas_series(long_strings[0]):
-        dtypes = get_koalas_dtypes(dtypes)
-
-    with ww.config.with_options(categorical_threshold=19):
-        for dtype in dtypes:
-            inferred_type = ww.type_system.infer_logical_type(long_strings[0].astype(dtype))
-            assert isinstance(inferred_type, Unknown)
-            inferred_type = ww.type_system.infer_logical_type(long_strings[1].astype(dtype))
-            assert isinstance(inferred_type, Categorical)
 
 
 def test_pdna_inference(pdnas):

--- a/woodwork/tests/utils/test_accessor_utils.py
+++ b/woodwork/tests/utils/test_accessor_utils.py
@@ -63,7 +63,7 @@ def test_init_series_with_invalid_type(sample_df):
 
 
 def test_init_series_with_np_array(sample_series_pandas):
-    series = init_series(np.array(['a', 'b', 'c', 'a']))
+    series = init_series(sample_series_pandas.to_numpy())
     series2 = init_series(sample_series_pandas)  # Sample series panda contains ['a','b','c','a']
     assert series.equals(series2)
     assert series.ww.logical_type == series2.ww.logical_type

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -25,7 +25,7 @@ from woodwork.logical_types import (
 from woodwork.type_sys.type_system import DEFAULT_INFERENCE_FUNCTIONS
 from woodwork.type_sys.utils import (
     _get_specified_ltype_params,
-    _is_categorical,
+    _is_categorical_series,
     _is_numeric_series,
     col_is_datetime,
     list_logical_types,
@@ -460,20 +460,20 @@ def test_infer_datetime_format(datetimes):
 
 def test_is_categorical() -> None:
     # not categorical because unhashable type (list)
-    assert not _is_categorical(pd.Series([[1]]), 0)
-    assert not _is_categorical(pd.Series([None, [1]]), 0)
+    assert not _is_categorical_series(pd.Series([[1]]), 0)
+    assert not _is_categorical_series(pd.Series([None, [1]]), 0)
 
     # not categorical because empty series
-    assert not _is_categorical(pd.Series([]), 0)
-    assert not _is_categorical(pd.Series([None]), 0)
-    assert not _is_categorical(pd.Series([None, None]), 0)
+    assert not _is_categorical_series(pd.Series([]), 0)
+    assert not _is_categorical_series(pd.Series([None]), 0)
+    assert not _is_categorical_series(pd.Series([None, None]), 0)
 
     # not categorical because too many unique values
-    assert not _is_categorical(pd.Series([1, 2]), 0.5)
-    assert not _is_categorical(pd.Series([1, 2, 3, 1]), 0.5)
-    assert not _is_categorical(pd.Series([1, 2, 3, 4]), 0.75)
+    assert not _is_categorical_series(pd.Series([1, 2]), 0.5)
+    assert not _is_categorical_series(pd.Series([1, 2, 3, 1]), 0.5)
+    assert not _is_categorical_series(pd.Series([1, 2, 3, 4]), 0.75)
 
     # categorical
-    assert _is_categorical(pd.Series([1, 1]), 0.5)
-    assert _is_categorical(pd.Series([1, 2, 1, 1]), 0.5)
-    assert _is_categorical(pd.Series([1, 2, 3, 1]), 0.75)
+    assert _is_categorical_series(pd.Series([1, 1]), 0.5)
+    assert _is_categorical_series(pd.Series([1, 2, 1, 1]), 0.5)
+    assert _is_categorical_series(pd.Series([1, 2, 3, 1]), 0.75)

--- a/woodwork/type_sys/inference_functions.py
+++ b/woodwork/type_sys/inference_functions.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pandas.api.types as pdtypes
 
 import woodwork as ww
-from woodwork.type_sys.utils import _is_categorical, col_is_datetime
+from woodwork.type_sys.utils import _is_categorical_series, col_is_datetime
 
 INFERENCE_SAMPLE_SIZE = 10000
 
@@ -24,12 +24,12 @@ def categorical_func(series):
         sample = get_inference_sample(series)
         categorical_threshold = ww.config.get_option('categorical_threshold')
 
-        return _is_categorical(sample, categorical_threshold)
+        return _is_categorical_series(sample, categorical_threshold)
 
     if pdtypes.is_float_dtype(series.dtype) or pdtypes.is_integer_dtype(series.dtype):
         numeric_categorical_threshold = ww.config.get_option('numeric_categorical_threshold')
         if numeric_categorical_threshold is not None:
-            return _is_categorical(series, numeric_categorical_threshold)
+            return _is_categorical_series(series, numeric_categorical_threshold)
         else:
             return False
 
@@ -46,7 +46,7 @@ def integer_nullable_func(series):
     if pdtypes.is_integer_dtype(series.dtype):
         threshold = ww.config.get_option('numeric_categorical_threshold')
         if threshold is not None:
-            return not _is_categorical(series, threshold)
+            return not _is_categorical_series(series, threshold)
         else:
             return True
 
@@ -57,7 +57,7 @@ def double_func(series):
     if pdtypes.is_float_dtype(series.dtype):
         threshold = ww.config.get_option('numeric_categorical_threshold')
         if threshold is not None:
-            return not _is_categorical(series, threshold)
+            return not _is_categorical_series(series, threshold)
         else:
             return True
 

--- a/woodwork/type_sys/inference_functions.py
+++ b/woodwork/type_sys/inference_functions.py
@@ -36,7 +36,7 @@ def categorical_func(series):
 
     if pdtypes.is_float_dtype(series.dtype) or pdtypes.is_integer_dtype(series.dtype):
         numeric_categorical_threshold = ww.config.get_option('numeric_categorical_threshold')
-        if numeric_categorical_threshold != -1:
+        if numeric_categorical_threshold is not None:
             return _is_categorical(series, numeric_categorical_threshold)
         else:
             return False
@@ -53,7 +53,7 @@ def integer_func(series):
 def integer_nullable_func(series):
     if pdtypes.is_integer_dtype(series.dtype):
         threshold = ww.config.get_option('numeric_categorical_threshold')
-        if threshold != -1:
+        if threshold is not None:
             return not _is_categorical(series, threshold)
         else:
             return True
@@ -64,7 +64,7 @@ def integer_nullable_func(series):
 def double_func(series):
     if pdtypes.is_float_dtype(series.dtype):
         threshold = ww.config.get_option('numeric_categorical_threshold')
-        if threshold != -1:
+        if threshold is not None:
             return not _is_categorical(series, threshold)
         else:
             return True

--- a/woodwork/type_sys/inference_functions.py
+++ b/woodwork/type_sys/inference_functions.py
@@ -35,7 +35,7 @@ def categorical_func(series):
     if pdtypes.is_categorical_dtype(series.dtype):
         return True
     if ((pdtypes.is_float_dtype(series.dtype) or pdtypes.is_integer_dtype(series.dtype)) and
-            _is_numeric_categorical(series, numeric_categorical_threshold)):
+            _is_categorical(series, numeric_categorical_threshold)):
         return True
     return False
 
@@ -49,7 +49,7 @@ def integer_func(series):
 def integer_nullable_func(series):
     numeric_categorical_threshold = ww.config.get_option('numeric_categorical_threshold')
     if (pdtypes.is_integer_dtype(series.dtype) and
-            not _is_numeric_categorical(series, numeric_categorical_threshold)):
+            not _is_categorical(series, numeric_categorical_threshold)):
         return True
     return False
 
@@ -57,7 +57,7 @@ def integer_nullable_func(series):
 def double_func(series):
     numeric_categorical_threshold = ww.config.get_option('numeric_categorical_threshold')
     if (pdtypes.is_float_dtype(series.dtype) and
-            not _is_numeric_categorical(series, numeric_categorical_threshold)):
+            not _is_categorical(series, numeric_categorical_threshold)):
         return True
     return False
 
@@ -107,5 +107,5 @@ def email_address_func(series: pd.Series) -> bool:
     return matches.sum() == matches.count()
 
 
-def _is_numeric_categorical(series, threshold):
+def _is_categorical(series, threshold):
     return threshold != -1 and series.nunique() < threshold

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -162,11 +162,8 @@ def _is_categorical_series(series: pd.Series, threshold: float) -> bool:
             return False
         else:
             raise  # pragma: no cover
-    count = series.count()
-
-    if nunique == 0 or count == 0:
+    if nunique == 0:
         return False
 
-    pct_unique = nunique / count
-
+    pct_unique = nunique / series.count()
     return pct_unique <= threshold

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -143,7 +143,7 @@ def _get_specified_ltype_params(ltype):
     return ltype.__dict__
 
 
-def _is_categorical(series: pd.Series, threshold: float) -> bool:
+def _is_categorical_series(series: pd.Series, threshold: float) -> bool:
     """
     Return ``True`` if the given series is "likely" to be categorical.
     Otherwise, return ``False``.  We say that a series is "likely" to be


### PR DESCRIPTION
- Attempts to make inference of categorical types more consistent.
- Closes #1051 

This is really just a first stab at this.  I ended up keeping the `numerical_categorical_threshold` setting since it appears that it was being used in a couple places (and to make inference of categoricals from numericals optional).  I ended up having to update a lot of tests that were broken by this update.