### PR TITLE
[DO NOT MERGE] Add df.ww.to_parquet method to serialize to a single file

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -40,6 +40,7 @@ WoodworkTableAccessor
     WoodworkTableAccessor.time_index
     WoodworkTableAccessor.to_disk
     WoodworkTableAccessor.to_dictionary
+    WoodworkTableAccessor.to_parquet
     WoodworkTableAccessor.types
     WoodworkTableAccessor.use_standard_tags
     WoodworkTableAccessor.value_counts
@@ -128,6 +129,7 @@ Deserialization
 .. autosummary::
     :toctree: generated/
 
+    read_parquet
     read_table_typing_information
     read_woodwork_table
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,7 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Add Slack link to GitHub issue creation templates (:pr:`1242`)
-        * Add ``df.ww.to_parquet`` and ``ww.read_parquet`` methods to read/write a Woodwork table to a single parquet file (:pr:`968`)
+        * Add ``df.ww.to_parquet`` and ``ww.read_parquet`` methods to read/write a Woodwork table to a single parquet file (:pr:`1243`)
     * Fixes
     * Changes
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,7 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Add Slack link to GitHub issue creation templates (:pr:`1242`)
-        * Add ``df.ww.to_parquet`` and ``ww.read_parquet`` methods to read/write a Woodwork table to a single parquet file (:pr:`1243`)
+        * Add ``df.ww.to_parquet`` and ``ww.read_parquet`` methods to read/write a Woodwork table to/from a single parquet file (:pr:`1243`)
     * Fixes
     * Changes
         * Prevent setting index that contains null values (:pr:`1239`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Add Slack link to GitHub issue creation templates (:pr:`1242`)
+        * Add ``df.ww.to_parquet`` and ``ww.read_parquet`` methods to read/write a Woodwork table to a single parquet file (:pr:`968`)
     * Fixes
     * Changes
     * Documentation Changes
@@ -15,7 +16,7 @@ Future Release
         * Fix permissions issue with S3 deserialization test (:pr:`1238`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`
+    :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`
 
 v0.11.1 Jan 4, 2022
 ===================

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -2,6 +2,7 @@
 import pkg_resources
 
 from .config import config
+from .deserialize import read_parquet_file
 from .type_sys import type_system
 from .type_sys.utils import list_logical_types, list_semantic_tags
 from .utils import concat_columns, read_file

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -2,7 +2,7 @@
 import pkg_resources
 
 from .config import config
-from .deserialize import read_parquet_file
+from .deserialize import read_parquet
 from .type_sys import type_system
 from .type_sys.utils import list_logical_types, list_semantic_tags
 from .utils import concat_columns, read_file

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -231,15 +231,15 @@ def _typing_info_to_init_params(typing_info):
 
 def read_parquet(path, filename, lib="pandas"):
     """
-    Read data from the parquet file at the location specified by `path`
-    with the filename specified by `filename`. Will initialize Woodwork using
+    Read data from the parquet file at the location specified by ``path``
+    with the filename specified by ``filename``. Will initialize Woodwork using
     the typing information stored in the parquet file metadata. If typing info
     is not present, will initialize Woodwork without any arguments.
 
     Args:
         path (str): Location on disk to read from.
         filename (str): Name of file to read. Will be ignored if reading dataframe with Dask.
-        lib (str): Name of library to use for reading data. Defaults to pandas.
+        lib (str): Name of library to use for reading data. Defaults to ``pandas``.
             Should be one of ["pandas", "dask"]
     """
     import pyarrow as pa

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -217,7 +217,7 @@ def _check_schema_version(saved_version_str):
         )
 
 
-def read_parquet_file(filepath):
+def read_parquet(filepath):
     """Read data from the specified parquet file and initialize Woodwork using
     the typing information stored in the parquet file metadata."""
     import pyarrow as pa

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -265,7 +265,7 @@ def read_parquet(path, filename, lib="pandas", profile_name=None):
         dataframe = pd.read_parquet(filepath)
         file_metadata = pa.parquet.read_metadata(filepath)
 
-    ww_metadata = file_metadata.metadata.get(str.encode(METADATA_KEY))
+    ww_metadata = file_metadata.metadata.get(METADATA_KEY)
     init_params = {}
     validate = True
     if ww_metadata is not None:

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -249,12 +249,12 @@ def read_parquet(path, filename, lib="pandas"):
         # Read the metadata from the first parquet file in the directory
         meta_filepath = glob.glob(os.path.join(path, "*.parquet"))[0]
         file_metadata = pa.parquet.read_metadata(meta_filepath)
-    elif lib == "koalas":
-        filepath = os.path.join(path, "*.parquet")
-        dataframe = ks.read_parquet(filepath)
-        # Read the metadata from the first parquet file in the directory
-        meta_filepath = glob.glob(filepath)[0]
-        file_metadata = pa.parquet.read_metadata(meta_filepath)
+    # elif lib == "koalas":
+    #     filepath = os.path.join(path, "*.parquet")
+    #     dataframe = ks.read_parquet(filepath)
+    #     # Read the metadata from the first parquet file in the directory
+    #     meta_filepath = glob.glob(filepath)[0]
+    #     file_metadata = pa.parquet.read_metadata(meta_filepath)
     else:
         filepath = os.path.join(path, filename)
         dataframe = pd.read_parquet(filepath)

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -57,35 +57,10 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
     kwargs = loading_info.get("params", {})
     table_type = loading_info.get("table_type", "pandas")
 
-    logical_types = {}
-    semantic_tags = {}
-    column_descriptions = {}
-    column_origins = {}
-    column_metadata = {}
-    use_standard_tags = {}
     column_dtypes = {}
     for col in table_typing_info["column_typing_info"]:
         col_name = col["name"]
-
-        ltype_metadata = col["logical_type"]
-        ltype = ww.type_system.str_to_logical_type(
-            ltype_metadata["type"], params=ltype_metadata["parameters"]
-        )
-
-        tags = col["semantic_tags"]
-
-        if "index" in tags:
-            tags.remove("index")
-        elif "time_index" in tags:
-            tags.remove("time_index")
-
-        logical_types[col_name] = ltype
-        semantic_tags[col_name] = tags
-        column_descriptions[col_name] = col["description"]
-        column_origins[col_name] = col["origin"]
-        column_metadata[col_name] = col["metadata"]
-        use_standard_tags[col_name] = col["use_standard_tags"]
-
+        
         col_type = col["physical_type"]["type"]
         if col_type == "category":
             # Make sure categories are recreated properly
@@ -135,19 +110,8 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
     elif load_format == "orc":
         dataframe = lib.read_orc(file)
 
-    dataframe.ww.init(
-        name=table_typing_info.get("name"),
-        index=table_typing_info.get("index"),
-        time_index=table_typing_info.get("time_index"),
-        logical_types=logical_types,
-        semantic_tags=semantic_tags,
-        use_standard_tags=use_standard_tags,
-        table_metadata=table_typing_info.get("table_metadata"),
-        column_metadata=column_metadata,
-        column_descriptions=column_descriptions,
-        column_origins=column_origins,
-        validate=validate,
-    )
+    init_params = _typing_info_to_init_params(table_typing_info)
+    dataframe.ww.init(**init_params, validate=validate)
 
     return dataframe
 
@@ -217,26 +181,16 @@ def _check_schema_version(saved_version_str):
         )
 
 
