### PR TITLE
Update box plot bounds to min and max if necessary

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Add Slack link to GitHub issue creation templates (:pr:`1242`)
     * Fixes
         * Fixed issue with tuples being incorrectly inferred as EmailAddress (:pr:`1253`)
+        * Set high and low bounds to the max and min values if no outliers are present in ``box_plot_dict`` (:pr:`1269`)
     * Changes
         * Prevent setting index that contains null values (:pr:`1239`)
         * Allow tuple NaN LatLong values (:pr:`1255`)
@@ -22,7 +23,7 @@ Future Release
         * Fix permissions issue with S3 deserialization test (:pr:`1238`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`dvreed77`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`dvreed77`,:user:`tamargrey`, :user:`thehomebrewnerd`
 
 v0.11.1 Jan 4, 2022
 ===================

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -406,9 +406,9 @@ class WoodworkColumnAccessor:
                 Defaults to True.
 
         Note:
-            The minimum quantiles necessary for building a box ploy using the IQR method are the
+            The minimum quantiles necessary for building a box plot using the IQR method are the
             minimum value (0.0 in the quantiles dict), first quartile (0.25), third quartile (0.75), and maximum value (1.0).
-            If no quantiles are providex, the following quantiles will be calculated:
+            If no quantiles are provided, the following quantiles will be calculated:
             {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to {min, first quantile, median, third quantile, max}.
 
         Returns:

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -415,8 +415,8 @@ class WoodworkColumnAccessor:
             (dict[str -> float,list[number]]): Returns a dictionary containing box plot information for the Series.
                 The following elements will be found in the dictionary:
 
-                - low_bound (float): the lower bound below which outliers lay - to be used as a whisker
-                - high_bound (float): the high bound above which outliers lay - to be used as a whisker
+                - low_bound (float): the lowest data point in the dataset excluding any outliers - to be used as a whisker
+                - high_bound (float): the highest point in the dataset excluding any outliers - to be used as a whisker
                 - quantiles (list[float]): the quantiles used to determine the bounds.
                     If quantiles were passed in, will contain all quantiles passed in. Otherwise, contains the five
                     quantiles {0.0, 0.25, 0.5, 0.75, 1.0}.

--- a/woodwork/column_accessor.py
+++ b/woodwork/column_accessor.py
@@ -406,10 +406,10 @@ class WoodworkColumnAccessor:
                 Defaults to True.
 
         Note:
-            The minimum quantiles necessary for outlier detection using the IQR method are the
-            first quartile (0.25) and third quartile (0.75). If these keys are missing from the quantiles dictionary,
-            the following quantiles will be calculated: {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to
-            {min, first quantile, median, third quantile, max}.
+            The minimum quantiles necessary for building a box ploy using the IQR method are the
+            minimum value (0.0 in the quantiles dict), first quartile (0.25), third quartile (0.75), and maximum value (1.0).
+            If no quantiles are providex, the following quantiles will be calculated:
+            {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to {min, first quantile, median, third quantile, max}.
 
         Returns:
             (dict[str -> float,list[number]]): Returns a dictionary containing box plot information for the Series.

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -463,10 +463,10 @@ def _get_box_plot_info_for_column(
             Defaults to True.
 
     Note:
-        The minimum quantiles necessary for outlier detection using the IQR method are the
-        first quartile (0.25) and third quartile (0.75). If these keys are missing from the quantiles dictionary,
-        the following quantiles will be calculated: {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to
-        {min, first quantile, median, third quantile, max}.
+        The minimum quantiles necessary for building a box ploy using the IQR method are the
+        minimum value (0.0 in the quantiles dict), first quartile (0.25), third quartile (0.75), and maximum value (1.0).
+        If no quantiles are providex, the following quantiles will be calculated:
+        {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to {min, first quantile, median, third quantile, max}.
 
     Returns:
         (dict[str -> float,list[number]]): Returns a dictionary containing box plot information for the Series.

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -526,46 +526,32 @@ def _get_box_plot_info_for_column(
     # calculate the outlier bounds using IQR
     if quantiles is None:
         quantiles = series.quantile([0.0, 0.25, 0.5, 0.75, 1.0]).to_dict()
-    elif 0.25 not in quantiles or 0.75 not in quantiles:
+    elif len(set(quantiles.keys()) & {0.0, 0.25, 0.75, 1.0}) != 4:
         raise ValueError(
-            "Input quantiles do not contain the minimum necessary quantiles for outlier calculation: "
-            "0.25 (the first quartile) and 0.75 (the third quartile)."
+            "Input quantiles do not contain the minimum necessary quantiles for box plot calculation: "
+            "0.0 (the minimum value), 0.25 (the first quartile), 0.75 (the third quartile), and 1.0 (the maximum value)."
         )
-
+    min_value = quantiles[0.0]
     q1 = quantiles[0.25]
     q3 = quantiles[0.75]
+    max_value = quantiles[1.0]
 
+    # Box plot bounds calculation - the bounds should never be beyond the min and max values
     iqr = q3 - q1
-
-    low_bound = q1 - (iqr * 1.5)
-    high_bound = q3 + (iqr * 1.5)
+    low_bound = max(q1 - (iqr * 1.5), min_value)
+    high_bound = min(q3 + (iqr * 1.5), max_value)
 
     if include_indices_and_values:
         # identify outliers in the series
-        min = quantiles.get(0.0)
-        max = quantiles.get(1.0)
-        if (
-            min is not None
-            and max is not None
-            and low_bound <= min
-            and high_bound >= max
-        ):
-            outliers_dict = {
-                "low_values": [],
-                "high_values": [],
-                "low_indices": [],
-                "high_indices": [],
-            }
-        else:
-            low_series = series[series < low_bound]
-            high_series = series[series > high_bound]
+        low_series = series[series < low_bound] if low_bound > min_value else pd.Series()
+        high_series = series[series > high_bound] if high_bound < max_value else pd.Series()
 
-            outliers_dict = {
-                "low_values": low_series.tolist(),
-                "high_values": high_series.tolist(),
-                "low_indices": low_series.index.tolist(),
-                "high_indices": high_series.index.tolist(),
-            }
+        outliers_dict = {
+            "low_values": low_series.tolist(),
+            "high_values": high_series.tolist(),
+            "low_indices": low_series.index.tolist(),
+            "high_indices": high_series.index.tolist(),
+        }
 
     return {
         "low_bound": low_bound,

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -543,8 +543,12 @@ def _get_box_plot_info_for_column(
 
     if include_indices_and_values:
         # identify outliers in the series
-        low_series = series[series < low_bound] if low_bound > min_value else pd.Series()
-        high_series = series[series > high_bound] if high_bound < max_value else pd.Series()
+        low_series = (
+            series[series < low_bound] if low_bound > min_value else pd.Series()
+        )
+        high_series = (
+            series[series > high_bound] if high_bound < max_value else pd.Series()
+        )
 
         outliers_dict = {
             "low_values": low_series.tolist(),

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -463,9 +463,9 @@ def _get_box_plot_info_for_column(
             Defaults to True.
 
     Note:
-        The minimum quantiles necessary for building a box ploy using the IQR method are the
+        The minimum quantiles necessary for building a box plot using the IQR method are the
         minimum value (0.0 in the quantiles dict), first quartile (0.25), third quartile (0.75), and maximum value (1.0).
-        If no quantiles are providex, the following quantiles will be calculated:
+        If no quantiles are provided, the following quantiles will be calculated:
         {0.0, 0.25, 0.5, 0.75, 1.0}, which correspond to {min, first quantile, median, third quantile, max}.
 
     Returns:

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -472,8 +472,8 @@ def _get_box_plot_info_for_column(
         (dict[str -> float,list[number]]): Returns a dictionary containing box plot information for the Series.
             The following elements will be found in the dictionary:
 
-            - low_bound (float): the lower bound below which outliers lay - to be used as a whisker
-            - high_bound (float): the high bound above which outliers lay - to be used as a whisker
+            - low_bound (float): the lowest data point in the dataset excluding any outliers - to be used as a whisker
+            - high_bound (float): the highest point in the dataset excluding any outliers - to be used as a whisker
             - quantiles (list[float]): the quantiles used to determine the bounds.
                 If quantiles were passed in, will contain all quantiles passed in. Otherwise, contains the five
                 quantiles {0.0, 0.25, 0.5, 0.75, 1.0}.


### PR DESCRIPTION
- Requires min and max values in quantiles so they can be used to set the high and low bounds when no outliers are present
- Closes #1267 
