### PR TITLE
Fix mutual_information bug with string index

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Fix bug that causes ``mutual_information`` to fail with certain index types (:pr:`1199`)
     * Changes
         * Update pip to 21.3.1 for test requirements (:pr:`1196`)
     * Documentation Changes
@@ -14,7 +15,7 @@ Future Release
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`thehomebrewnerd`
 
 v0.9.0 Nov 11, 2021
 ===================

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -280,8 +280,9 @@ def _get_mutual_information_dict(
         if type(col.logical_type) in valid_types
     ]
 
-    if not include_index and dataframe.ww.index is not None:
-        valid_columns.remove(dataframe.ww.index)
+    index = dataframe.ww.index
+    if not include_index and index is not None and index in valid_columns:
+        valid_columns.remove(index)
 
     data = dataframe.loc[:, valid_columns]
     if _is_dask_dataframe(data):

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -295,6 +295,23 @@ def test_get_valid_mi_columns_with_index(sample_df):
     assert "id" in mi
 
 
+def test_mutual_info_with_string_index():
+    df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c"],
+            "col1": [1, 2, 3],
+            "col2": [10, 20, 30],
+        }
+    )
+    df.ww.init(index="id", logical_types={"id": "unknown"})
+    mi = df.ww.mutual_information()
+
+    cols_used = set(np.unique(mi[["column_1", "column_2"]].values))
+    assert "id" not in cols_used
+    assert "col1" in cols_used
+    assert "col2" in cols_used
+
+
 def test_get_describe_dict(describe_df):
     describe_df.ww.init(index="index_col")
 


### PR DESCRIPTION
- Fix mutual_information bug with string index
- Closes #1198 

Update so that we only try to remove the index column from the list of valid columns for mutual information if it is present, preventing an error that happened when a string index was used previously.