-def read_parquet(filepath):
-    """Read data from the specified parquet file and initialize Woodwork using
-    the typing information stored in the parquet file metadata."""
-    import pyarrow as pa
-
-    dataframe = pd.read_parquet(filepath)
-    file_metadata = pa.parquet.read_metadata(filepath)
-    table_typing_info = json.loads(file_metadata.metadata[b"woodwork_metadata"])
-
-    loading_info = table_typing_info["loading_info"]
-    table_type = loading_info.get("table_type", "pandas")
-
+def _typing_info_to_init_params(typing_info):
+    """Take table typing info created from the `typing_info_to_dict` function and extract
+    parameters that can be used to initialize Woodwork."""
     logical_types = {}
     semantic_tags = {}
     column_descriptions = {}
     column_origins = {}
     column_metadata = {}
     use_standard_tags = {}
-    column_dtypes = {}
-    for col in table_typing_info["column_typing_info"]:
+    for col in typing_info["column_typing_info"]:
         col_name = col["name"]
 
         ltype_metadata = col["logical_type"]
@@ -258,30 +212,31 @@ def read_parquet(filepath):
         column_metadata[col_name] = col["metadata"]
         use_standard_tags[col_name] = col["use_standard_tags"]
 
-        col_type = col["physical_type"]["type"]
-        if col_type == "category":
-            # Make sure categories are recreated properly
-            cat_values = col["physical_type"]["cat_values"]
-            cat_dtype = col["physical_type"]["cat_dtype"]
-            if table_type == "pandas":
-                cat_object = pd.CategoricalDtype(pd.Index(cat_values, dtype=cat_dtype))
-            else:
-                cat_object = pd.CategoricalDtype(pd.Series(cat_values))
-            col_type = cat_object
-        column_dtypes[col_name] = col_type
+    return {
+        "name": typing_info.get("name"),
+        "index": typing_info.get("index"),
+        "time_index": typing_info.get("time_index"),
+        "logical_types": logical_types,
+        "semantic_tags": semantic_tags,
+        "column_descriptions": column_descriptions,
+        "column_origins": column_origins,
+        "table_metadata": typing_info.get("table_metadata"),
+        "column_metadata": column_metadata,
+        "use_standard_tags": use_standard_tags,
+    }
 
