### PR TITLE
Upgrade nbconvert; remove jinja2 dependency

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,16 +3,18 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
         * Allow attr version in setup.cfg (:pr:`1361`)
     * Documentation Changes
+        * Upgrade nbconvert and remove jinja2 dependency (:pr:`1362`)
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`gsheni`, :user:`rwedge`
 
 v0.15.0 Mar 24, 2022
 ====================

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,7 @@ dev =
     sphinx-inline-tabs == 2022.1.2b11; python_version >= '3.8'
     sphinx-copybutton == 0.4.0
     myst-parser == 0.16.1
-    nbconvert == 6.2.0
-    Jinja2 == 3.0.3
+    nbconvert == 6.4.5
     ipython == 7.31.1
     pygments == 2.10.0
     jupyter == 1.0.0


### PR DESCRIPTION
nbconvert 6.4.5 fixes issue with 3.1.x jinja2 

removing jinja2 dependency since it is not used directly