### PR TITLE
Add 'ignore' and 'passthrough' tags

### DIFF
--- a/docs/source/guides/logical_types_and_semantic_tags.ipynb
+++ b/docs/source/guides/logical_types_and_semantic_tags.ipynb
@@ -81,6 +81,7 @@
     "This section lists any tags that Woodwork will neither add to a DataFrame nor take direct action upon, but that are recognized to have a special meaning.\n",
     "\n",
     "- `'date_of_birth'` - Indicates that a datetime column should be parsed as a date of birth\n",
+    "- `'ignore'`/`'passthrough'` - Indicates that a column should be ignored during feature engineering or model building but should still be passed through these operations so that the column is not lost.\n",
     "\n",
     "Additional tags beyond the ones Woodwork adds at initialization may be useful for a DataFrame's interpretability, so users are encouraged to add any tags that will allow them to use their data more efficiently. \n",
     "\n",

--- a/docs/source/guides/logical_types_and_semantic_tags.ipynb
+++ b/docs/source/guides/logical_types_and_semantic_tags.ipynb
@@ -78,7 +78,7 @@
     "    - A time index column will contain either datetime or numeric data\n",
     "\n",
     "#### Other Tags\n",
-    "This section lists any tags that Woodwork will neither add to a DataFrame nor take direct action upon, but that are recognized to have a special meaning.\n",
+    "The tags listed below may be added directly to columns during or after Woodwork initialization. They are tags that have suggested meanings and that can be added to columns that will be used in the manner described below. Woodwork will neither add them automatically to a DataFrame nor take direct action upon a column if they are present. \n",
     "\n",
     "- `'date_of_birth'` - Indicates that a datetime column should be parsed as a date of birth\n",
     "- `'ignore'`/`'passthrough'` - Indicates that a column should be ignored during feature engineering or model building but should still be passed through these operations so that the column is not lost.\n",

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ===============
-  * Enhancements
-  * Fixes
-  * Changes
-  * Documentation Changes
-  * Testing Changes
+Future Release
+===============
+    * Enhancements
+        * Add ``'passthrough'`` and ``'ignore'`` to tags in ``list_semantic_tags`` (:pr:`1094`)
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`tamargrey`
 
 v0.6.0 Aug 4, 2021
 ==================

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -160,9 +160,12 @@ def test_list_semantic_tags():
 
     assert set(df.columns) == {'name', 'is_standard_tag', 'valid_logical_types'}
 
-    for name, log_type_list in df[['name', 'valid_logical_types']].values:
-        if name not in ['index', 'time_index', 'date_of_birth']:
-            for log_type in log_type_list:
+    for name, valid_ltypes in df[['name', 'valid_logical_types']].values:
+        if name in ['passthrough', 'ignore']:
+            assert valid_ltypes == 'Any LogicalType'
+        elif name not in ['index', 'time_index', 'date_of_birth']:
+            assert isinstance(valid_ltypes, list)
+            for log_type in valid_ltypes:
                 assert name in log_type.standard_tags
 
 

--- a/woodwork/tests/utils/test_utils.py
+++ b/woodwork/tests/utils/test_utils.py
@@ -161,9 +161,9 @@ def test_list_semantic_tags():
     assert set(df.columns) == {'name', 'is_standard_tag', 'valid_logical_types'}
 
     for name, valid_ltypes in df[['name', 'valid_logical_types']].values:
-        if name in ['passthrough', 'ignore']:
+        if name in ['passthrough', 'ignore', 'index']:
             assert valid_ltypes == 'Any LogicalType'
-        elif name not in ['index', 'time_index', 'date_of_birth']:
+        elif name not in ['time_index', 'date_of_birth']:
             assert isinstance(valid_ltypes, list)
             for log_type in valid_ltypes:
                 assert name in log_type.standard_tags

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -111,7 +111,7 @@ def list_semantic_tags():
          for tag in sem_tags]
     )
     tags_df = tags_df.append(
-        pd.DataFrame([['index', False, [ww.type_system.str_to_logical_type(tag) for tag in ['integer', 'double', 'categorical', 'datetime']]],
+        pd.DataFrame([['index', False, 'Any LogicalType'],
                       ['time_index', False, [ww.type_system.str_to_logical_type('datetime')]],
                       ['date_of_birth', False, [ww.type_system.str_to_logical_type('datetime')]],
                       ['ignore', False, 'Any LogicalType'],

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -113,7 +113,9 @@ def list_semantic_tags():
     tags_df = tags_df.append(
         pd.DataFrame([['index', False, [ww.type_system.str_to_logical_type(tag) for tag in ['integer', 'double', 'categorical', 'datetime']]],
                       ['time_index', False, [ww.type_system.str_to_logical_type('datetime')]],
-                      ['date_of_birth', False, [ww.type_system.str_to_logical_type('datetime')]]
+                      ['date_of_birth', False, [ww.type_system.str_to_logical_type('datetime')]],
+                      ['ignore', False, 'Any LogicalType'],
+                      ['passthrough', False, 'Any LogicalType']
                       ], columns=tags_df.columns), ignore_index=True)
     return tags_df
 

--- a/woodwork/type_sys/utils.py
+++ b/woodwork/type_sys/utils.py
@@ -112,7 +112,7 @@ def list_semantic_tags():
     )
     tags_df = tags_df.append(
         pd.DataFrame([['index', False, 'Any LogicalType'],
-                      ['time_index', False, [ww.type_system.str_to_logical_type('datetime')]],
+                      ['time_index', False, [ww.type_system.str_to_logical_type('datetime')] + sem_tags['numeric']],
                       ['date_of_birth', False, [ww.type_system.str_to_logical_type('datetime')]],
                       ['ignore', False, 'Any LogicalType'],
                       ['passthrough', False, 'Any LogicalType']


### PR DESCRIPTION
- Adds `'ignore'` and `'passthrough'` tags to `list_semantic_tags` and update the Understanding Logical Types and Semantic Tags guide to include explanations of them.
- Closes #929 