-    dataframe.ww.init(
-        name=table_typing_info.get("name"),
-        index=table_typing_info.get("index"),
-        time_index=table_typing_info.get("time_index"),
-        logical_types=logical_types,
-        semantic_tags=semantic_tags,
-        use_standard_tags=use_standard_tags,
-        table_metadata=table_typing_info.get("table_metadata"),
-        column_metadata=column_metadata,
-        column_descriptions=column_descriptions,
-        column_origins=column_origins,
-        validate=False,
-    )
+
+def read_parquet(filepath):
+    """Read data from the specified parquet file and initialize Woodwork using
+    the typing information stored in the parquet file metadata."""
+    import pyarrow as pa
+
+    dataframe = pd.read_parquet(filepath)
+    file_metadata = pa.parquet.read_metadata(filepath)
+    table_typing_info = json.loads(file_metadata.metadata[b"woodwork_metadata"])
+
+    init_params = _typing_info_to_init_params(table_typing_info)
+
+    dataframe.ww.init(**init_params, validate=False)
 
     return dataframe

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -7,14 +7,15 @@ import warnings
 from itertools import zip_longest
 from pathlib import Path
 
-import dask.dataframe as dd
 import pandas as pd
 
 import woodwork as ww
 from woodwork.exceptions import OutdatedSchemaWarning, UpgradeSchemaWarning
 from woodwork.s3_utils import get_transport_params, use_smartopen
 from woodwork.serialize import FORMATS, SCHEMA_VERSION
-from woodwork.utils import _is_s3, _is_url, import_or_raise
+from woodwork.utils import _is_s3, _is_url, import_or_none, import_or_raise
+
+dd = import_or_none("dask.dataframe")
 
 
 def read_table_typing_information(path):

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -16,7 +16,6 @@ from woodwork.serialize import FORMATS, SCHEMA_VERSION
 from woodwork.utils import _is_s3, _is_url, import_or_none, import_or_raise
 
 dd = import_or_none("dask.dataframe")
