### PR TITLE
Fix to allow all np.nan values in _infer_datetime_format with Datetime ltype

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Fix bug in ``_infer_datetime_format`` with all ``np.nan`` input (:pr:`1089`)
     * Changes
         * The criteria for categorical type inference have changed (:pr:`1065`)
         * The meaning of both the ``categorical_threshold`` and
@@ -21,7 +22,7 @@ Future Release
         * Update the sample_df fixture to have more logical_type coverage (:pr:`1058`)
 
     Thanks to the following people for contributing to this release:
-    :user:`davesque`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`tuethan1999`
+    :user:`davesque`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`thehomebrewnerd`, :user:`tuethan1999`
 
 Breaking Changes
 ++++++++++++++++

--- a/woodwork/tests/utils/test_accessor_utils.py
+++ b/woodwork/tests/utils/test_accessor_utils.py
@@ -15,10 +15,6 @@ from woodwork.accessor_utils import (
 )
 from woodwork.exceptions import TypeConversionError
 from woodwork.logical_types import Categorical, Datetime, NaturalLanguage
-from woodwork.utils import import_or_none
-
-dd = import_or_none('dask.dataframe')
-ks = import_or_none('databricks.koalas')
 
 
 def test_init_series_valid_conversion_specified_ltype(sample_series):
@@ -138,31 +134,6 @@ def test_init_series_error_on_invalid_conversion(sample_series):
         "Please confirm the underlying data is consistent with logical type IntegerNullable."
     with pytest.raises(TypeConversionError, match=error_message):
         init_series(sample_series, logical_type='integer_nullable')
-
-
-def test_init_series_datetime_all_null():
-    missing_lists = [
-        [None, None, None],
-        [np.nan, np.nan, np.nan],
-        [pd.NA, pd.NA, pd.NA]
-    ]
-
-    for items in missing_lists:
-        pd_series = pd.Series(items)
-        dd_series = dd.from_pandas(pd_series, npartitions=2)
-        ks_series = ks.from_pandas(pd_series)
-
-        new_pd_series = init_series(pd_series, logical_type='Datetime')
-        assert isinstance(new_pd_series.ww.logical_type, Datetime)
-        assert new_pd_series.ww.logical_type.datetime_format is None
-
-        new_dd_series = init_series(dd_series, logical_type='Datetime')
-        assert isinstance(new_dd_series.ww.logical_type, Datetime)
-        assert new_dd_series.ww.logical_type.datetime_format is None
-
-        new_ks_series = init_series(ks_series, logical_type='Datetime')
-        assert isinstance(new_ks_series.ww.logical_type, Datetime)
-        assert new_ks_series.ww.logical_type.datetime_format is None
 
 
 def test_is_series(sample_df):

--- a/woodwork/tests/utils/test_accessor_utils.py
+++ b/woodwork/tests/utils/test_accessor_utils.py
@@ -15,6 +15,10 @@ from woodwork.accessor_utils import (
 )
 from woodwork.exceptions import TypeConversionError
 from woodwork.logical_types import Categorical, Datetime, NaturalLanguage
+from woodwork.utils import import_or_none
+
+dd = import_or_none('dask.dataframe')
+ks = import_or_none('databricks.koalas')
 
 
 def test_init_series_valid_conversion_specified_ltype(sample_series):
@@ -134,6 +138,31 @@ def test_init_series_error_on_invalid_conversion(sample_series):
         "Please confirm the underlying data is consistent with logical type IntegerNullable."
     with pytest.raises(TypeConversionError, match=error_message):
         init_series(sample_series, logical_type='integer_nullable')
+
+
+def test_init_series_datetime_all_null():
+    missing_lists = [
+        [None, None, None],
+        [np.nan, np.nan, np.nan],
+        [pd.NA, pd.NA, pd.NA]
+    ]
+
+    for items in missing_lists:
+        pd_series = pd.Series(items)
+        dd_series = dd.from_pandas(pd_series, npartitions=2)
+        ks_series = ks.from_pandas(pd_series)
+
+        new_pd_series = init_series(pd_series, logical_type='Datetime')
+        assert isinstance(new_pd_series.ww.logical_type, Datetime)
+        assert new_pd_series.ww.logical_type.datetime_format is None
+
+        new_dd_series = init_series(dd_series, logical_type='Datetime')
+        assert isinstance(new_dd_series.ww.logical_type, Datetime)
+        assert new_dd_series.ww.logical_type.datetime_format is None
+
+        new_ks_series = init_series(ks_series, logical_type='Datetime')
+        assert isinstance(new_ks_series.ww.logical_type, Datetime)
+        assert new_ks_series.ww.logical_type.datetime_format is None
 
 
 def test_is_series(sample_df):

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -49,6 +49,9 @@ from woodwork.utils import (
     import_or_raise
 )
 
