### PR TITLE
Make box plot low/high indices/values optional to return

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Set a maximum version for pyspark until we understand why :pr:`1169` failed (:pr:`1179`)
         * Require newer dask version (:pr:`1180`)
     * Changes
+        * Make box plot low/high indices/values optional to return in ``box_plot_dict`` (:pr:`1184`)
     * Documentation Changes
         * Update docs dependencies (:pr:`1176`)
     * Testing Changes
@@ -16,7 +17,7 @@ Future Release
         * Updated notebook standardizer to standardize python versions (:pr:`1166`)
 
     Thanks to the following people for contributing to this release:
-    :user:`davesque`, :user:`gsheni`, :user:`bchen1116`, :user:`rwedge`
+    :user:`davesque`, :user:`gsheni`, :user:`bchen1116`, :user:`rwedge`, :user:`tamargrey`
 
 v0.8.2 Oct 12, 2021
 ===================

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -393,7 +393,7 @@ class WoodworkColumnAccessor:
         self._schema._set_semantic_tags(semantic_tags)
 
     @_check_column_schema
-    def box_plot_dict(self, quantiles=None):
+    def box_plot_dict(self, quantiles=None, include_indices_and_values=True):
         """Gets the information necessary to create a box and whisker plot with outliers for a numeric column
         using the IQR method.
 
@@ -401,6 +401,9 @@ class WoodworkColumnAccessor:
             quantiles (dict[float -> float], optional): A dictionary containing the quantiles for the data
                 where the key indicates the quantile, and the value is the quantile's value for the data. If
                 no qantiles are provided, they will be computed from the data.
+            include_indices_and_values (bool, optional): Whether or not the lists containing individual
+                outlier values and their indices will be included in the returned dictionary.
+                Defaults to True.
 
         Note:
             The minimum quantiles necessary for outlier detection using the IQR method are the
@@ -417,12 +420,20 @@ class WoodworkColumnAccessor:
                 - quantiles (list[float]): the quantiles used to determine the bounds.
                     If quantiles were passed in, will contain all quantiles passed in. Otherwise, contains the five
                     quantiles {0.0, 0.25, 0.5, 0.75, 1.0}.
-                - low_values (list[float, int]): the values of the lower outliers
-                - high_values (list[float, int]): the values of the upper outliers
-                - low_indices (list[int]): the corresponding index values for each of the lower outliers
-                - high_indices (list[int]): the corresponding index values for each of the upper outliers
+                - low_values (list[float, int], optional): the values of the lower outliers.
+                    Will not be included if ``include_indices_and_values`` is False.
+                - high_values (list[float, int], optional): the values of the upper outliers
+                    Will not be included if ``include_indices_and_values`` is False.
+                - low_indices (list[int], optional): the corresponding index values for each of the lower outliers
+                    Will not be included if ``include_indices_and_values`` is False.
+                - high_indices (list[int], optional): the corresponding index values for each of the upper outliers
+                    Will not be included if ``include_indices_and_values`` is False.
         """
-        return _get_box_plot_info_for_column(self._series, quantiles=quantiles)
+        box_plot_dict = _get_box_plot_info_for_column(self._series, quantiles=quantiles)
+
+        if not include_indices_and_values:
+            return {key: value for key, value in box_plot_dict.items() if key in ['quantiles', 'high_bound', 'low_bound']}
+        return box_plot_dict
 
 
 def _validate_schema(schema, series):

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -429,11 +429,9 @@ class WoodworkColumnAccessor:
                 - high_indices (list[int], optional): the corresponding index values for each of the upper outliers
                     Will not be included if ``include_indices_and_values`` is False.
         """
-        box_plot_dict = _get_box_plot_info_for_column(self._series, quantiles=quantiles)
-
-        if not include_indices_and_values:
-            return {key: value for key, value in box_plot_dict.items() if key in ['quantiles', 'high_bound', 'low_bound']}
-        return box_plot_dict
+        return _get_box_plot_info_for_column(self._series,
+                                             quantiles=quantiles,
+                                             include_indices_and_values=include_indices_and_values)
 
 
 def _validate_schema(schema, series):

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -429,9 +429,11 @@ class WoodworkColumnAccessor:
                 - high_indices (list[int], optional): the corresponding index values for each of the upper outliers
                     Will not be included if ``include_indices_and_values`` is False.
         """
-        return _get_box_plot_info_for_column(self._series,
-                                             quantiles=quantiles,
-                                             include_indices_and_values=include_indices_and_values)
+        return _get_box_plot_info_for_column(
+            self._series,
+            quantiles=quantiles,
+            include_indices_and_values=include_indices_and_values,
+        )
 
 
 def _validate_schema(schema, series):

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -428,7 +428,9 @@ def _get_value_counts(dataframe, ascending=False, top_n=10, dropna=False):
     return val_counts
 
 