-ks = import_or_none("databricks.koalas")
 
 
 def read_table_typing_information(path):

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -232,7 +232,7 @@ def _typing_info_to_init_params(typing_info):
 def read_parquet(path, filename, lib="pandas"):
     """
     Read data from the parquet file at the location specified by `path`
-    with the filename specified by `filename. Will initialize Woodwork using
+    with the filename specified by `filename`. Will initialize Woodwork using
     the typing information stored in the parquet file metadata, if present.
 
     Args:

--- a/woodwork/deserialize.py
+++ b/woodwork/deserialize.py
@@ -60,7 +60,7 @@ def _typing_information_to_woodwork_table(table_typing_info, validate, **kwargs)
     column_dtypes = {}
     for col in table_typing_info["column_typing_info"]:
         col_name = col["name"]
-        
+
         col_type = col["physical_type"]["type"]
         if col_type == "category":
             # Make sure categories are recreated properly

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -236,18 +236,6 @@ def _save_parquet_file(dataframe, path, filename):
     if _is_dask_dataframe(dataframe):
         ww_metadata = {"woodwork_metadata": json.dumps(ww_typing)}
         dataframe.to_parquet(path, custom_metadata=ww_metadata)
-    # elif _is_koalas_dataframe(dataframe):
-    #     dataframe.to_parquet(path)
-    #     parquet_files = glob.glob(os.path.join(path, "*.parquet"))
-    #     for parquet_file in parquet_files:
-    #         table = pq.read_table(parquet_file)
-    #         table_meta = table.schema.metadata
-    #         combined_metadata = {
-    #             "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
-    #             **table_meta,
-    #         }
-    #         table = table.replace_schema_metadata(combined_metadata)
-    #         pq.write_table(table, parquet_file)
     else:
         table = pa.Table.from_pandas(dataframe)
         table_meta = table.schema.metadata

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -14,7 +14,7 @@ from woodwork.utils import _is_s3, _is_url
 
 SCHEMA_VERSION = "11.3.0"
 FORMATS = ["csv", "pickle", "parquet", "arrow", "feather", "orc"]
-METADATA_KEY = "_woodwork_metadata"
+METADATA_KEY = b"_woodwork_metadata"
 
 
 def typing_info_to_dict(dataframe):
@@ -241,12 +241,9 @@ def _save_parquet_file(dataframe, path, filename, profile_name):
         if filename is None:
             filename = "data.parquet"
         table = pa.Table.from_pandas(dataframe)
-        table_meta = table.schema.metadata
-        combined_metadata = {
-            METADATA_KEY.encode(): json.dumps(ww_typing).encode(),
-            **table_meta,
-        }
-        table = table.replace_schema_metadata(combined_metadata)
+        new_metadata = table.schema.metadata
+        new_metadata[METADATA_KEY] = json.dumps(ww_typing).encode()
+        table = table.replace_schema_metadata(new_metadata)
 
         if _is_s3(path):
             with tempfile.TemporaryDirectory() as tmpdir:

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -225,30 +225,26 @@ def save_orc_file(dataframe, filepath):
     orc.write_table(pa_table, filepath)
 
 
-def save_parquet_file(dataframe, path, filename, profile_name, **kwargs):
+def _save_parquet_file(dataframe, path, filename):
     """Write a Woodwork dataframe to disk, saving typing information in
     the parquet file metadata."""
     import pyarrow as pa
     import pyarrow.parquet as pq
 
-    table = pa.Table.from_pandas(dataframe)
-    table_meta = table.schema.metadata
     ww_typing = typing_info_to_dict(dataframe)
-    combined_metadata = {
-        "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
-        **table_meta,
-    }
-    table = table.replace_schema_metadata(combined_metadata)
 
-    if _is_s3(path):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            local_filepath = os.path.join(tmpdir, filename)
-            pq.write_table(table, local_filepath)
-
-            transport_params = get_transport_params(profile_name)
-            use_smartopen(
-                local_filepath, path, read=False, transport_params=transport_params
-            )
+    if _is_dask_dataframe(dataframe):
+        ww_metadata = {"woodwork_metadata": json.dumps(ww_typing)}
+        dataframe.to_parquet(path, custom_metadata=ww_metadata)
     else:
+        table = pa.Table.from_pandas(dataframe)
+        table_meta = table.schema.metadata
+        combined_metadata = {
+            "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
+            **table_meta,
+        }
+        table = table.replace_schema_metadata(combined_metadata)
+        if filename is None:
+            filename = "data.parquet"
         filepath = os.path.join(path, filename)
         pq.write_table(table, filepath)

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -1,5 +1,4 @@
 import datetime
-import glob
 import json
 import os
 import tarfile
@@ -237,19 +236,18 @@ def _save_parquet_file(dataframe, path, filename):
     if _is_dask_dataframe(dataframe):
         ww_metadata = {"woodwork_metadata": json.dumps(ww_typing)}
         dataframe.to_parquet(path, custom_metadata=ww_metadata)
-    elif _is_koalas_dataframe(dataframe):
-        dataframe.to_parquet(path)
-        breakpoint()
-        parquet_files = glob.glob(os.path.join(path, "*.parquet"))
-        for parquet_file in parquet_files:
-            table = pq.read_table(parquet_file)
-            table_meta = table.schema.metadata
-            combined_metadata = {
-                "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
-                **table_meta,
-            }
-            table = table.replace_schema_metadata(combined_metadata)
-            pq.write_table(table, parquet_file)
+    # elif _is_koalas_dataframe(dataframe):
+    #     dataframe.to_parquet(path)
+    #     parquet_files = glob.glob(os.path.join(path, "*.parquet"))
+    #     for parquet_file in parquet_files:
+    #         table = pq.read_table(parquet_file)
+    #         table_meta = table.schema.metadata
+    #         combined_metadata = {
+    #             "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
+    #             **table_meta,
+    #         }
+    #         table = table.replace_schema_metadata(combined_metadata)
+    #         pq.write_table(table, parquet_file)
     else:
         table = pa.Table.from_pandas(dataframe)
         table_meta = table.schema.metadata

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -1,4 +1,5 @@
 import datetime
+import glob
 import json
 import os
 import tarfile
@@ -236,6 +237,19 @@ def _save_parquet_file(dataframe, path, filename):
     if _is_dask_dataframe(dataframe):
         ww_metadata = {"woodwork_metadata": json.dumps(ww_typing)}
         dataframe.to_parquet(path, custom_metadata=ww_metadata)
+    elif _is_koalas_dataframe(dataframe):
+        dataframe.to_parquet(path)
+        breakpoint()
+        parquet_files = glob.glob(os.path.join(path, "*.parquet"))
+        for parquet_file in parquet_files:
+            table = pq.read_table(parquet_file)
+            table_meta = table.schema.metadata
+            combined_metadata = {
+                "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
+                **table_meta,
+            }
+            table = table.replace_schema_metadata(combined_metadata)
+            pq.write_table(table, parquet_file)
     else:
         table = pa.Table.from_pandas(dataframe)
         table_meta = table.schema.metadata

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -14,6 +14,7 @@ from woodwork.utils import _is_s3, _is_url
 
 SCHEMA_VERSION = "11.3.0"
 FORMATS = ["csv", "pickle", "parquet", "arrow", "feather", "orc"]
+METADATA_KEY = "_woodwork_metadata"
 
 
 def typing_info_to_dict(dataframe):
@@ -234,7 +235,7 @@ def _save_parquet_file(dataframe, path, filename, profile_name):
     ww_typing = typing_info_to_dict(dataframe)
 
     if _is_dask_dataframe(dataframe):
-        ww_metadata = {"woodwork_metadata": json.dumps(ww_typing)}
+        ww_metadata = {METADATA_KEY: json.dumps(ww_typing)}
         dataframe.to_parquet(path, custom_metadata=ww_metadata)
     else:
         if filename is None:
@@ -242,7 +243,7 @@ def _save_parquet_file(dataframe, path, filename, profile_name):
         table = pa.Table.from_pandas(dataframe)
         table_meta = table.schema.metadata
         combined_metadata = {
-            "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
+            METADATA_KEY.encode(): json.dumps(ww_typing).encode(),
             **table_meta,
         }
         table = table.replace_schema_metadata(combined_metadata)

--- a/woodwork/serialize.py
+++ b/woodwork/serialize.py
@@ -223,3 +223,21 @@ def save_orc_file(dataframe, filepath):
             df[c] = df[c].astype("string")
     pa_table = Table.from_pandas(df, preserve_index=False)
     orc.write_table(pa_table, filepath)
+
+
+def save_parquet_file(dataframe, filepath):
+    """Write a Woodwork dataframe to disk, saving typing information in
+    the parquet file metadata."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.Table.from_pandas(dataframe)
+    table_meta = table.schema.metadata
+    ww_typing = typing_info_to_dict(dataframe)
+    combined_metadata = {
+        "woodwork_metadata".encode(): json.dumps(ww_typing).encode(),
+        **table_meta,
+    }
+    table = table.replace_schema_metadata(combined_metadata)
+
+    pq.write_table(table, filepath)

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -681,6 +681,27 @@ class WoodworkTableAccessor:
             **kwargs,
         )
 
