### PR TITLE
Fixed typo in the "Get Started" documentation

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
     * Fixes
     * Changes
     * Documentation Changes
+        * Fix typo in the "Get Started" documentation (:pr:`1126`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -145,7 +145,7 @@
     "df.ww.set_types(logical_types={\n",
     "    'customer_name': 'PersonFullName',\n",
     "    'country': 'Categorical',\n",
-    "    'order_id': 'Categorical'\n",
+    "    'order_product_id': 'Categorical'\n",
     "})\n",
     "df.ww.types"
    ]


### PR DESCRIPTION
- corrected order_id to order_product_id in start.ipynb
- Closes #1125

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*