### PR TITLE
Remove cli entry point

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,13 +8,14 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
+        * Remove framework for unused ``woodwork`` CLI (:pr:`1288`)
     * Documentation Changes
         * Updating contributing doc with PATH and JAVA_HOME instructions (:pr:`1273`)
         * Better install page with new Sphinx extensions for copying and in-line tabs (:pr:`1280`, :pr:`1282`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`rwedge`
 
 
 v0.12.0 Jan 27, 2022

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     extras_require=extras_require,
     keywords="data science machine learning typing",
     include_package_data=True,
-    entry_points={"console_scripts": ["woodwork = woodwork.__main__:cli"]},
     long_description=long_description,
     long_description_content_type="text/markdown",
     data_files=[("woodwork/data", ["woodwork/data/1-1000.txt"])],


### PR DESCRIPTION
- Removes non-functional `woodwork` CLI command
- CLI sub-commands removed previously in #891