+    @_check_table_schema
+    def to_parquet(self, filepath, profile_name=None, **kwargs):
+        """Write Woodwork table to disk as a parquet file at the location specified by `path`, with
+        the file name specified by `filename`. All Woodwork typing information will be stored in the
+        parquet file metadata.
+
+
+        Note:
+            As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used.
+
+        Args:
+            filepath (str) : Location on disk to write to, including filename. Path can be a local path or an S3 path.
+            profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
+            kwargs (keywords) : Additional keyword arguments to specify AWS profile.
+        """
+        serialize.save_parquet_file(
+            self._dataframe,
+            filepath,
+            **kwargs,
+        )
+
     def _sort_columns(self, already_sorted):
         if _is_dask_dataframe(self._dataframe) or _is_koalas_dataframe(self._dataframe):
             already_sorted = True  # Skip sorting for Dask and Koalas input

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -688,7 +688,9 @@ class WoodworkTableAccessor:
         parquet file metadata. Only supported for pandas and Dask DataFrames.
 
         Note:
-            As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used.
+            As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used. Also,
+            users should take care if modifying the parquet file metadata, as changes to the information
+            written by Woodwork could prevent the data from being deserialized correctly.
 
         Args:
             path (str): Location on disk to write to.

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -683,8 +683,8 @@ class WoodworkTableAccessor:
 
     @_check_table_schema
     def to_parquet(self, path, filename=None):
-        """Write Woodwork table to disk as a parquet file at the location specified by `path`, with
-        the filename specified by `filename`. All Woodwork typing information will be stored in the
+        """Write Woodwork table to disk as a parquet file at the location specified by ``path``, with
+        the filename specified by ``filename``. All Woodwork typing information will be stored in the
         parquet file metadata. Only supported for pandas and Dask DataFrames.
 
         Note:
@@ -693,7 +693,7 @@ class WoodworkTableAccessor:
         Args:
             path (str): Location on disk to write to.
             filename (str): Name of file to write. Optional for Dask dataframes, and will be ignored if provided.
-                Defaults to `data.parquet` if not specified for pandas dataframes.
+                Defaults to ``data.parquet`` if not specified for pandas dataframes.
         """
         serialize._save_parquet_file(self._dataframe, path, filename)
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -684,7 +684,7 @@ class WoodworkTableAccessor:
     @_check_table_schema
     def to_parquet(self, path, filename=None):
         """Write Woodwork table to disk as a parquet file at the location specified by `path`, with
