### PR TITLE
Update auto approve workflow schedule, and use PR number

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -1,7 +1,8 @@
 name: Auto Approve Dependency PRs
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,22 +11,27 @@ jobs:
       - name: Find dependency PRs
         id: find_prs
         run: |
+          gh auth status
           rm -f dep_PRs_waiting_approval.json
-          gh pr list --repo "${{ github.repository }}" --author "machineFL" --base main --state open --search "status:success review:required" --limit 1 --json url > dep_PRs_waiting_approval.json
-          echo ::set-output name=dep_pull_request_url::$(cat dep_PRs_waiting_approval.json | grep -Eo "(https)://[a-zA-Z0-9./?=_%:-]*")
+          gh pr list --repo "${{ github.repository }}" --author "machineFL" --base main --state open --search "status:success review:required" --limit 1 --json number > dep_PRs_waiting_approval.json
+          cat dep_PRs_waiting_approval.json
+          dep_pull_request=$(cat dep_PRs_waiting_approval.json | grep -Eo "[0-9]*")
+          echo $dep_pull_request
+          echo ::set-output name=dep_pull_request::${dep_pull_request}
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
       - name: Approve dependency PRs and enable auto-merge
         id: approve_prs
         if: >-
           ${{
-            steps.find_prs.outputs.dep_pull_request_url != '' &&
-            contains( steps.find_prs.outputs.dep_pull_request_url, 'https://github.com/alteryx/woodwork/pull/')
+            steps.find_prs.outputs.dep_pull_request != '' &&
+            steps.find_prs.outputs.dep_pull_request != null &&
+            steps.find_prs.outputs.dep_pull_request > 1
           }}
         run: |
-          echo ${{ steps.find_prs.outputs.dep_pull_request_url }}
-          gh pr review --repo "${{ github.repository }}" --comment --body "auto approve" ${{ steps.find_prs.outputs.dep_pull_request_url }}
-          gh pr review --repo "${{ github.repository }}" --approve ${{ steps.find_prs.outputs.dep_pull_request_url }}
-          gh pr merge --repo "${{ github.repository }}" --auto --squash ${{ steps.find_prs.outputs.dep_pull_request_url }}
+          echo ${{ steps.find_prs.outputs.dep_pull_request }}
+          gh pr review --repo "${{ github.repository }}" --comment --body "auto approve" ${{ steps.find_prs.outputs.dep_pull_request }}
+          gh pr review --repo "${{ github.repository }}" --approve ${{ steps.find_prs.outputs.dep_pull_request }}
+          gh pr merge --repo "${{ github.repository }}" --auto --squash ${{ steps.find_prs.outputs.dep_pull_request }}
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -5,6 +5,7 @@ name: Latest Dependency Checker
 on:
   schedule:
     - cron: '0 * * * *'
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 name: Unit Tests - Latest Dependencies
 jobs:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
     * Changes
     * Documentation Changes
     * Testing Changes
-        * Change auto approve workfow to use PR number (:pr:`1240`)
+        * Change auto approve workfow to use PR number and run every 30 minutes (:pr:`1240`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Change auto approve workfow to use PR number (:pr:`1240`)
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`gsheni`
 
 v0.11.1 Jan 4, 2022
 ===================


### PR DESCRIPTION
- Changed auto approve to run every 30 minutes, rather than once every hour
- Use PR number rather than URL for auto approve workflow
- Added **workflow_dispatch** so unit tests, latest dep check, and auto approve can be kickoff off manually.