+dd = import_or_none('dask.dataframe')
+ks = import_or_none('databricks.koalas')
+
 
 def test_camel_to_snake():
     test_items = {
@@ -456,6 +459,24 @@ def test_infer_datetime_format(datetimes):
     dt1 = pd.Series(['3/11/2000 9:00', '3/11/2000 10:00', '3/11/2000 11:00', '3/11/2000 12:00'])
     fmt = _infer_datetime_format(dt1)
     assert fmt == '%m/%d/%Y %H:%M'
+
+
+def test_infer_datetime_format_all_null():
+    missing_lists = [
+        [None, None, None],
+        [np.nan, np.nan, np.nan],
+        [pd.NA, pd.NA, pd.NA],
+        [],
+    ]
+
+    for items in missing_lists:
+        pd_series = pd.Series(items)
+        dd_series = dd.from_pandas(pd_series, npartitions=2)
+        ks_series = ks.from_pandas(pd_series)
+
+        assert _infer_datetime_format(pd_series) is None
+        assert _infer_datetime_format(dd_series) is None
+        assert _infer_datetime_format(ks_series) is None
 
 
 def test_is_categorical() -> None:

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -462,21 +462,21 @@ def test_infer_datetime_format(datetimes):
 
 
 def test_infer_datetime_format_all_null():
-    missing_lists = [
-        [None, None, None],
-        [np.nan, np.nan, np.nan],
-        [pd.NA, pd.NA, pd.NA],
-        [],
+    missing_data = [
+        pd.Series([None, None, None]),
+        pd.Series([np.nan, np.nan, np.nan]),
+        pd.Series([pd.NA, pd.NA, pd.NA]),
+        pd.Series([]),
     ]
 
-    for items in missing_lists:
-        pd_series = pd.Series(items)
-        dd_series = dd.from_pandas(pd_series, npartitions=2)
-        ks_series = ks.from_pandas(pd_series)
-
+    for pd_series in missing_data:
         assert _infer_datetime_format(pd_series) is None
-        assert _infer_datetime_format(dd_series) is None
-        assert _infer_datetime_format(ks_series) is None
+        if dd:
+            dd_series = dd.from_pandas(pd_series, npartitions=2)
+            assert _infer_datetime_format(dd_series) is None
+        if ks:
+            ks_series = ks.from_pandas(pd_series)
+            assert _infer_datetime_format(ks_series) is None
 
 
 def test_is_categorical() -> None:

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -458,7 +458,7 @@ def _infer_datetime_format(dates, n=100):
     first_n = dates.dropna().head(n)
     if len(first_n) == 0:
         return None
-    try:
+    try:    
         fmts = first_n.map(pd.core.tools.datetimes.guess_datetime_format)
         mode_fmt = fmts.mode().loc[0]  # select first most common format
     except (TypeError, ValueError, IndexError, KeyError, NotImplementedError):

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -458,7 +458,7 @@ def _infer_datetime_format(dates, n=100):
     first_n = dates.dropna().head(n)
     if len(first_n) == 0:
         return None
-    try:    
+    try:
         fmts = first_n.map(pd.core.tools.datetimes.guess_datetime_format)
         mode_fmt = fmts.mode().loc[0]  # select first most common format
     except (TypeError, ValueError, IndexError, KeyError, NotImplementedError):

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -455,8 +455,10 @@ def _infer_datetime_format(dates, n=100):
         dates (Series): Series of string or datetime string to guess the format of
         n (int): the maximum number of nonnull rows to sample from the series
     """
+    first_n = dates.dropna().head(n)
+    if len(first_n) == 0:
+        return None
     try:
-        first_n = dates.dropna().head(n)
         fmts = first_n.map(pd.core.tools.datetimes.guess_datetime_format)
         mode_fmt = fmts.mode().loc[0]  # select first most common format
     except (TypeError, ValueError, IndexError, KeyError, NotImplementedError):


### PR DESCRIPTION
- Fix to allow all np.nan values in _infer_datetime_format
- Closes #1088 

Updates logic in `_infer_datetime_format` to prevent error when trying to infer formats on a series with all `np.nan` values, particularly a Koalas series.