-        the file name specified by `filename`. All Woodwork typing information will be stored in the
+        the filename specified by `filename`. All Woodwork typing information will be stored in the
         parquet file metadata. Only supported for pandas and Dask DataFrames.
 
         Note:

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -682,28 +682,20 @@ class WoodworkTableAccessor:
         )
 
     @_check_table_schema
-    def to_parquet(self, path, filename, profile_name=None, **kwargs):
+    def to_parquet(self, path, filename=None):
         """Write Woodwork table to disk as a parquet file at the location specified by `path`, with
         the file name specified by `filename`. All Woodwork typing information will be stored in the
         parquet file metadata.
-
 
         Note:
             As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used.
 
         Args:
-            path (str): Location on disk to write to. Path can be a local path or an S3 path.
-            filename (str): Name of file to write.
-            profile_name (str): Name of AWS profile to use, False to use an anonymous profile, or None.
-            kwargs (keywords): Additional keyword arguments to specify AWS profile.
+            path (str): Location on disk to write to.
+            filename (str): Name of file to write. Optional for Dask dataframes. Defaults to `data.parquet`
+                if not specified for pandas dataframes.
         """
-        serialize.save_parquet_file(
-            self._dataframe,
-            path,
-            filename,
-            profile_name,
-            **kwargs,
-        )
+        serialize._save_parquet_file(self._dataframe, path, filename)
 
     def _sort_columns(self, already_sorted):
         if _is_dask_dataframe(self._dataframe) or _is_koalas_dataframe(self._dataframe):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -692,8 +692,7 @@ class WoodworkTableAccessor:
 
         Args:
             path (str): Location on disk to write to.
-            filename (str): Name of file to write. Optional for Dask dataframes. Defaults to `data.parquet`
-                if not specified for pandas dataframes.
+            filename (str): Name of file to write. Optional for Dask dataframes. Defaults to `data.parquet` if not specified for pandas dataframes.
         """
         serialize._save_parquet_file(self._dataframe, path, filename)
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -682,7 +682,7 @@ class WoodworkTableAccessor:
         )
 
     @_check_table_schema
-    def to_parquet(self, path, filename=None):
+    def to_parquet(self, path, filename=None, profile_name=None):
         """Write Woodwork table to disk as a parquet file at the location specified by ``path``, with
         the filename specified by ``filename``. All Woodwork typing information will be stored in the
         parquet file metadata. Only supported for pandas and Dask DataFrames.
@@ -694,8 +694,9 @@ class WoodworkTableAccessor:
             path (str): Location on disk to write to.
             filename (str): Name of file to write. Optional for Dask dataframes, and will be ignored if provided.
                 Defaults to ``data.parquet`` if not specified for pandas dataframes.
+            profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
         """
-        serialize._save_parquet_file(self._dataframe, path, filename)
+        serialize._save_parquet_file(self._dataframe, path, filename, profile_name)
 
     def _sort_columns(self, already_sorted):
         if _is_dask_dataframe(self._dataframe) or _is_koalas_dataframe(self._dataframe):

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -685,14 +685,15 @@ class WoodworkTableAccessor:
     def to_parquet(self, path, filename=None):
         """Write Woodwork table to disk as a parquet file at the location specified by `path`, with
         the file name specified by `filename`. All Woodwork typing information will be stored in the
-        parquet file metadata.
+        parquet file metadata. Only supported for pandas and Dask DataFrames.
 
         Note:
             As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used.
 
         Args:
             path (str): Location on disk to write to.
-            filename (str): Name of file to write. Optional for Dask dataframes. Defaults to `data.parquet` if not specified for pandas dataframes.
+            filename (str): Name of file to write. Optional for Dask dataframes, and will be ignored if provided.
+                Defaults to `data.parquet` if not specified for pandas dataframes.
         """
         serialize._save_parquet_file(self._dataframe, path, filename)
 

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -682,7 +682,7 @@ class WoodworkTableAccessor:
         )
 
     @_check_table_schema
-    def to_parquet(self, filepath, profile_name=None, **kwargs):
+    def to_parquet(self, path, filename, profile_name=None, **kwargs):
         """Write Woodwork table to disk as a parquet file at the location specified by `path`, with
         the file name specified by `filename`. All Woodwork typing information will be stored in the
         parquet file metadata.
@@ -692,13 +692,16 @@ class WoodworkTableAccessor:
             As the engine `fastparquet` cannot handle nullable pandas dtypes, `pyarrow` will be used.
 
         Args:
