### PR TITLE
Update get_invalid_schema_message to prevent nested looping

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,12 +9,13 @@ Future Release
         * Add ``get_valid_mi_columns`` method to list columns that have valid logical types for mutual information calculation (:pr:`1129`)
     * Fixes
     * Changes
+        * Update ``get_invalid_schema_message`` to improve performance (:pr:`1132`)
     * Documentation Changes
         * Fix typo in the "Get Started" documentation (:pr:`1126`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`ajaypallekonda`
+    :user:`ajaypallekonda`, :user:`thehomebrewnerd`
 
 v0.7.1 Aug 25, 2021
 ===================

--- a/woodwork/accessor_utils.py
+++ b/woodwork/accessor_utils.py
@@ -97,12 +97,13 @@ def get_invalid_schema_message(dataframe, schema):
     if schema_cols_not_in_df:
         return f'The following columns in the typing information were missing from the DataFrame: '\
             f'{schema_cols_not_in_df}'
+    logical_types = schema.logical_types
     for name in dataframe.columns:
         df_dtype = dataframe[name].dtype
-        valid_dtype = schema.logical_types[name]._get_valid_dtype(type(dataframe[name]))
+        valid_dtype = logical_types[name]._get_valid_dtype(type(dataframe[name]))
         if str(df_dtype) != valid_dtype:
             return f'dtype mismatch for column {name} between DataFrame dtype, '\
-                f'{df_dtype}, and {schema.logical_types[name]} dtype, {valid_dtype}'
+                f'{df_dtype}, and {logical_types[name]} dtype, {valid_dtype}'
     if schema.index is not None and isinstance(dataframe, pd.DataFrame):
         # Index validation not performed for Dask/Koalas
         if not pd.Series(dataframe.index, dtype=dataframe[schema.index].dtype).equals(pd.Series(dataframe[schema.index].values)):


### PR DESCRIPTION
- Update get_invalid_schema_message to prevent nested looping

Updates the `get_invalid_schema_message` function to remove nested looping that was being caused by calling `schema.logical_types` inside of a for loop looping over all the columns in a dataframe. Moved `schema.logical` types outside of the for loop so it is now only called once.