### PR TITLE
Remove team reviewers for dependency checker

### DIFF
--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -59,4 +59,4 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: main
-        team-reviewers: alteryx/ml-tools
+        reviewers: thehomebrewnerd, tamargrey, jeff-hernandez, tuethan1999, davesque, simha104 

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -90,4 +90,4 @@ jobs:
           branch: min-dep-update
           branch-suffix: short-commit-hash
           base: main
-          team-reviewers: alteryx/ml-tools
+          reviewers: thehomebrewnerd, tamargrey, jeff-hernandez, tuethan1999, davesque, simha104 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
   * Changes
   * Documentation Changes
   * Testing Changes
-        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1070`, :pr:`1073`)
+        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1070`, :pr:`1073`, :pr:`1077`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`


### PR DESCRIPTION
- The team reviewers functionality is not working so reverting back to specifying individual people 