-def _get_box_plot_info_for_column(series, quantiles=None, include_indices_and_values=True):
+def _get_box_plot_info_for_column(
+    series, quantiles=None, include_indices_and_values=True
+):
     """Gets the information necessary to create a box and whisker plot with outliers for a numeric column
         using the IQR method.
 
@@ -483,10 +485,12 @@ def _get_box_plot_info_for_column(series, quantiles=None, include_indices_and_va
     # An empty or fully null Series has no outliers, bounds, or quantiles
     if series.shape[0] == 0:
         if include_indices_and_values:
-            outliers_dict = {"low_values": [],
-                             "high_values": [],
-                             "low_indices": [],
-                             "high_indices": []}
+            outliers_dict = {
+                "low_values": [],
+                "high_values": [],
+                "low_indices": [],
+                "high_indices": [],
+            }
         return {
             "low_bound": np.nan,
             "high_bound": np.nan,
@@ -497,7 +501,7 @@ def _get_box_plot_info_for_column(series, quantiles=None, include_indices_and_va
                 0.75: np.nan,
                 1.0: np.nan,
             },
-            **outliers_dict
+            **outliers_dict,
         }
 
     # calculate the outlier bounds using IQR
@@ -521,7 +525,12 @@ def _get_box_plot_info_for_column(series, quantiles=None, include_indices_and_va
         # identify outliers in the series
         min = quantiles.get(0.0)
         max = quantiles.get(1.0)
-        if min is not None and max is not None and low_bound <= min and high_bound >= max:
+        if (
+            min is not None
+            and max is not None
+            and low_bound <= min
+            and high_bound >= max
+        ):
             outliers_dict = {
                 "low_values": [],
                 "high_values": [],

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -1256,6 +1256,13 @@ def test_box_plot_optional_return_values(outliers_df):
     has_outliers_series = outliers_df["has_outliers"]
     has_outliers_series.ww.init()
 
-    box_plot_info = has_outliers_series.ww.box_plot_dict(include_indices_and_values=False)
+    has_outliers_box_plot_info = has_outliers_series.ww.box_plot_dict(include_indices_and_values=False)
 
-    assert {"low_bound", "high_bound", "quantiles"} == set(box_plot_info.keys())
+    assert {"low_bound", "high_bound", "quantiles"} == set(has_outliers_box_plot_info.keys())
+
+    no_outliers_series = outliers_df["no_outliers"]
+    no_outliers_series.ww.init()
+
+    no_outliers_box_plot_info = no_outliers_series.ww.box_plot_dict(include_indices_and_values=False)
+
+    assert {"low_bound", "high_bound", "quantiles"} == set(no_outliers_box_plot_info.keys())

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -1250,3 +1250,12 @@ def test_box_plot_quantiles_errors(outliers_df):
     error = "quantiles must be a dictionary."
     with pytest.raises(TypeError, match=error):
         series.ww.box_plot_dict(quantiles=1)
+
+
+def test_box_plot_optional_return_values(outliers_df):
+    has_outliers_series = outliers_df["has_outliers"]
+    has_outliers_series.ww.init()
+
+    box_plot_info = has_outliers_series.ww.box_plot_dict(include_indices_and_values=False)
+
+    assert {"low_bound", "high_bound", "quantiles"} == set(box_plot_info.keys())

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -1256,13 +1256,21 @@ def test_box_plot_optional_return_values(outliers_df):
     has_outliers_series = outliers_df["has_outliers"]
     has_outliers_series.ww.init()
 
-    has_outliers_box_plot_info = has_outliers_series.ww.box_plot_dict(include_indices_and_values=False)
+    has_outliers_box_plot_info = has_outliers_series.ww.box_plot_dict(
+        include_indices_and_values=False
+    )
 
-    assert {"low_bound", "high_bound", "quantiles"} == set(has_outliers_box_plot_info.keys())
+    assert {"low_bound", "high_bound", "quantiles"} == set(
+        has_outliers_box_plot_info.keys()
+    )
 
     no_outliers_series = outliers_df["no_outliers"]
     no_outliers_series.ww.init()
 
-    no_outliers_box_plot_info = no_outliers_series.ww.box_plot_dict(include_indices_and_values=False)
+    no_outliers_box_plot_info = no_outliers_series.ww.box_plot_dict(
+        include_indices_and_values=False
+    )
 
-    assert {"low_bound", "high_bound", "quantiles"} == set(no_outliers_box_plot_info.keys())
+    assert {"low_bound", "high_bound", "quantiles"} == set(
+        no_outliers_box_plot_info.keys()
+    )

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -1256,21 +1256,45 @@ def test_box_plot_optional_return_values(outliers_df):
     has_outliers_series = outliers_df["has_outliers"]
     has_outliers_series.ww.init()
 
-    has_outliers_box_plot_info = has_outliers_series.ww.box_plot_dict(
+    has_outliers_box_plot_info_without_optional = has_outliers_series.ww.box_plot_dict(
         include_indices_and_values=False
+    )
+    has_outliers_box_plot_info_with_optional = has_outliers_series.ww.box_plot_dict(
+        include_indices_and_values=True
     )
 
     assert {"low_bound", "high_bound", "quantiles"} == set(
-        has_outliers_box_plot_info.keys()
+        has_outliers_box_plot_info_without_optional.keys()
     )
+    assert {
+        "low_bound",
+        "high_bound",
+        "quantiles",
+        "low_values",
+        "high_values",
+        "low_indices",
+        "high_indices",
+    } == set(has_outliers_box_plot_info_with_optional.keys())
 
     no_outliers_series = outliers_df["no_outliers"]
     no_outliers_series.ww.init()
 
-    no_outliers_box_plot_info = no_outliers_series.ww.box_plot_dict(
+    no_outliers_box_plot_info_without_optional = no_outliers_series.ww.box_plot_dict(
         include_indices_and_values=False
+    )
+    no_outliers_box_plot_info_with_optional = no_outliers_series.ww.box_plot_dict(
+        include_indices_and_values=True
     )
 
     assert {"low_bound", "high_bound", "quantiles"} == set(
-        no_outliers_box_plot_info.keys()
+        no_outliers_box_plot_info_without_optional.keys()
     )
+    assert {
+        "low_bound",
+        "high_bound",
+        "quantiles",
+        "low_values",
+        "high_values",
+        "low_indices",
+        "high_indices",
+    } == set(no_outliers_box_plot_info_with_optional.keys())


### PR DESCRIPTION
- Adds a parameter to `box_plot_dict` that determines whether the lists of outlier values and their indices are included in the returned dictionary
- Closes #1168 