### PR TITLE
Check for schema initialization in a decorator

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * The meaning of both the ``categorical_threshold`` and
           ``numeric_categorical_threshold`` settings have changed (:pr:`1065`)
         * Make sampling for type inference more consistent (:pr:`1083`)
+        * Accessor logic checking if Woodwork has been initialized moved to decorator (:pr:`1093`)
     * Documentation Changes
         * Fix some release notes that ended up under the wrong release (:pr:`1082`)
         * Add BooleanNullable and IntegerNullable types to the docs (:pr:`1085`)
@@ -23,7 +24,7 @@ Future Release
         * Update the sample_df fixture to have more logical_type coverage (:pr:`1058`)
 
     Thanks to the following people for contributing to this release:
-    :user:`davesque`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`tamargrey`, :user:`thehomebrewnerd`, :user:`tuethan1999`
+    :user:`davesque`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`, :user:`tuethan1999`
 
 Breaking Changes
 ++++++++++++++++

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -152,23 +152,25 @@ def _is_koalas_series(data):
     return False
 
 
-def _check_schema_init(method):
-    '''Decorator for Woodwork ColumnAccessor and WoodworkTableAccessor that
-       checks schema initialization
-    '''
+def _check_column_schema(method):
+    '''Decorator for WoodworkColumnAccessor that checks schema initialization'''
     @wraps(method)
     def wrapper(self, *args, **kwargs):
         if self._schema is None:
-            from woodwork.column_accessor import WoodworkColumnAccessor
-            from woodwork.table_accessor import WoodworkTableAccessor
-            if isinstance(self, WoodworkTableAccessor):
-                data_structure = "DataFrame"
-            elif isinstance(self, WoodworkColumnAccessor):
-                data_structure = "Series"
-            else:
-                raise TypeError("decorator was applied to a non-accessor method")
-            msg = (f"Woodwork not initialized for this {data_structure}. "
-                   f"Initialize by calling {data_structure}.ww.init")
+            msg = ("Woodwork not initialized for this Series. Initialize by "
+                   "calling Series.ww.init")
+            raise WoodworkNotInitError(msg)
+        return method(self, *args, **kwargs)
+    return wrapper
+
+
+def _check_table_schema(method):
+    '''Decorator for WoodworkTableAccessor that checks schema initialization'''
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if self._schema is None:
+            msg = ("Woodwork not initialized for this DataFrame. Initialize by "
+                   "calling DataFrame.ww.init")
             raise WoodworkNotInitError(msg)
         return method(self, *args, **kwargs)
     return wrapper

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -1,6 +1,9 @@
+from functools import wraps
+
 import numpy as np
 import pandas as pd
 
+from woodwork.exceptions import WoodworkNotInitError
 from woodwork.utils import _get_column_logical_type, import_or_none
 
 dd = import_or_none('dask.dataframe')
@@ -147,3 +150,19 @@ def _is_koalas_series(data):
     if ks and isinstance(data, ks.Series):
         return True
     return False
+
+
+def _check_schema_init(data_structure):
+    '''Decorator for Woodwork ColumnAccessor and WoodworkTableAccessor that
+       checks schema initialization
+    '''
+    def inner_decorator(method):
+        @wraps(method)
+        def wrapper(self, *args, **kwargs):
+            if self._schema is None:
+                msg = (f"Woodwork not initialized for this {data_structure}. "
+                       f"Initialize by calling {data_structure}.ww.init")
+                raise WoodworkNotInitError(msg)
+            return method(self, *args, **kwargs)
+        return wrapper
+    return inner_decorator

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -108,29 +108,29 @@ class WoodworkColumnAccessor:
         return copy.deepcopy(self._schema)
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def description(self):
         """The description of the series"""
         return self._schema.description
 
     @description.setter
-    @_check_schema_init("Series")
+    @_check_schema_init
     def description(self, description):
         self._schema.description = description
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def origin(self):
         """The origin of the series"""
         return self._schema.origin
 
     @origin.setter
-    @_check_schema_init("Series")
+    @_check_schema_init
     def origin(self, origin):
         self._schema.origin = origin
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def iloc(self):
         """
         Integer-location based indexing for selection by position.
@@ -153,7 +153,7 @@ class WoodworkColumnAccessor:
         return _iLocIndexer(self._series)
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def loc(self):
         """
         Access a group of rows by label(s) or a boolean array.
@@ -181,30 +181,30 @@ class WoodworkColumnAccessor:
         return _locIndexer(self._series)
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def logical_type(self):
         """The logical type of the series"""
         return self._schema.logical_type
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def metadata(self):
         """The metadata of the series"""
         return self._schema.metadata
 
     @metadata.setter
-    @_check_schema_init("Series")
+    @_check_schema_init
     def metadata(self, metadata):
         self._schema.metadata = metadata
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def semantic_tags(self):
         """The semantic tags assigned to the series"""
         return self._schema.semantic_tags
 
     @property
-    @_check_schema_init("Series")
+    @_check_schema_init
     def use_standard_tags(self):
         return self._schema.use_standard_tags
 
@@ -217,7 +217,7 @@ class WoodworkColumnAccessor:
             return self._series.equals(other._series)
         return True
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def __getattr__(self, attr):
         # Called if method is not present on the Accessor
         # If the method is present on Series, uses that method.
@@ -226,7 +226,7 @@ class WoodworkColumnAccessor:
         else:
             raise AttributeError(f"Woodwork has no attribute '{attr}'")
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def __repr__(self):
         msg = u"<Series: {} ".format(self._series.name)
         msg += u"(Physical Type = {}) ".format(self._series.dtype)
@@ -294,7 +294,7 @@ class WoodworkColumnAccessor:
                                  "LatLong data. Try reformatting before initializing or use the "
                                  "woodwork.init_series function to initialize.")
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def add_semantic_tags(self, semantic_tags):
         """Add the specified semantic tags to the set of tags.
 
@@ -304,7 +304,7 @@ class WoodworkColumnAccessor:
         self._schema._add_semantic_tags(semantic_tags,
                                         self._series.name)
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def remove_semantic_tags(self, semantic_tags):
         """Removes specified semantic tags from the current tags.
 
@@ -314,7 +314,7 @@ class WoodworkColumnAccessor:
         self._schema._remove_semantic_tags(semantic_tags,
                                            self._series.name)
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def reset_semantic_tags(self):
         """Reset the semantic tags to the default values. The default values
         will be either an empty set or a set of the standard tags based on the
@@ -325,7 +325,7 @@ class WoodworkColumnAccessor:
         """
         self._schema._reset_semantic_tags()
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def set_logical_type(self, logical_type):
         """Update the logical type for the series, clearing any previously set semantic tags,
         and returning a new series with Woodwork initialied.
@@ -348,7 +348,7 @@ class WoodworkColumnAccessor:
                            origin=self.origin,
                            metadata=copy.deepcopy(self.metadata))
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def set_semantic_tags(self, semantic_tags):
         """Replace current semantic tags with new values. If `use_standard_tags` is set
         to True for the series, any standard tags associated with the LogicalType of the
@@ -359,7 +359,7 @@ class WoodworkColumnAccessor:
         """
         self._schema._set_semantic_tags(semantic_tags)
 
-    @_check_schema_init("Series")
+    @_check_schema_init
     def box_plot_dict(self, quantiles=None):
         """Gets the information necessary to create a box and whisker plot with outliers for a numeric column
         using the IQR method.

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -5,7 +5,7 @@ import weakref
 import pandas as pd
 
 from woodwork.accessor_utils import (
-    _check_schema_init,
+    _check_column_schema,
     _is_dataframe,
     _is_series,
     init_series,
@@ -108,29 +108,29 @@ class WoodworkColumnAccessor:
         return copy.deepcopy(self._schema)
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def description(self):
         """The description of the series"""
         return self._schema.description
 
     @description.setter
-    @_check_schema_init
+    @_check_column_schema
     def description(self, description):
         self._schema.description = description
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def origin(self):
         """The origin of the series"""
         return self._schema.origin
 
     @origin.setter
-    @_check_schema_init
+    @_check_column_schema
     def origin(self, origin):
         self._schema.origin = origin
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def iloc(self):
         """
         Integer-location based indexing for selection by position.
@@ -153,7 +153,7 @@ class WoodworkColumnAccessor:
         return _iLocIndexer(self._series)
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def loc(self):
         """
         Access a group of rows by label(s) or a boolean array.
@@ -181,30 +181,30 @@ class WoodworkColumnAccessor:
         return _locIndexer(self._series)
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def logical_type(self):
         """The logical type of the series"""
         return self._schema.logical_type
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def metadata(self):
         """The metadata of the series"""
         return self._schema.metadata
 
     @metadata.setter
-    @_check_schema_init
+    @_check_column_schema
     def metadata(self, metadata):
         self._schema.metadata = metadata
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def semantic_tags(self):
         """The semantic tags assigned to the series"""
         return self._schema.semantic_tags
 
     @property
-    @_check_schema_init
+    @_check_column_schema
     def use_standard_tags(self):
         return self._schema.use_standard_tags
 
@@ -217,7 +217,7 @@ class WoodworkColumnAccessor:
             return self._series.equals(other._series)
         return True
 
-    @_check_schema_init
+    @_check_column_schema
     def __getattr__(self, attr):
         # Called if method is not present on the Accessor
         # If the method is present on Series, uses that method.
@@ -226,7 +226,7 @@ class WoodworkColumnAccessor:
         else:
             raise AttributeError(f"Woodwork has no attribute '{attr}'")
 
-    @_check_schema_init
+    @_check_column_schema
     def __repr__(self):
         msg = u"<Series: {} ".format(self._series.name)
         msg += u"(Physical Type = {}) ".format(self._series.dtype)
@@ -294,7 +294,7 @@ class WoodworkColumnAccessor:
                                  "LatLong data. Try reformatting before initializing or use the "
                                  "woodwork.init_series function to initialize.")
 
-    @_check_schema_init
+    @_check_column_schema
     def add_semantic_tags(self, semantic_tags):
         """Add the specified semantic tags to the set of tags.
 
@@ -304,7 +304,7 @@ class WoodworkColumnAccessor:
         self._schema._add_semantic_tags(semantic_tags,
                                         self._series.name)
 
-    @_check_schema_init
+    @_check_column_schema
     def remove_semantic_tags(self, semantic_tags):
         """Removes specified semantic tags from the current tags.
 
@@ -314,7 +314,7 @@ class WoodworkColumnAccessor:
         self._schema._remove_semantic_tags(semantic_tags,
                                            self._series.name)
 
-    @_check_schema_init
+    @_check_column_schema
     def reset_semantic_tags(self):
         """Reset the semantic tags to the default values. The default values
         will be either an empty set or a set of the standard tags based on the
@@ -325,7 +325,7 @@ class WoodworkColumnAccessor:
         """
         self._schema._reset_semantic_tags()
 
-    @_check_schema_init
+    @_check_column_schema
     def set_logical_type(self, logical_type):
         """Update the logical type for the series, clearing any previously set semantic tags,
         and returning a new series with Woodwork initialied.
@@ -348,7 +348,7 @@ class WoodworkColumnAccessor:
                            origin=self.origin,
                            metadata=copy.deepcopy(self.metadata))
 
-    @_check_schema_init
+    @_check_column_schema
     def set_semantic_tags(self, semantic_tags):
         """Replace current semantic tags with new values. If `use_standard_tags` is set
         to True for the series, any standard tags associated with the LogicalType of the
@@ -359,7 +359,7 @@ class WoodworkColumnAccessor:
         """
         self._schema._set_semantic_tags(semantic_tags)
 
-    @_check_schema_init
+    @_check_column_schema
     def box_plot_dict(self, quantiles=None):
         """Gets the information necessary to create a box and whisker plot with outliers for a numeric column
         using the IQR method.

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -31,6 +31,7 @@ ks = import_or_none('databricks.koalas')
 
 
 def _check_series_schema(func):
+    '''Decorator for WoodworkColumnAccessor that checks schema initialization'''
     def wrapper(self, *args, **kwargs):
         if self.schema is None:
             msg = ("Woodwork not initialized for this Series. Initialize by "

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -374,34 +374,31 @@ class WoodworkColumnAccessor:
         """Gets the information necessary to create a box and whisker plot with outliers for a numeric column
         using the IQR method.
 
-    Args:
-        quantiles (dict[float -> float], optional): A dictionary containing the quantiles for the data
-            where the key indicates the quantile, and the value is the quantile's value for the data. If
-            no qantiles are provided, they will be computed from the data.
+        Args:
+            quantiles (dict[float -> float], optional): A dictionary containing the quantiles for the data
+                where the key indicates the quantile, and the value is the quantile's value for the data. If
+                no qantiles are provided, they will be computed from the data.
 
-    Note:
-        The minimum quantiles necessary for outlier detection using the IQR method are the
-        first quartile (0.25) and third quartile (0.75). If these keys are missing from the quantiles dictionary,
-        the following quantiles will be calculated: {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to
-        {min, first quantile, median, third quantile, max}.
+        Note:
+            The minimum quantiles necessary for outlier detection using the IQR method are the
+            first quartile (0.25) and third quartile (0.75). If these keys are missing from the quantiles dictionary,
+            the following quantiles will be calculated: {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to
+            {min, first quantile, median, third quantile, max}.
 
-    Returns:
-        (dict[str -> float,list[number]]): Returns a dictionary containing box plot information for the Series.
-            The following elements will be found in the dictionary:
+        Returns:
+            (dict[str -> float,list[number]]): Returns a dictionary containing box plot information for the Series.
+                The following elements will be found in the dictionary:
 
-            - low_bound (float): the lower bound below which outliers lay - to be used as a whisker
-            - high_bound (float): the high bound above which outliers lay - to be used as a whisker
-            - quantiles (list[float]): the quantiles used to determine the bounds.
-                If quantiles were passed in, will contain all quantiles passed in. Otherwise, contains the five
-                quantiles {0.0, 0.25, 0.5, 0.75, 1.0}.
-            - low_values (list[float, int]): the values of the lower outliers
-            - high_values (list[float, int]): the values of the upper outliers
-            - low_indices (list[int]): the corresponding index values for each of the lower outliers
-            - high_indices (list[int]): the corresponding index values for each of the upper outliers
+                - low_bound (float): the lower bound below which outliers lay - to be used as a whisker
+                - high_bound (float): the high bound above which outliers lay - to be used as a whisker
+                - quantiles (list[float]): the quantiles used to determine the bounds.
+                    If quantiles were passed in, will contain all quantiles passed in. Otherwise, contains the five
+                    quantiles {0.0, 0.25, 0.5, 0.75, 1.0}.
+                - low_values (list[float, int]): the values of the lower outliers
+                - high_values (list[float, int]): the values of the upper outliers
+                - low_indices (list[int]): the corresponding index values for each of the lower outliers
+                - high_indices (list[int]): the corresponding index values for each of the upper outliers
         """
-        if self._schema is None:
-            _raise_init_error()
-
         return _get_box_plot_info_for_column(self._series, quantiles=quantiles)
 
 

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -33,7 +33,7 @@ ks = import_or_none('databricks.koalas')
 def _check_series_schema(func):
     '''Decorator for WoodworkColumnAccessor that checks schema initialization'''
     def wrapper(self, *args, **kwargs):
-        if self.schema is None:
+        if self._schema is None:
             msg = ("Woodwork not initialized for this Series. Initialize by "
                    "calling Series.ww.init")
             raise WoodworkNotInitError(msg)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 import woodwork.serialize as serialize
 from woodwork.accessor_utils import (
-    _check_schema_init,
+    _check_table_schema,
     _is_dask_dataframe,
     _is_dataframe,
     _is_koalas_dataframe,
@@ -158,7 +158,7 @@ class WoodworkTableAccessor:
             return self._dataframe.equals(other.ww._dataframe)
         return True
 
-    @_check_schema_init
+    @_check_table_schema
     def __getattr__(self, attr):
         # Called if method is not present on the Accessor
         # If the method is present on TableSchema, uses that method.
@@ -170,7 +170,7 @@ class WoodworkTableAccessor:
         else:
             raise AttributeError(f"Woodwork has no attribute '{attr}'")
 
-    @_check_schema_init
+    @_check_table_schema
     def __getitem__(self, key):
         if isinstance(key, list):
             columns = set(self._dataframe.columns)
@@ -221,7 +221,7 @@ class WoodworkTableAccessor:
         containing typing information and a preview of the data."""
         return self._get_typing_info().to_html()
 
-    @_check_schema_init
+    @_check_table_schema
     def _get_typing_info(self):
         """Creates a DataFrame that contains the typing information for a Woodwork table."""
         typing_info = self._schema._get_typing_info().copy()
@@ -231,25 +231,25 @@ class WoodworkTableAccessor:
         return typing_info
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def name(self):
         """Name of the DataFrame"""
         return self._schema.name
 
     @name.setter
-    @_check_schema_init
+    @_check_table_schema
     def name(self, name):
         """Set name of the DataFrame"""
         self._schema.name = name
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def metadata(self):
         """Metadata of the DataFrame"""
         return self._schema.metadata
 
     @metadata.setter
-    @_check_schema_init
+    @_check_table_schema
     def metadata(self, metadata):
         """Set metadata of the DataFrame"""
         self._schema.metadata = metadata
@@ -259,7 +259,7 @@ class WoodworkTableAccessor:
         return self._dataframe_weakref()
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def iloc(self):
         """
         Integer-location based indexing for selection by position.
@@ -282,7 +282,7 @@ class WoodworkTableAccessor:
         return _iLocIndexer(self._dataframe)
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def loc(self):
         """
         Access a group of rows by label(s) or a boolean array.
@@ -316,49 +316,49 @@ class WoodworkTableAccessor:
             return copy.deepcopy(self._schema)
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def physical_types(self):
         """A dictionary containing physical types for each column"""
         return {col_name: self._schema.logical_types[col_name]._get_valid_dtype(type(self._dataframe[col_name])) for col_name in self._dataframe.columns}
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def types(self):
         """DataFrame containing the physical dtypes, logical types and semantic
         tags for the schema."""
         return self._get_typing_info()
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def logical_types(self):
         """A dictionary containing logical types for each column"""
         return self._schema.logical_types
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def semantic_tags(self):
         """A dictionary containing semantic tags for each column"""
         return self._schema.semantic_tags
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def index(self):
         """The index column for the table"""
         return self._schema.index
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def time_index(self):
         """The time index column for the table"""
         return self._schema.time_index
 
     @property
-    @_check_schema_init
+    @_check_table_schema
     def use_standard_tags(self):
         """A dictionary containing the use_standard_tags setting for each column in the table"""
         return self._schema.use_standard_tags
 
-    @_check_schema_init
+    @_check_table_schema
     def set_index(self, new_index):
         """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
         and clears the tag from any previously set index column.
@@ -377,7 +377,7 @@ class WoodworkTableAccessor:
             _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
 
-    @_check_schema_init
+    @_check_table_schema
     def set_time_index(self, new_time_index):
         """Set the time index. Adds the 'time_index' semantic tag to the column and
         clears the tag from any previously set index column
@@ -388,7 +388,7 @@ class WoodworkTableAccessor:
         """
         self._schema.set_time_index(new_time_index)
 
-    @_check_schema_init
+    @_check_table_schema
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
         """Update the logical type and semantic tags for any columns names in the provided types dictionaries,
         updating the Woodwork typing information for the DataFrame.
@@ -415,7 +415,7 @@ class WoodworkTableAccessor:
             if updated_series is not series:
                 self._dataframe[col_name] = updated_series
 
-    @_check_schema_init
+    @_check_table_schema
     def select(self, include=None, exclude=None, return_schema=False):
         """Create a DataFrame with Woodwork typing information initialized
         that includes only columns whose Logical Type and semantic tags match
@@ -449,7 +449,7 @@ class WoodworkTableAccessor:
             return self._schema._get_subset_schema(cols_to_include)
         return self._get_subset_df_with_schema(cols_to_include)
 
-    @_check_schema_init
+    @_check_table_schema
     def add_semantic_tags(self, semantic_tags):
         """Adds specified semantic tags to columns, updating the Woodwork typing information.
         Will retain any previously set values.
@@ -460,7 +460,7 @@ class WoodworkTableAccessor:
         """
         self._schema.add_semantic_tags(semantic_tags)
 
-    @_check_schema_init
+    @_check_table_schema
     def remove_semantic_tags(self, semantic_tags):
         """Remove the semantic tags for any column names in the provided semantic_tags
         dictionary, updating the Woodwork typing information. Including `index` or `time_index`
@@ -472,7 +472,7 @@ class WoodworkTableAccessor:
         """
         self._schema.remove_semantic_tags(semantic_tags)
 
-    @_check_schema_init
+    @_check_table_schema
     def reset_semantic_tags(self, columns=None, retain_index_tags=False):
         """Reset the semantic tags for the specified columns to the default values.
         The default values will be either an empty set or a set of the standard tags
@@ -488,7 +488,7 @@ class WoodworkTableAccessor:
         """
         self._schema.reset_semantic_tags(columns=columns, retain_index_tags=retain_index_tags)
 
-    @_check_schema_init
+    @_check_table_schema
     def to_dictionary(self):
         """Get a dictionary representation of the Woodwork typing information.
 
@@ -497,7 +497,7 @@ class WoodworkTableAccessor:
         """
         return serialize.typing_info_to_dict(self._dataframe)
 
-    @_check_schema_init
+    @_check_table_schema
     def to_disk(self, path, format='csv', compression=None, profile_name=None, **kwargs):
         """Write Woodwork table to disk in the format specified by `format`, location specified by `path`.
             Path could be a local path or an S3 path.
@@ -624,7 +624,7 @@ class WoodworkTableAccessor:
 
         return new_df
 
-    @_check_schema_init
+    @_check_table_schema
     def pop(self, column_name):
         """Return a Series with Woodwork typing information and remove it from the DataFrame.
 
@@ -647,7 +647,7 @@ class WoodworkTableAccessor:
 
         return series
 
-    @_check_schema_init
+    @_check_table_schema
     def drop(self, columns, inplace=False):
         """Drop specified columns from a DataFrame.
 
@@ -671,7 +671,7 @@ class WoodworkTableAccessor:
             raise ColumnNotPresentError(not_present)
         return self._get_subset_df_with_schema([col for col in self._dataframe.columns if col not in columns], inplace=inplace)
 
-    @_check_schema_init
+    @_check_table_schema
     def rename(self, columns, inplace=False):
         """Renames columns in a DataFrame, maintaining Woodwork typing information.
 
@@ -697,7 +697,7 @@ class WoodworkTableAccessor:
         new_df.ww.init(schema=new_schema)
         return new_df
 
-    @_check_schema_init
+    @_check_table_schema
     def mutual_information_dict(self, num_bins=10, nrows=None, include_index=False, callback=None):
         """
         Calculates mutual information between all pairs of columns in the DataFrame that
@@ -764,7 +764,7 @@ class WoodworkTableAccessor:
         mutual_info = self.mutual_information_dict(num_bins, nrows, include_index, callback)
         return pd.DataFrame(mutual_info)
 
-    @_check_schema_init
+    @_check_table_schema
     def describe_dict(self, include=None, callback=None, extra_stats=False, bins=10, top_x=10, recent_x=10):
         """Calculates statistics for data contained in the DataFrame.
 
@@ -845,7 +845,7 @@ class WoodworkTableAccessor:
         ]
         return pd.DataFrame(results).reindex(index_order)
 
-    @_check_schema_init
+    @_check_table_schema
     def value_counts(self, ascending=False, top_n=10, dropna=False):
         """Returns a list of dictionaries with counts for the most frequent values in each column (only
             for columns with `category` as a standard tag).

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -40,6 +40,7 @@ ks = import_or_none('databricks.koalas')
 
 
 def _check_df_schema(func):
+    '''Decorator for WoodworkTableAccessor that checks schema initialization'''
     def wrapper(self, *args, **kwargs):
         if self.schema is None:
             msg = ("Woodwork not initialized for this DataFrame. Initialize by "

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -42,7 +42,7 @@ ks = import_or_none('databricks.koalas')
 def _check_df_schema(func):
     '''Decorator for WoodworkTableAccessor that checks schema initialization'''
     def wrapper(self, *args, **kwargs):
-        if self.schema is None:
+        if self._schema is None:
             msg = ("Woodwork not initialized for this DataFrame. Initialize by "
                    "calling DataFrame.ww.init")
             raise WoodworkNotInitError(msg)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 import woodwork.serialize as serialize
 from woodwork.accessor_utils import (
+    _check_schema_init,
     _is_dask_dataframe,
     _is_dataframe,
     _is_koalas_dataframe,
@@ -16,8 +17,7 @@ from woodwork.exceptions import (
     ColumnNotPresentError,
     IndexTagRemovedWarning,
     ParametersIgnoredWarning,
-    TypingInfoMismatchWarning,
-    WoodworkNotInitError
+    TypingInfoMismatchWarning
 )
 from woodwork.indexers import _iLocIndexer, _locIndexer
 from woodwork.logical_types import Datetime
@@ -37,17 +37,6 @@ from woodwork.utils import (
 
 dd = import_or_none('dask.dataframe')
 ks = import_or_none('databricks.koalas')
-
-
-def _check_df_schema(func):
-    '''Decorator for WoodworkTableAccessor that checks schema initialization'''
-    def wrapper(self, *args, **kwargs):
-        if self._schema is None:
-            msg = ("Woodwork not initialized for this DataFrame. Initialize by "
-                   "calling DataFrame.ww.init")
-            raise WoodworkNotInitError(msg)
-        return func(self, *args, **kwargs)
-    return wrapper
 
 
 class WoodworkTableAccessor:
@@ -169,7 +158,7 @@ class WoodworkTableAccessor:
             return self._dataframe.equals(other.ww._dataframe)
         return True
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def __getattr__(self, attr):
         # Called if method is not present on the Accessor
         # If the method is present on TableSchema, uses that method.
@@ -181,7 +170,7 @@ class WoodworkTableAccessor:
         else:
             raise AttributeError(f"Woodwork has no attribute '{attr}'")
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def __getitem__(self, key):
         if isinstance(key, list):
             columns = set(self._dataframe.columns)
@@ -232,7 +221,7 @@ class WoodworkTableAccessor:
         containing typing information and a preview of the data."""
         return self._get_typing_info().to_html()
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def _get_typing_info(self):
         """Creates a DataFrame that contains the typing information for a Woodwork table."""
         typing_info = self._schema._get_typing_info().copy()
@@ -242,25 +231,25 @@ class WoodworkTableAccessor:
         return typing_info
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def name(self):
         """Name of the DataFrame"""
         return self._schema.name
 
     @name.setter
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def name(self, name):
         """Set name of the DataFrame"""
         self._schema.name = name
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def metadata(self):
         """Metadata of the DataFrame"""
         return self._schema.metadata
 
     @metadata.setter
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def metadata(self, metadata):
         """Set metadata of the DataFrame"""
         self._schema.metadata = metadata
@@ -270,7 +259,7 @@ class WoodworkTableAccessor:
         return self._dataframe_weakref()
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def iloc(self):
         """
         Integer-location based indexing for selection by position.
@@ -293,7 +282,7 @@ class WoodworkTableAccessor:
         return _iLocIndexer(self._dataframe)
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def loc(self):
         """
         Access a group of rows by label(s) or a boolean array.
@@ -327,49 +316,49 @@ class WoodworkTableAccessor:
             return copy.deepcopy(self._schema)
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def physical_types(self):
         """A dictionary containing physical types for each column"""
         return {col_name: self._schema.logical_types[col_name]._get_valid_dtype(type(self._dataframe[col_name])) for col_name in self._dataframe.columns}
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def types(self):
         """DataFrame containing the physical dtypes, logical types and semantic
         tags for the schema."""
         return self._get_typing_info()
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def logical_types(self):
         """A dictionary containing logical types for each column"""
         return self._schema.logical_types
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def semantic_tags(self):
         """A dictionary containing semantic tags for each column"""
         return self._schema.semantic_tags
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def index(self):
         """The index column for the table"""
         return self._schema.index
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def time_index(self):
         """The time index column for the table"""
         return self._schema.time_index
 
     @property
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def use_standard_tags(self):
         """A dictionary containing the use_standard_tags setting for each column in the table"""
         return self._schema.use_standard_tags
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def set_index(self, new_index):
         """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
         and clears the tag from any previously set index column.
@@ -388,7 +377,7 @@ class WoodworkTableAccessor:
             _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def set_time_index(self, new_time_index):
         """Set the time index. Adds the 'time_index' semantic tag to the column and
         clears the tag from any previously set index column
@@ -399,7 +388,7 @@ class WoodworkTableAccessor:
         """
         self._schema.set_time_index(new_time_index)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
         """Update the logical type and semantic tags for any columns names in the provided types dictionaries,
         updating the Woodwork typing information for the DataFrame.
@@ -426,7 +415,7 @@ class WoodworkTableAccessor:
             if updated_series is not series:
                 self._dataframe[col_name] = updated_series
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def select(self, include=None, exclude=None, return_schema=False):
         """Create a DataFrame with Woodwork typing information initialized
         that includes only columns whose Logical Type and semantic tags match
@@ -460,7 +449,7 @@ class WoodworkTableAccessor:
             return self._schema._get_subset_schema(cols_to_include)
         return self._get_subset_df_with_schema(cols_to_include)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def add_semantic_tags(self, semantic_tags):
         """Adds specified semantic tags to columns, updating the Woodwork typing information.
         Will retain any previously set values.
@@ -471,7 +460,7 @@ class WoodworkTableAccessor:
         """
         self._schema.add_semantic_tags(semantic_tags)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def remove_semantic_tags(self, semantic_tags):
         """Remove the semantic tags for any column names in the provided semantic_tags
         dictionary, updating the Woodwork typing information. Including `index` or `time_index`
@@ -483,7 +472,7 @@ class WoodworkTableAccessor:
         """
         self._schema.remove_semantic_tags(semantic_tags)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def reset_semantic_tags(self, columns=None, retain_index_tags=False):
         """Reset the semantic tags for the specified columns to the default values.
         The default values will be either an empty set or a set of the standard tags
@@ -499,7 +488,7 @@ class WoodworkTableAccessor:
         """
         self._schema.reset_semantic_tags(columns=columns, retain_index_tags=retain_index_tags)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def to_dictionary(self):
         """Get a dictionary representation of the Woodwork typing information.
 
@@ -508,7 +497,7 @@ class WoodworkTableAccessor:
         """
         return serialize.typing_info_to_dict(self._dataframe)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def to_disk(self, path, format='csv', compression=None, profile_name=None, **kwargs):
         """Write Woodwork table to disk in the format specified by `format`, location specified by `path`.
             Path could be a local path or an S3 path.
@@ -635,7 +624,7 @@ class WoodworkTableAccessor:
 
         return new_df
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def pop(self, column_name):
         """Return a Series with Woodwork typing information and remove it from the DataFrame.
 
@@ -658,7 +647,7 @@ class WoodworkTableAccessor:
 
         return series
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def drop(self, columns, inplace=False):
         """Drop specified columns from a DataFrame.
 
@@ -682,7 +671,7 @@ class WoodworkTableAccessor:
             raise ColumnNotPresentError(not_present)
         return self._get_subset_df_with_schema([col for col in self._dataframe.columns if col not in columns], inplace=inplace)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def rename(self, columns, inplace=False):
         """Renames columns in a DataFrame, maintaining Woodwork typing information.
 
@@ -708,7 +697,7 @@ class WoodworkTableAccessor:
         new_df.ww.init(schema=new_schema)
         return new_df
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def mutual_information_dict(self, num_bins=10, nrows=None, include_index=False, callback=None):
         """
         Calculates mutual information between all pairs of columns in the DataFrame that
@@ -775,7 +764,7 @@ class WoodworkTableAccessor:
         mutual_info = self.mutual_information_dict(num_bins, nrows, include_index, callback)
         return pd.DataFrame(mutual_info)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def describe_dict(self, include=None, callback=None, extra_stats=False, bins=10, top_x=10, recent_x=10):
         """Calculates statistics for data contained in the DataFrame.
 
@@ -856,7 +845,7 @@ class WoodworkTableAccessor:
         ]
         return pd.DataFrame(results).reindex(index_order)
 
-    @_check_df_schema
+    @_check_schema_init("DataFrame")
     def value_counts(self, ascending=False, top_n=10, dropna=False):
         """Returns a list of dictionaries with counts for the most frequent values in each column (only
             for columns with `category` as a standard tag).

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -158,7 +158,7 @@ class WoodworkTableAccessor:
             return self._dataframe.equals(other.ww._dataframe)
         return True
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def __getattr__(self, attr):
         # Called if method is not present on the Accessor
         # If the method is present on TableSchema, uses that method.
@@ -170,7 +170,7 @@ class WoodworkTableAccessor:
         else:
             raise AttributeError(f"Woodwork has no attribute '{attr}'")
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def __getitem__(self, key):
         if isinstance(key, list):
             columns = set(self._dataframe.columns)
@@ -221,7 +221,7 @@ class WoodworkTableAccessor:
         containing typing information and a preview of the data."""
         return self._get_typing_info().to_html()
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def _get_typing_info(self):
         """Creates a DataFrame that contains the typing information for a Woodwork table."""
         typing_info = self._schema._get_typing_info().copy()
@@ -231,25 +231,25 @@ class WoodworkTableAccessor:
         return typing_info
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def name(self):
         """Name of the DataFrame"""
         return self._schema.name
 
     @name.setter
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def name(self, name):
         """Set name of the DataFrame"""
         self._schema.name = name
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def metadata(self):
         """Metadata of the DataFrame"""
         return self._schema.metadata
 
     @metadata.setter
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def metadata(self, metadata):
         """Set metadata of the DataFrame"""
         self._schema.metadata = metadata
@@ -259,7 +259,7 @@ class WoodworkTableAccessor:
         return self._dataframe_weakref()
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def iloc(self):
         """
         Integer-location based indexing for selection by position.
@@ -282,7 +282,7 @@ class WoodworkTableAccessor:
         return _iLocIndexer(self._dataframe)
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def loc(self):
         """
         Access a group of rows by label(s) or a boolean array.
@@ -316,49 +316,49 @@ class WoodworkTableAccessor:
             return copy.deepcopy(self._schema)
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def physical_types(self):
         """A dictionary containing physical types for each column"""
         return {col_name: self._schema.logical_types[col_name]._get_valid_dtype(type(self._dataframe[col_name])) for col_name in self._dataframe.columns}
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def types(self):
         """DataFrame containing the physical dtypes, logical types and semantic
         tags for the schema."""
         return self._get_typing_info()
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def logical_types(self):
         """A dictionary containing logical types for each column"""
         return self._schema.logical_types
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def semantic_tags(self):
         """A dictionary containing semantic tags for each column"""
         return self._schema.semantic_tags
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def index(self):
         """The index column for the table"""
         return self._schema.index
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def time_index(self):
         """The time index column for the table"""
         return self._schema.time_index
 
     @property
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def use_standard_tags(self):
         """A dictionary containing the use_standard_tags setting for each column in the table"""
         return self._schema.use_standard_tags
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def set_index(self, new_index):
         """Sets the index column of the DataFrame. Adds the 'index' semantic tag to the column
         and clears the tag from any previously set index column.
@@ -377,7 +377,7 @@ class WoodworkTableAccessor:
             _check_index(self._dataframe, self._schema.index)
         self._set_underlying_index()
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def set_time_index(self, new_time_index):
         """Set the time index. Adds the 'time_index' semantic tag to the column and
         clears the tag from any previously set index column
@@ -388,7 +388,7 @@ class WoodworkTableAccessor:
         """
         self._schema.set_time_index(new_time_index)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def set_types(self, logical_types=None, semantic_tags=None, retain_index_tags=True):
         """Update the logical type and semantic tags for any columns names in the provided types dictionaries,
         updating the Woodwork typing information for the DataFrame.
@@ -415,7 +415,7 @@ class WoodworkTableAccessor:
             if updated_series is not series:
                 self._dataframe[col_name] = updated_series
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def select(self, include=None, exclude=None, return_schema=False):
         """Create a DataFrame with Woodwork typing information initialized
         that includes only columns whose Logical Type and semantic tags match
@@ -449,7 +449,7 @@ class WoodworkTableAccessor:
             return self._schema._get_subset_schema(cols_to_include)
         return self._get_subset_df_with_schema(cols_to_include)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def add_semantic_tags(self, semantic_tags):
         """Adds specified semantic tags to columns, updating the Woodwork typing information.
         Will retain any previously set values.
@@ -460,7 +460,7 @@ class WoodworkTableAccessor:
         """
         self._schema.add_semantic_tags(semantic_tags)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def remove_semantic_tags(self, semantic_tags):
         """Remove the semantic tags for any column names in the provided semantic_tags
         dictionary, updating the Woodwork typing information. Including `index` or `time_index`
@@ -472,7 +472,7 @@ class WoodworkTableAccessor:
         """
         self._schema.remove_semantic_tags(semantic_tags)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def reset_semantic_tags(self, columns=None, retain_index_tags=False):
         """Reset the semantic tags for the specified columns to the default values.
         The default values will be either an empty set or a set of the standard tags
@@ -488,7 +488,7 @@ class WoodworkTableAccessor:
         """
         self._schema.reset_semantic_tags(columns=columns, retain_index_tags=retain_index_tags)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def to_dictionary(self):
         """Get a dictionary representation of the Woodwork typing information.
 
@@ -497,7 +497,7 @@ class WoodworkTableAccessor:
         """
         return serialize.typing_info_to_dict(self._dataframe)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def to_disk(self, path, format='csv', compression=None, profile_name=None, **kwargs):
         """Write Woodwork table to disk in the format specified by `format`, location specified by `path`.
             Path could be a local path or an S3 path.
@@ -624,7 +624,7 @@ class WoodworkTableAccessor:
 
         return new_df
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def pop(self, column_name):
         """Return a Series with Woodwork typing information and remove it from the DataFrame.
 
@@ -647,7 +647,7 @@ class WoodworkTableAccessor:
 
         return series
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def drop(self, columns, inplace=False):
         """Drop specified columns from a DataFrame.
 
@@ -671,7 +671,7 @@ class WoodworkTableAccessor:
             raise ColumnNotPresentError(not_present)
         return self._get_subset_df_with_schema([col for col in self._dataframe.columns if col not in columns], inplace=inplace)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def rename(self, columns, inplace=False):
         """Renames columns in a DataFrame, maintaining Woodwork typing information.
 
@@ -697,7 +697,7 @@ class WoodworkTableAccessor:
         new_df.ww.init(schema=new_schema)
         return new_df
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def mutual_information_dict(self, num_bins=10, nrows=None, include_index=False, callback=None):
         """
         Calculates mutual information between all pairs of columns in the DataFrame that
@@ -764,7 +764,7 @@ class WoodworkTableAccessor:
         mutual_info = self.mutual_information_dict(num_bins, nrows, include_index, callback)
         return pd.DataFrame(mutual_info)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def describe_dict(self, include=None, callback=None, extra_stats=False, bins=10, top_x=10, recent_x=10):
         """Calculates statistics for data contained in the DataFrame.
 
@@ -845,7 +845,7 @@ class WoodworkTableAccessor:
         ]
         return pd.DataFrame(results).reindex(index_order)
 
-    @_check_schema_init("DataFrame")
+    @_check_schema_init
     def value_counts(self, ascending=False, top_n=10, dropna=False):
         """Returns a list of dictionaries with counts for the most frequent values in each column (only
             for columns with `category` as a standard tag).


### PR DESCRIPTION
- Many methods and attributes in ColumnAccessor and TableAccessor have checks to see if woodwork has been initialized on the dataframe / series.  This PR moves these checks into a decorator.
- Closes #1060
