### PR TITLE
Handle ints represented as doubles in describe_dict with extra stats

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,17 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
+        * Update ``describe_dict`` to compute ``top_values`` for double columns that contain only integer values (:pr:`1206`)
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 v0.9.1 Nov 19, 2021
 ===================

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -2,10 +2,11 @@ from timeit import default_timer as timer
 
 import numpy as np
 import pandas as pd
+from pandas.core.dtypes.common import is_integer_dtype
 from sklearn.metrics.cluster import normalized_mutual_info_score
 
 from woodwork.accessor_utils import _is_dask_dataframe, _is_koalas_dataframe
-from woodwork.logical_types import Datetime, Double, Integer, IntegerNullable, LatLong
+from woodwork.logical_types import Datetime, Double, LatLong
 from woodwork.utils import _update_progress, get_valid_mi_types, import_or_none
 
 dd = import_or_none("dask.dataframe")
@@ -147,14 +148,17 @@ def _get_describe_dict(
         if extra_stats:
             if column.is_numeric:
                 values["histogram"] = _get_histogram_values(series, bins=bins)
-                if isinstance(column.logical_type, (Integer, IntegerNullable)):
-                    _range = range(int(values["min"]), int(values["max"]) + 1)
-                    # Calculate top numeric values if range of values present
-                    # is less than or equal number of histogram bins
-                    if len(_range) <= bins:
-                        values["top_values"] = _get_numeric_value_counts_in_range(
-                            series, _range
-                        )
+                _range = range(int(values["min"]), int(values["max"]) + 1)
+                # Calculate top numeric values if range of values present
+                # is less than or equal number of histogram bins
+                if (
+                    len(_range) <= bins
+                    and values["nunique"] <= bins
+                    and (series % 1 == 0).all()
+                ):
+                    values["top_values"] = _get_numeric_value_counts_in_range(
+                        series, _range
+                    )
             elif column.is_categorical:
                 values["top_values"] = _get_top_values_categorical(series, top_x)
             elif column.is_datetime:
@@ -571,7 +575,11 @@ def _get_numeric_value_counts_in_range(series, _range):
     """
     frequencies = series.value_counts(dropna=True)
     value_counts = [
-        {"value": i, "count": frequencies[i] if i in frequencies else 0} for i in _range
+        {
+            "value": i if is_integer_dtype(series) else float(i),
+            "count": frequencies[i] if i in frequencies else 0,
+        }
+        for i in _range
     ]
     return sorted(value_counts, key=lambda i: (-i["count"], i["value"]))
 

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -147,15 +147,19 @@ def _get_describe_dict(
         # Calculate extra detailed stats, if requested
         if extra_stats:
             if column.is_numeric:
-                values["histogram"] = _get_histogram_values(series, bins=bins)
-                _range = range(int(values["min"]), int(values["max"]) + 1)
-                # Calculate top numeric values if range of values present
-                # is less than or equal number of histogram bins and series
-                # contains only integer values
-                if len(_range) <= bins and (series % 1 == 0).all():
-                    values["top_values"] = _get_numeric_value_counts_in_range(
-                        series, _range
-                    )
+                if pd.isnull(values["max"]) or pd.isnull(values["min"]):
+                    values["histogram"] = []
+                    values["top_values"] = []
+                else:
+                    values["histogram"] = _get_histogram_values(series, bins=bins)
+                    _range = range(int(values["min"]), int(values["max"]) + 1)
+                    # Calculate top numeric values if range of values present
+                    # is less than or equal number of histogram bins and series
+                    # contains only integer values
+                    if len(_range) <= bins and (series % 1 == 0).all():
+                        values["top_values"] = _get_numeric_value_counts_in_range(
+                            series, _range
+                        )
             elif column.is_categorical:
                 values["top_values"] = _get_top_values_categorical(series, top_x)
             elif column.is_datetime:

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -151,10 +151,7 @@ def _get_describe_dict(
                 _range = range(int(values["min"]), int(values["max"]) + 1)
                 # Calculate top numeric values if range of values present
                 # is less than or equal number of histogram bins
-                if (
-                    len(_range) <= bins
-                    and (series % 1 == 0).all()
-                ):
+                if len(_range) <= bins and (series % 1 == 0).all():
                     values["top_values"] = _get_numeric_value_counts_in_range(
                         series, _range
                     )

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -150,7 +150,8 @@ def _get_describe_dict(
                 values["histogram"] = _get_histogram_values(series, bins=bins)
                 _range = range(int(values["min"]), int(values["max"]) + 1)
                 # Calculate top numeric values if range of values present
-                # is less than or equal number of histogram bins
+                # is less than or equal number of histogram bins and series
+                # contains only integer values
                 if len(_range) <= bins and (series % 1 == 0).all():
                     values["top_values"] = _get_numeric_value_counts_in_range(
                         series, _range

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -153,7 +153,6 @@ def _get_describe_dict(
                 # is less than or equal number of histogram bins
                 if (
                     len(_range) <= bins
-                    and values["nunique"] <= bins
                     and (series % 1 == 0).all()
                 ):
                     values["top_values"] = _get_numeric_value_counts_in_range(

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -833,6 +833,12 @@ def test_describe_dict_extra_stats(describe_df):
     describe_df["nullable_integer_col"] = describe_df["numeric_col"]
     describe_df["integer_col"] = describe_df["numeric_col"].fillna(0)
     describe_df["small_range_col"] = describe_df["numeric_col"].fillna(0) // 10
+    describe_df["small_range_col_ints_as_double"] = (
+        describe_df["numeric_col"].fillna(0) // 10.0
+    )
+    describe_df["small_range_col_double_not_valid"] = (
+        describe_df["numeric_col"].fillna(0) / 10
+    )
 
     ltypes = {
         "category_col": "Categorical",
@@ -841,6 +847,8 @@ def test_describe_dict_extra_stats(describe_df):
         "nullable_integer_col": "IntegerNullable",
         "integer_col": "Integer",
         "small_range_col": "Integer",
+        "small_range_col_ints_as_double": "Double",
+        "small_range_col_double_not_valid": "Double",
     }
     describe_df.ww.init(index="index_col", logical_types=ltypes)
     desc_dict = describe_df.ww.describe_dict(extra_stats=True)
@@ -861,10 +869,12 @@ def test_describe_dict_extra_stats(describe_df):
         "nullable_integer_col",
         "integer_col",
         "small_range_col",
+        "small_range_col_ints_as_double",
+        "small_range_col_double_not_valid",
     ]:
         assert isinstance(desc_dict[col]["histogram"], list)
         assert desc_dict[col].get("recent_values") is None
-        if col == "small_range_col":
+        if col in {"small_range_col", "small_range_col_ints_as_double"}:
             # If values are in a narrow range, top values should be present
             assert isinstance(desc_dict[col]["top_values"], list)
         else:

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -766,7 +766,7 @@ def test_describe_with_include(sample_df):
 def test_describe_numeric_all_nans():
     df = pd.DataFrame({"nulls": [np.nan] * 5})
     logical_types = ["double", "integer_nullable"]
-    
+
     for logical_type in logical_types:
         df.ww.init(logical_types={"nulls": logical_type})
         stats = df.ww.describe_dict(extra_stats=True)

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -765,16 +765,18 @@ def test_describe_with_include(sample_df):
 
 def test_describe_numeric_all_nans():
     df = pd.DataFrame({"float": [np.nan] * 5})
-    df.ww.init(logical_types={"float": "double"})
-
-    stats = df.ww.describe_dict(extra_stats=True)
-    assert pd.isnull(stats["float"]["max"])
-    assert pd.isnull(stats["float"]["min"])
-    assert pd.isnull(stats["float"]["mean"])
-    assert pd.isnull(stats["float"]["std"])
-    assert stats["float"]["nan_count"] == 5
-    assert stats["float"]["histogram"] == []
-    assert stats["float"]["top_values"] == []
+    logical_types = ["double", "integer_nullable"]
+    
+    for logical_type in logical_types:
+        df.ww.init(logical_types={"float": logical_type})
+        stats = df.ww.describe_dict(extra_stats=True)
+        assert pd.isnull(stats["float"]["max"])
+        assert pd.isnull(stats["float"]["min"])
+        assert pd.isnull(stats["float"]["mean"])
+        assert pd.isnull(stats["float"]["std"])
+        assert stats["float"]["nan_count"] == 5
+        assert stats["float"]["histogram"] == []
+        assert stats["float"]["top_values"] == []
 
 
 def test_pandas_nullable_integer_quantile_fix():

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -764,19 +764,19 @@ def test_describe_with_include(sample_df):
 
 
 def test_describe_numeric_all_nans():
-    df = pd.DataFrame({"float": [np.nan] * 5})
+    df = pd.DataFrame({"nulls": [np.nan] * 5})
     logical_types = ["double", "integer_nullable"]
     
     for logical_type in logical_types:
-        df.ww.init(logical_types={"float": logical_type})
+        df.ww.init(logical_types={"nulls": logical_type})
         stats = df.ww.describe_dict(extra_stats=True)
-        assert pd.isnull(stats["float"]["max"])
-        assert pd.isnull(stats["float"]["min"])
-        assert pd.isnull(stats["float"]["mean"])
-        assert pd.isnull(stats["float"]["std"])
-        assert stats["float"]["nan_count"] == 5
-        assert stats["float"]["histogram"] == []
-        assert stats["float"]["top_values"] == []
+        assert pd.isnull(stats["nulls"]["max"])
+        assert pd.isnull(stats["nulls"]["min"])
+        assert pd.isnull(stats["nulls"]["mean"])
+        assert pd.isnull(stats["nulls"]["std"])
+        assert stats["nulls"]["nan_count"] == 5
+        assert stats["nulls"]["histogram"] == []
+        assert stats["nulls"]["top_values"] == []
 
 
 def test_pandas_nullable_integer_quantile_fix():

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -763,6 +763,20 @@ def test_describe_with_include(sample_df):
     multi_params_df["full_name"].equals(sample_df.ww.describe()["full_name"])
 
 
+def test_describe_numeric_all_nans():
+    df = pd.DataFrame({"float": [np.nan] * 5})
+    df.ww.init(logical_types={"float": "double"})
+
+    stats = df.ww.describe_dict(extra_stats=True)
+    assert pd.isnull(stats["float"]["max"])
+    assert pd.isnull(stats["float"]["min"])
+    assert pd.isnull(stats["float"]["mean"])
+    assert pd.isnull(stats["float"]["std"])
+    assert stats["float"]["nan_count"] == 5
+    assert stats["float"]["histogram"] == []
+    assert stats["float"]["top_values"] == []
+
+
 def test_pandas_nullable_integer_quantile_fix():
     """Should fail when https://github.com/pandas-dev/pandas/issues/42626 gets fixed"""
     if pd.__version__ not in ["1.3.0", "1.3.1"]:  # pragma: no cover


### PR DESCRIPTION
- Handle ints represented as doubles in describe extra stats
- Closes #1203 

Updates `df.ww.describe_dict` to compute `top_values` for integers stored as doubles. Top values will be computed for double columns if the range of values is less than or equal to the number of histogram bins and all of the numbers are actually integers, just stored as floats.