### PR TITLE
Return histogram bins as list of floats instead of a pd.Interval object

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,7 +7,7 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
-        * Return histogram bins a a list of floats instead of a ``pandas.Interval`` object (:pr:`1207`)
+        * Return histogram bins as a list of floats instead of a ``pandas.Interval`` object (:pr:`1207`)
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,10 +17,10 @@ Future Release
 Breaking Changes
 ++++++++++++++++
     * :pr:``1207``: The behavior of ``describe_dict`` has changed when using
-    ``extra_stats=True``. Previously, the histogram bins were returned as
-    ``pandas.Interval`` objects. This has been updated so that the histogram
-    bins are now represented as a two-element list of floats with the first element
-    being the left edge of the bin and the second element being the right edge.
+      ``extra_stats=True``. Previously, the histogram bins were returned as
+      ``pandas.Interval`` objects. This has been updated so that the histogram
+      bins are now represented as a two-element list of floats with the first element
+      being the left edge of the bin and the second element being the right edge.
 
 v0.9.1 Nov 19, 2021
 ===================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,25 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Return histogram bins a a list of floats instead of a ``pandas.Interval`` object (:pr:`1207`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
+Breaking Changes
+++++++++++++++++
+    * :pr:``1207``: The behavior of ``describe_dict`` has changed when using
+    ``extra_stats=True``. Previously, the histogram bins were returned as
+    ``pandas.Interval`` objects. This has been updated so that the histogram
+    bins are now represented as a two-element list of floats with the first element
+    being the left edge of the bin and the second element being the right edge.
 
 v0.9.1 Nov 19, 2021
 ===================

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -630,4 +630,13 @@ def _get_histogram_values(series, bins=10):
     values = pd.cut(series, bins=bins, duplicates="drop").value_counts().sort_index()
     df = values.reset_index()
     df.columns = ["bins", "frequency"]
-    return list(df.to_dict(orient="index").values())
+    results = []
+    for _, row in df.iterrows():
+        results.append(
+            {
+                "bins": [row["bins"].left, row["bins"].right],
+                "frequency": row["frequency"],
+            }
+        )
+
+    return results

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -959,6 +959,9 @@ def test_numeric_histogram():
     total = 0
     for info in values:
         assert "bins" in info
+        assert len(info["bins"]) == 2
+        assert isinstance(info["bins"][0], float)
+        assert isinstance(info["bins"][1], float)
         assert "frequency" in info
         freq = info["frequency"]
         total += freq


### PR DESCRIPTION
- Return histogram bins as list of floats
- Closes #1204 

Updates the `bins` returned by `_get_histogram_values` to be a 2 element list of floats representing the bin edges instead of the `pd.Interval` object that was returned previously.