-            filepath (str) : Location on disk to write to, including filename. Path can be a local path or an S3 path.
-            profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
-            kwargs (keywords) : Additional keyword arguments to specify AWS profile.
+            path (str): Location on disk to write to. Path can be a local path or an S3 path.
+            filename (str): Name of file to write.
+            profile_name (str): Name of AWS profile to use, False to use an anonymous profile, or None.
+            kwargs (keywords): Additional keyword arguments to specify AWS profile.
         """
         serialize.save_parquet_file(
             self._dataframe,
-            filepath,
+            path,
+            filename,
+            profile_name,
             **kwargs,
         )
 

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -788,3 +788,13 @@ def test_to_parquet_single_file(sample_df, tmpdir):
         to_pandas(sample_df, index=sample_df.ww.index, sort_index=True),
     )
     assert deserialized_df.ww.schema == sample_df.ww.schema
+
+
+def test_to_parquet_single_file_default_pandas_name(sample_df_pandas, tmpdir):
+    sample_df_pandas.ww.init()
+    sample_df_pandas.ww.to_parquet(str(tmpdir))
+
+    deserialized_df = deserialize.read_parquet(str(tmpdir), "data.parquet")
+
+    pd.testing.assert_frame_equal(sample_df_pandas, deserialized_df)
+    assert deserialized_df.ww.schema == sample_df_pandas.ww.schema

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -760,6 +760,7 @@ def test_to_parquet_single_file(sample_df, tmpdir):
     sample_df.ww.init(
         name="test_data",
         index="full_name",
+        time_index="signup_date",
         semantic_tags={"id": "tag1"},
         logical_types={"age": Ordinal(order=[25, 33, 57])},
         column_descriptions={

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -779,7 +779,7 @@ def test_to_parquet_single_file(sample_df, tmpdir):
     filepath = os.path.join(str(tmpdir), "sample_df.parquet")
     sample_df.ww.to_parquet(filepath)
 
-    deserialized_df = deserialize.read_parquet_file(filepath)
+    deserialized_df = deserialize.read_parquet(filepath)
 
     pd.testing.assert_frame_equal(
         to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -752,6 +752,8 @@ def test_earlier_schema_version():
 
 
 def test_to_parquet_single_file(sample_df, tmpdir):
+    if _is_koalas_dataframe(sample_df):
+        pytest.skip("Not supported for Koalas yet")
     sample_df.ww.init(
         name="test_data",
         index="full_name",
@@ -778,13 +780,13 @@ def test_to_parquet_single_file(sample_df, tmpdir):
     if _is_dask_dataframe(sample_df):
         lib = "dask"
         filename = None
-    if _is_koalas_dataframe(sample_df):
-        lib = "koalas"
-        filename = None
+    # if _is_koalas_dataframe(sample_df):
+    #     lib = "koalas"
+    #     filename = None
 
     sample_df.ww.to_parquet(str(tmpdir), filename)
     deserialized_df = deserialize.read_parquet(str(tmpdir), filename, lib)
-    breakpoint()
+
     pd.testing.assert_frame_equal(
         to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),
         to_pandas(sample_df, index=sample_df.ww.index, sort_index=True),

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -780,9 +780,6 @@ def test_to_parquet_single_file(sample_df, tmpdir):
     if _is_dask_dataframe(sample_df):
         lib = "dask"
         filename = None
-    # if _is_koalas_dataframe(sample_df):
-    #     lib = "koalas"
-    #     filename = None
 
     sample_df.ww.to_parquet(str(tmpdir), filename)
     deserialized_df = deserialize.read_parquet(str(tmpdir), filename, lib)

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -752,12 +752,7 @@ def test_earlier_schema_version():
 
 
 def test_to_parquet_single_file(sample_df, tmpdir):
-    # if _is_dask_dataframe(sample_df):
-    #     # Dask errors with pd.NA in some partitions, but not others
-    #     sample_df["age"] = sample_df["age"].fillna(25)
-    import databricks.koalas as ks
-
-    if isinstance(sample_df, ks.DataFrame):
+    if _is_koalas_dataframe:
         pytest.skip("Skipping for now")
     sample_df.ww.init(
         name="test_data",

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -825,3 +825,20 @@ def test_read_parquet_without_ww_info(sample_df, tmpdir):
         to_pandas(sample_df, sort_index=True),
     )
     assert deserialized_df.ww.schema == sample_df.ww.schema
+
+
+@pytest.mark.parametrize("profile_name", [None, False])
+def test_serialize_s3_to_parquet_single_file(
+    sample_df_pandas, s3_client, s3_bucket, profile_name
+):
+    sample_df_pandas.ww.init()
+    filename = "s3_test.parquet"
+    sample_df_pandas.ww.to_parquet(TEST_S3_URL, filename, profile_name=profile_name)
+    make_public(s3_client, s3_bucket)
+
+    deserialized_df = deserialize.read_parquet(
+        TEST_S3_URL, filename, profile_name=profile_name
+    )
+
+    pd.testing.assert_frame_equal(sample_df_pandas, deserialized_df)
+    assert sample_df_pandas.ww.schema == deserialized_df.ww.schema

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -752,7 +752,7 @@ def test_earlier_schema_version():
 
 
 def test_to_parquet_single_file(sample_df, tmpdir):
-    if _is_koalas_dataframe:
+    if _is_koalas_dataframe(sample_df):
         pytest.skip("Skipping for now")
     sample_df.ww.init(
         name="test_data",

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -752,8 +752,6 @@ def test_earlier_schema_version():
 
 
 def test_to_parquet_single_file(sample_df, tmpdir):
-    if _is_koalas_dataframe(sample_df):
-        pytest.skip("Skipping for now")
     sample_df.ww.init(
         name="test_data",
         index="full_name",
@@ -774,15 +772,19 @@ def test_to_parquet_single_file(sample_df, tmpdir):
             "age": {"interesting_values": [33, 57]},
         },
     )
-    sample_df.ww.to_parquet(str(tmpdir), "sample_df.parquet")
 
     lib = "pandas"
+    filename = "sample_df.parquet"
     if _is_dask_dataframe(sample_df):
         lib = "dask"
-    deserialized_df = deserialize.read_parquet(
-        str(tmpdir), "sample_df.parquet", lib=lib
-    )
+        filename = None
+    if _is_koalas_dataframe(sample_df):
+        lib = "koalas"
+        filename = None
 
+    sample_df.ww.to_parquet(str(tmpdir), filename)
+    deserialized_df = deserialize.read_parquet(str(tmpdir), filename, lib)
+    breakpoint()
     pd.testing.assert_frame_equal(
         to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),
         to_pandas(sample_df, index=sample_df.ww.index, sort_index=True),

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -755,7 +755,9 @@ def test_to_parquet_single_file(sample_df, tmpdir):
     # if _is_dask_dataframe(sample_df):
     #     # Dask errors with pd.NA in some partitions, but not others
     #     sample_df["age"] = sample_df["age"].fillna(25)
-    if not isinstance(sample_df, pd.DataFrame):
+    import databricks.koalas as ks
+
+    if isinstance(sample_df, ks.DataFrame):
         pytest.skip("Skipping for now")
     sample_df.ww.init(
         name="test_data",
@@ -779,33 +781,15 @@ def test_to_parquet_single_file(sample_df, tmpdir):
     )
     sample_df.ww.to_parquet(str(tmpdir), "sample_df.parquet")
 
-    deserialized_df = deserialize.read_parquet(str(tmpdir), "sample_df.parquet")
+    lib = "pandas"
+    if _is_dask_dataframe(sample_df):
+        lib = "dask"
+    deserialized_df = deserialize.read_parquet(
+        str(tmpdir), "sample_df.parquet", lib=lib
+    )
 
     pd.testing.assert_frame_equal(
         to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),
         to_pandas(sample_df, index=sample_df.ww.index, sort_index=True),
     )
     assert deserialized_df.ww.schema == sample_df.ww.schema
-
-
-@pytest.mark.parametrize("profile_name", [None, False])
-def test_serialize_s3_parquet_single_file(
-    sample_df, s3_client, s3_bucket, profile_name
-):
-    if not isinstance(sample_df, pd.DataFrame):
-        pytest.skip("Skipping for now")
-    xfail_tmp_disappears(sample_df)
-
-    sample_df.ww.init()
-    sample_df.ww.to_parquet(TEST_S3_URL, "sample_df.parquet", profile_name=profile_name)
-
-    make_public(s3_client, s3_bucket)
-    deserialized_df = deserialize.read_parquet(
-        TEST_S3_URL, "sample_df.parquet", profile_name=profile_name
-    )
-
-    pd.testing.assert_frame_equal(
-        to_pandas(sample_df, index=sample_df.ww.index, sort_index=True),
-        to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),
-    )
-    assert sample_df.ww.schema == deserialized_df.ww.schema

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -329,6 +329,7 @@ def test_accessor_init_errors_methods(sample_df):
         "to_dictionary": None,
         "value_counts": None,
         "infer_temporal_frequencies": None,
+        "to_parquet": "test.parquet",
     }
     error = re.escape(
         "Woodwork not initialized for this DataFrame. Initialize by calling DataFrame.ww.init"


### PR DESCRIPTION
Add df.ww.to_parquet method to serialize to a single file
- Closes #1223 
- Closes #1225 

Adds a new accessor method to serialize a Woodwork dataframe to the specified parquet file. Saves all Woodwork typing information and other metadata in the parquet file metadata. Also adds a new method `read_parquet` to deserialize the saved information back into a Woodwork initialized dataframe.


