### PR TITLE
Add release notes for backported 0.11.2 release

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -34,6 +34,19 @@ v0.12.0 Jan 27, 2022
     Thanks to the following people for contributing to this release:
     :user:`dvreed77`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
+v0.11.2 (Backport) Jan 28, 2022
+===============================
+    * Fixes
+        * Set high and low bounds to the max and min values if no outliers are present in ``box_plot_dict`` (:pr:`1269`)
+
+    Thanks to the following people for contributing to this release:
+    :user:`tamargrey`
+
+Note
+++++
+    * The pandas version for Koalas has been restricted, and a change was made to a pandas ``replace`` call to account for
+      the recent pandas 1.4.0 release.
+
 v0.11.1 Jan 4, 2022
 ===================
     * Changes


### PR DESCRIPTION
Adds the release notes section for the 0.11.2 release into main (since it currently only exists on the `0.11.x` branch). Indicates that it's a backported release 