### PR TITLE
Automated Latest Dependency Updates

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -11,7 +11,7 @@ jobs:
         id: find_prs
         run: |
           gh auth status
-          gh pr list --repo "${{ github.repository }}" --author "machineFL" --base main --state open --search "status:success review:required" --limit 1 --json number > dep_PRs_waiting_approval.json
+          gh pr list --repo "${{ github.repository }}" --assignee "machineFL" --base main --state open --search "status:success review:required" --limit 1 --json number > dep_PRs_waiting_approval.json
           dep_pull_request=$(cat dep_PRs_waiting_approval.json | grep -Eo "[0-9]*")
           echo ::set-output name=dep_pull_request::${dep_pull_request}
         env:

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -61,4 +61,5 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: main
-        reviewers: thehomebrewnerd, tamargrey, jeff-hernandez, tuethan1999, davesque
+        assignees: machineFL
+        reviewers: machineAYX

--- a/woodwork/tests/requirement_files/latest_dask_dependencies.txt
+++ b/woodwork/tests/requirement_files/latest_dask_dependencies.txt
@@ -1,4 +1,4 @@
-dask==2021.12.0
+dask==2022.1.0
 numpy==1.22.1
 pandas==1.3.5
 pyarrow==6.0.1


### PR DESCRIPTION
This is an auto-generated PR with **latest** dependency updates. Please do not delete the `latest-dep-update` branch because it's needed by the auto-dependency bot.