### PR TITLE
Make sampling for inference in woodwork more consistent

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Future Release
         * The criteria for categorical type inference have changed (:pr:`1065`)
         * The meaning of both the ``categorical_threshold`` and
           ``numeric_categorical_threshold`` settings have changed (:pr:`1065`)
+        * Make sampling for type inference more consistent (:pr:`1083`)
     * Documentation Changes
         * Fix some release notes that ended up under the wrong release (:pr:`1082`)
         * Add BooleanNullable and IntegerNullable types to the docs (:pr:`1085`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -43,14 +43,14 @@ Breaking Changes
       ``categorical_threshold`` or ``numeric_categorical_threshold`` settings
       will need to adjust their settings accordingly.
     * :pr:`1083`: The process of sampling series for logical type inference was
-      updated to be more consistent.  Before, only dask and koalas collections
-      were sampled in every case during type inference.  Also, further
-      randomized subsampling was performed in some cases during categorical
-      inference and in every case during email inference.  Overall, the way
-      sampling was done was inconsistent and unpredictable.  Now, the first
-      100,000 records of a series are sampled for logical type inference
-      regardless of collection type (pandas, dask, or koalas) although only
-      records from the first partition of a dask dataset will be used.
+      updated to be more consistent.  Before, initial sampling for inference
+      differed depending on collection type (pandas, dask, or koalas).  Also,
+      further randomized subsampling was performed in some cases during
+      categorical inference and in every case during email inference regardless
+      of collection type.  Overall, the way sampling was done was inconsistent
+      and unpredictable.  Now, the first 100,000 records of a column are
+      sampled for logical type inference regardless of collection type although
+      only records from the first partition of a dask dataset will be used.
       Subsampling performed by the inference functions of individual types has
       been removed.  The effect of these changes is that inferred types may now
       be different although in many cases they will be more correct.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -42,6 +42,18 @@ Breaking Changes
       categorical.  Users who have overridden either the
       ``categorical_threshold`` or ``numeric_categorical_threshold`` settings
       will need to adjust their settings accordingly.
+    * :pr:`1083`: The process of sampling series for logical type inference was
+      updated to be more consistent.  Before, only dask and koalas collections
+      were sampled in every case during type inference.  Also, further
+      randomized subsampling was performed in some cases during categorical
+      inference and in every case during email inference.  Overall, the way
+      sampling was done was inconsistent and unpredictable.  Now, the first
+      100,000 records of a series are sampled for logical type inference
+      regardless of collection type (pandas, dask, or koalas) although only
+      records from the first partition of a dask dataset will be used.
+      Subsampling performed by the inference functions of individual types has
+      been removed.  The effect of these changes is that inferred types may now
+      be different although in many cases they will be more correct.
 
 v0.5.1 Jul 22, 2021
 ===================

--- a/woodwork/type_sys/inference_functions.py
+++ b/woodwork/type_sys/inference_functions.py
@@ -5,7 +5,7 @@ import woodwork as ww
 from woodwork.type_sys.utils import _is_categorical_series, col_is_datetime
 
 
-def categorical_func(series: pd.Series) -> bool:
+def categorical_func(series):
     if pdtypes.is_categorical_dtype(series.dtype):
         return True
 

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -266,7 +266,7 @@ class TypeSystem(object):
             elif _is_koalas_series(series):
                 series = series.head(100000).to_pandas()
             else:
-                raise ValueError(f"Unexpected arg type `{type(series)}`")
+                raise ValueError(f"Unexpected arg type `{type(series)}`")  # pragma: no cover
 
             # For dask or koalas collections, unknown type special case comes
             # *after* head calls to avoid evaluating a potentially large

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -82,6 +82,8 @@ DEFAULT_RELATIONSHIPS = [
 
 DEFAULT_TYPE = Unknown
 
+INFERENCE_SAMPLE_SIZE = 100000
+
 
 class TypeSystem(object):
     def __init__(self, inference_functions=None, relationships=None, default_type=DEFAULT_TYPE):
@@ -259,12 +261,12 @@ class TypeSystem(object):
             if series.count() == 0:
                 return Unknown()
 
-            series = series.head(100000)
+            series = series.head(INFERENCE_SAMPLE_SIZE)
         else:
             if _is_dask_series(series):
-                series = series.head(100000)
+                series = series.head(INFERENCE_SAMPLE_SIZE)
             elif _is_koalas_series(series):
-                series = series.head(100000).to_pandas()
+                series = series.head(INFERENCE_SAMPLE_SIZE).to_pandas()
             else:
                 raise ValueError(f"Unexpected arg type `{type(series)}`")  # pragma: no cover
 

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -268,7 +268,7 @@ class TypeSystem(object):
             elif _is_koalas_series(series):
                 series = series.head(INFERENCE_SAMPLE_SIZE).to_pandas()
             else:
-                raise ValueError(f"Unexpected arg type `{type(series)}`")  # pragma: no cover
+                raise ValueError(f"Unsupported series type `{type(series)}`")  # pragma: no cover
 
             # For dask or koalas collections, unknown type special case comes
             # *after* head calls to avoid evaluating a potentially large


### PR DESCRIPTION
- Removes any sampling that occurs in inference functions defined in `woodwork.type_sys.inference_functions`.
- Updates `TypeSystem.infer_logical_type` to standardize inference sampling.  Inference sampling is now done via a `.head(100000)` call that uses the appropriate API depending on the collection type (pandas, dask, or koalas).
- Changes the special case for all-null series to apply *before* sampling for pandas series and *after* sampling for dask and koalas series.  The thinking behind this is that we would ideally use the entire series to determine if there are any valid records and it is reasonably performant to do that when the series is already in-memory, but not otherwise.