### PR TITLE
Handle large range in extra stats

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Add validation to EmailAddress logical type (:pr:`1247`)
         * Add validation to URL logical type (:pr:`1285`)
     * Fixes
+        * Check range length in table stats without producing overflow error (:pr:`1287`)
     * Changes
         * Remove framework for unused ``woodwork`` CLI (:pr:`1288`)
     * Documentation Changes
@@ -17,7 +18,7 @@ Future Release
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`
+    :user:`gsheni`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`tamargrey`
 
 
 v0.12.0 Jan 27, 2022

--- a/woodwork/statistics_utils.py
+++ b/woodwork/statistics_utils.py
@@ -169,7 +169,8 @@ def _get_describe_dict(
                     # Calculate top numeric values if range of values present
                     # is less than or equal number of histogram bins and series
                     # contains only integer values
-                    if len(_range) <= bins and (series % 1 == 0).all():
+                    range_len = int(values["max"]) + 1 - int(values["min"])
+                    if range_len <= bins and (series % 1 == 0).all():
                         values["top_values"] = _get_numeric_value_counts_in_range(
                             series, _range
                         )

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from inspect import isclass
 
+from mock import patch
 import numpy as np
 import pandas as pd
 import pytest
@@ -895,6 +896,30 @@ def test_describe_dict_extra_stats(describe_df):
             assert isinstance(desc_dict[col]["top_values"], list)
         else:
             assert desc_dict[col].get("top_values") is None
+
+
+@patch("woodwork.statistics_utils._get_numeric_value_counts_in_range")
+def test_describe_dict_extra_stats_overflow_range(mock_get_numeric_value_counts_in_range, describe_df):
+    df = pd.DataFrame({
+        "large_range": [-9215883799005046784, 0, 1, 9223177510267041793],
+        'large_nums': [97896598486960007123867158471523621205853924, 0, 1, 2]
+    })
+    df.ww.init()
+
+    assert not mock_get_numeric_value_counts_in_range.called
+
+    # Confirm we don't make it inside the block that calls _get_numeric_value_counts_in_range,
+    # since that would still have an overflow error. This is okay, because when the range is so
+    # large that it causes overflow errors, it'd be absurd for there to be more bins such that
+    # we should go into that block of code
+    df.ww.describe_dict(extra_stats=True)
+    assert not mock_get_numeric_value_counts_in_range.called
+
+    # Confirm we actually have the ability to make it into that block
+    describe_df["small_range_col"] = describe_df["numeric_col"].fillna(0) // 10
+    describe_df.ww.init(index="index_col")
+    describe_df.ww.describe_dict(extra_stats=True)
+    assert mock_get_numeric_value_counts_in_range.called
 
 
 def test_value_counts(categorical_df):

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -2,10 +2,10 @@ import re
 from datetime import datetime
 from inspect import isclass
 
-from mock import patch
 import numpy as np
 import pandas as pd
 import pytest
+from mock import patch
 
 from woodwork.accessor_utils import _is_koalas_dataframe, init_series
 from woodwork.logical_types import (
@@ -899,11 +899,15 @@ def test_describe_dict_extra_stats(describe_df):
 
 
 @patch("woodwork.statistics_utils._get_numeric_value_counts_in_range")
-def test_describe_dict_extra_stats_overflow_range(mock_get_numeric_value_counts_in_range, describe_df):
-    df = pd.DataFrame({
-        "large_range": [-9215883799005046784, 0, 1, 9223177510267041793],
-        'large_nums': [97896598486960007123867158471523621205853924, 0, 1, 2]
-    })
+def test_describe_dict_extra_stats_overflow_range(
+    mock_get_numeric_value_counts_in_range, describe_df
+):
+    df = pd.DataFrame(
+        {
+            "large_range": [-9215883799005046784, 0, 1, 9223177510267041793],
+            "large_nums": [97896598486960007123867158471523621205853924, 0, 1, 2],
+        }
+    )
     df.ww.init()
 
     assert not mock_get_numeric_value_counts_in_range.called


### PR DESCRIPTION
- There are situations where the range between a column's min and max value is so large that `len(range(min, max))` produces an OverflowError, so we're changing the call in describe_dict's extra stats to just subtract `max + 1 - min`.