### PR TITLE
Restrict pyspark version for now

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Set a maximum version for pyspark until we understand why :pr:`1169` failed (:pr:`1179`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/koalas-requirements.txt
+++ b/koalas-requirements.txt
@@ -1,2 +1,2 @@
-pyspark>=3.0.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
-koalas>=1.8.0 ; python_version!='3.9' # remove once koalas adds python 3.9 support
+pyspark>=3.0.0,<3.2.0
+koalas>=1.8.0


### PR DESCRIPTION
As detailed in #1169 and #1173, updating to the latest pyspark was breaking the tests.  This sets a maximum pyspark version until we figure out those failures.