### PR TITLE
Update Datetime.transform to use default number rows in call to infer_datetime_format

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,20 @@
 
 Release Notes
 -------------
+
+Future Release
+==============
+    * Enhancements
+    * Fixes
+    * Changes
+        * Update ``Datetime.transform`` to use default nrows value when calling ``_infer_datetime_format`` (:pr:`1137`)
+    * Documentation Changes
+    * Testing Changes
+
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
+
 v0.8.0 Sep 9, 2021
 ==================
     * Enhancements

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -199,8 +199,7 @@ class Datetime(LogicalType):
         """Converts the series data to a formatted datetime. Datetime format will be inferred if datetime_format is None."""
         new_dtype = self._get_valid_dtype(type(series))
         if new_dtype != str(series.dtype):
-            sample_length = len(series.index) // 10 or len(series.index)
-            self.datetime_format = self.datetime_format or _infer_datetime_format(series, n=sample_length)
+            self.datetime_format = self.datetime_format or _infer_datetime_format(series)
             try:
                 if _is_dask_series(series):
                     name = series.name


### PR DESCRIPTION
- Update Datetime.transform to use default number rows in call to infer_datetime_format
- Closes #1135 

Update `Datetime.transform` to use default number of rows (100) when inferring the datetime format, instead of the previous approach of using 10% of the rows. This is being done to improve inference performance for datasets with a large number of rows.