### PR TITLE
Fix additional reviewers to min and latest dependency checker 

### DIFF
--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -59,4 +59,4 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: main
-        team-reviewers: @alteryx/ml-tools
+        team-reviewers: alteryx/ml-tools

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -90,4 +90,4 @@ jobs:
           branch: min-dep-update
           branch-suffix: short-commit-hash
           base: main
-          team-reviewers: @alteryx/ml-tools
+          team-reviewers: alteryx/ml-tools

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
   * Changes
   * Documentation Changes
   * Testing Changes
-        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1070`)
+        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1070`, :pr:`1073`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`


### PR DESCRIPTION
- Both workflows are failing on `main` due to a syntax error:
  - https://github.com/alteryx/woodwork/actions/runs/1068138616
  - https://github.com/alteryx/woodwork/actions/runs/1068138594
- This MR fixes it by referencing the correct team.