### PR TITLE
Conditionally run scheduled workflows

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -12,6 +12,7 @@ on:
       - completed
 jobs:
   build:
+    if: ${{ github.repository_owner == 'alteryx' }}
     runs-on: ubuntu-latest
     steps:
       - name: Find dependency PRs

--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -12,7 +12,7 @@ on:
       - completed
 jobs:
   build:
-    if: ${{ github.repository_owner == 'alteryx' }}
+    if: github.repository_owner == 'alteryx'
     runs-on: ubuntu-latest
     steps:
       - name: Find dependency PRs

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: ${{ github.repository_owner == 'alteryx' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    if: ${{ github.repository_owner == 'alteryx' }}
+    if: github.repository_owner == 'alteryx'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,9 +13,10 @@ Future Release
         * Updated lint check to only run on Python 3.10 (:pr:`1345`)
     * Documentation Changes
     * Testing Changes
+        * Updated scheduled workflows to only run on Alteryx owned repos (:pr:`1973`)
 
     Thanks to the following people for contributing to this release:
-    :user:`dvreed77`, :user:`bchen1116`
+    :user:`dvreed77`, :user:`bchen1116`, :user:`thehomebrewnerd`
 
 v0.14.0 Mar 15, 2022
 ====================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Future Release
         * Updated lint check to only run on Python 3.10 (:pr:`1345`)
     * Documentation Changes
     * Testing Changes
-        * Updated scheduled workflows to only run on Alteryx owned repos (:pr:`1973`)
+        * Updated scheduled workflows to only run on Alteryx owned repos (:pr:`1351`)
 
     Thanks to the following people for contributing to this release:
     :user:`dvreed77`, :user:`bchen1116`, :user:`thehomebrewnerd`


### PR DESCRIPTION
### Conditionally run scheduled workflows

Closes #1349 

Update scheduled workflows to run only if repository_owner is alteryx. This should prevent these scheduled workflows from running on repo forks and failing repeatedly.