### PR TITLE
Stores timezone in Datetime logical type

### DIFF
--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -278,6 +278,7 @@ class Datetime(LogicalType):
         self.timezone = None
 
     def _remove_timezone(self, series):
+        """Removes timezone from series and stores in logical type."""
         if hasattr(series.dtype, 'tz') and series.dtype.tz:
             self.timezone = str(series.dtype.tz)
             series = series.dt.tz_localize(None)
@@ -322,7 +323,6 @@ class Datetime(LogicalType):
                         series, format=self.datetime_format, errors="coerce"
                     )
 
-        # series = self._remove_timezone(series)
         return super().transform(series)
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -279,11 +279,10 @@ class Datetime(LogicalType):
 
     def _remove_timezone(self, series):
         """Removes timezone from series and stores in logical type."""
-        if hasattr(series.dtype, 'tz') and series.dtype.tz:
+        if hasattr(series.dtype, "tz") and series.dtype.tz:
             self.timezone = str(series.dtype.tz)
             series = series.dt.tz_localize(None)
         return series
-
 
     def transform(self, series):
         """Converts the series data to a formatted datetime. Datetime format will be inferred if datetime_format is None."""
@@ -295,10 +294,11 @@ class Datetime(LogicalType):
             self.datetime_format = self.datetime_format or _infer_datetime_format(
                 series
             )
+            utc = self.datetime_format.endswith("%z")
             if _is_dask_series(series):
                 name = series.name
                 series = dd.to_datetime(
-                    series, format=self.datetime_format, errors="coerce"
+                    series, format=self.datetime_format, errors="coerce", utc=utc
                 )
                 series.name = name
             elif _is_spark_series(series):
@@ -310,7 +310,9 @@ class Datetime(LogicalType):
                 )
             else:
                 try:
-                    series = pd.to_datetime(series, format=self.datetime_format)
+                    series = pd.to_datetime(
+                        series, format=self.datetime_format, utc=utc
+                    )
                 except (TypeError, ValueError):
                     warnings.warn(
                         f"Some rows in series '{series.name}' are incompatible with datetime format "
@@ -323,6 +325,7 @@ class Datetime(LogicalType):
                         series, format=self.datetime_format, errors="coerce"
                     )
 
+        series = self._remove_timezone(series)
         return super().transform(series)
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -273,8 +273,9 @@ class Datetime(LogicalType):
     primary_dtype = "datetime64[ns]"
     datetime_format = None
 
-    def __init__(self, datetime_format=None):
+    def __init__(self, datetime_format=None, timezone=None):
         self.datetime_format = datetime_format
+        self.timezone = None
 
     def transform(self, series):
         """Converts the series data to a formatted datetime. Datetime format will be inferred if datetime_format is None."""
@@ -312,6 +313,10 @@ class Datetime(LogicalType):
                     series = pd.to_datetime(
                         series, format=self.datetime_format, errors="coerce"
                     )
+
+        if hasattr(series.dtype, 'tz') and series.dt.tz:
+            self.timezone = str(series.dt.tz)
+            series = series.dt.tz_localize(None)
         return super().transform(series)
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -282,6 +282,10 @@ class Datetime(LogicalType):
         new_dtype = self._get_valid_dtype(type(series))
         series_dtype = str(series.dtype)
 
+        if hasattr(series.dtype, 'tz') and series.dtype.tz:
+            self.timezone = str(series.dtype.tz)
+            series = series.dt.tz_localize(None)
+
         if new_dtype != series_dtype:
             self.datetime_format = self.datetime_format or _infer_datetime_format(
                 series
@@ -314,9 +318,6 @@ class Datetime(LogicalType):
                         series, format=self.datetime_format, errors="coerce"
                     )
 
-        if hasattr(series.dtype, 'tz') and series.dt.tz:
-            self.timezone = str(series.dt.tz)
-            series = series.dt.tz_localize(None)
         return super().transform(series)
 
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -727,9 +727,41 @@ def test_float_dtype_inference_on_init():
 
 def test_datetime_timezones(timezones_df):
     timezones_df.ww.init()
-    expected = [None, 'UTC', 'US/Eastern', None, None, None]
-    actual = [lt.timezone for lt in timezones_df.ww.logical_types.values()]
-    assert actual == expected
+    actual_timezones = [lt.timezone for lt in timezones_df.ww.logical_types.values()]
+    expected_timezones = [None, "UTC", "US/Eastern", None, "UTC", "UTC"]
+    assert actual_timezones == expected_timezones
+
+    expected_df = pd.DataFrame(
+        data=[
+            [
+                "2022-01-01 00:00:00",
+                "2022-01-01 00:00:00",
+                "2022-01-01 00:00:00",
+                "2022-01-01 00:00:00",
+                "2022-01-01 00:00:00",
+                "2022-01-01 05:00:00",
+            ],
+            [
+                "2022-01-02 00:00:00",
+                "2022-01-02 00:00:00",
+                "2022-01-02 00:00:00",
+                "2022-01-02 00:00:00",
+                "2022-01-02 00:00:00",
+                "2022-01-02 05:00:00",
+            ],
+            ["NaT", "NaT", "NaT", "NaT", "NaT", "NaT"],
+        ],
+        columns=[
+            "default_1",
+            "utc_1",
+            "eastern_1",
+            "default_2",
+            "utc_2",
+            "eastern_2",
+        ],
+    ).astype("datetime64[ns]")
+    actual_df = to_pandas(timezones_df)
+    pd.testing.assert_frame_equal(actual_df, expected_df)
 
 
 def test_datetime_dtype_inference_on_init():

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -727,7 +727,7 @@ def test_float_dtype_inference_on_init():
 
 def test_datetime_timezones(timezones_df):
     timezones_df.ww.init()
-    expected = [None, 'UTC', 'US/Eastern', None, None]
+    expected = [None, 'UTC', 'US/Eastern', None, None, None]
     actual = [lt.timezone for lt in timezones_df.ww.logical_types.values()]
     assert actual == expected
 

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -725,6 +725,13 @@ def test_float_dtype_inference_on_init():
     assert df["floats_nan_specified"].dtype == "float64"
 
 
+def test_datetime_timezones(timezones_df):
+    timezones_df.ww.init()
+    expected = [None, 'UTC', 'US/Eastern', None, None]
+    actual = [lt.timezone for lt in timezones_df.ww.logical_types.values()]
+    assert actual == expected
+
+
 def test_datetime_dtype_inference_on_init():
     df = pd.DataFrame(
         {

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -914,3 +914,33 @@ def outliers_df_spark(outliers_df_pandas):
 @pytest.fixture(params=["outliers_df_pandas", "outliers_df_dask", "outliers_df_spark"])
 def outliers_df(request):
     return request.getfixturevalue(request.param)
+
+
+@pytest.fixture()
+def timezones_df_pandas():
+    return pd.DataFrame(
+        {
+            "default": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype=object),
+            "utc_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns, UTC]'),
+            "eastern_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns, US/Eastern]'),
+            "utc_2": pd.Series(['2022-01-01T00:00:00+00:00', '2022-01-02T00:00:00+00:00', 'NaT'], dtype=object),
+            "eastern_2": pd.Series(['2022-01-01 00:00:00-05:00', '2022-01-02 00:00:00-05:00', 'NaT'], dtype=object),
+        }
+    )
+    
+
+@pytest.fixture()
+def timezones_df_dask(timezones_df_pandas):
+    dd = pytest.importorskip("dask.dataframe", reason="Dask not installed, skipping")
+    return dd.from_pandas(timezones_df_pandas, npartitions=2)
+
+
+@pytest.fixture()
+def timezones_df_spark(timezones_df_pandas):
+    ps = pytest.importorskip("pyspark.pandas", reason="Spark not installed, skipping")
+    return ps.from_pandas(timezones_df_pandas)
+
+
+@pytest.fixture(params=["timezones_df_pandas", "timezones_df_dask", "timezones_df_spark"])
+def timezones_df(request):
+    return request.getfixturevalue(request.param)

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -918,23 +918,43 @@ def outliers_df(request):
 
 @pytest.fixture()
 def timezones_df_pandas():
+    dtypes = {
+        "default_1": "datetime64[ns]",
+        "utc_1": "datetime64[ns, UTC]",
+        "eastern_1": "datetime64[ns, US/Eastern]",
+        "default_2": "object",
+        "utc_2": "object",
+        "eastern_2": "object",
+    }
     return pd.DataFrame(
-        {
+        data=[
+            [
+                "2022-01-01",
+                "2022-01-01 00:00:00+00:00",
+                "2022-01-01 00:00:00-05:00",
+                "2022-01-01",
+                "2022-01-01T00:00:00+00:00",
+                "2022-01-01 00:00:00-05:00",
+            ],
+            [
+                "2022-01-02",
+                "2022-01-02 00:00:00+00:00",
+                "2022-01-02 00:00:00-05:00",
+                "2022-01-02",
+                "2022-01-02T00:00:00+00:00",
+                "2022-01-02 00:00:00-05:00",
+            ],
+            ["NaT", "NaT", "NaT", "NaT", "NaT", "NaT"],
+        ],
+        columns=["default_1", "utc_1", "eastern_1", "default_2", "utc_2", "eastern_2"],
+    ).astype(dtypes)
 
-            "default_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns]'),
-            "utc_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns, UTC]'),
-            "eastern_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns, US/Eastern]'),
-            "default_2": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype=object),
-            "utc_2": pd.Series(['2022-01-01T00:00:00+00:00', '2022-01-02T00:00:00+00:00', 'NaT'], dtype=object),
-            "eastern_2": pd.Series(['2022-01-01 00:00:00-05:00', '2022-01-02 00:00:00-05:00', 'NaT'], dtype=object),
-        }
-    )
-    
 
 @pytest.fixture()
 def timezones_df_dask(timezones_df_pandas):
     dd = pytest.importorskip("dask.dataframe", reason="Dask not installed, skipping")
     return dd.from_pandas(timezones_df_pandas, npartitions=2)
+
 
 @pytest.fixture(params=["timezones_df_pandas", "timezones_df_dask"])
 def timezones_df(request):

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -920,9 +920,11 @@ def outliers_df(request):
 def timezones_df_pandas():
     return pd.DataFrame(
         {
-            "default": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype=object),
+
+            "default_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns]'),
             "utc_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns, UTC]'),
             "eastern_1": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype='datetime64[ns, US/Eastern]'),
+            "default_2": pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype=object),
             "utc_2": pd.Series(['2022-01-01T00:00:00+00:00', '2022-01-02T00:00:00+00:00', 'NaT'], dtype=object),
             "eastern_2": pd.Series(['2022-01-01 00:00:00-05:00', '2022-01-02 00:00:00-05:00', 'NaT'], dtype=object),
         }
@@ -934,13 +936,6 @@ def timezones_df_dask(timezones_df_pandas):
     dd = pytest.importorskip("dask.dataframe", reason="Dask not installed, skipping")
     return dd.from_pandas(timezones_df_pandas, npartitions=2)
 
-
-@pytest.fixture()
-def timezones_df_spark(timezones_df_pandas):
-    ps = pytest.importorskip("pyspark.pandas", reason="Spark not installed, skipping")
-    return ps.from_pandas(timezones_df_pandas)
-
-
-@pytest.fixture(params=["timezones_df_pandas", "timezones_df_dask", "timezones_df_spark"])
+@pytest.fixture(params=["timezones_df_pandas", "timezones_df_dask"])
 def timezones_df(request):
     return request.getfixturevalue(request.param)


### PR DESCRIPTION
The expected behavior as a result from this PR:

- A `datetime64[ns]` series with no timezone will remain as `datetime64[ns]`. The logical type will have no timezone.
- A `datetime64[ns, UTC]` series will change to  `datetime64[ns]`. The logical type will store the UTC timezone.
- A `datetime64[ns, US/Eastern]` series will change to `datetime64[ns]`. The logical type will store the ET timezone.
- A series that contains datetime strings with timezones will be converted to UTC and then changed to `datetime64[ns]`. The logical types will store the UTC timezone.
- A series that contains datetime strings with no timezones will change to `datetime64[ns]`. The logical types will have no timezone.


#### Limitations

I found a few inconsistencies in pandas, dask, and spark when handling timezones.

- Dask cannot create metadata for timezones

    ```
    >>> series = dd.to_datetime(pd.Series(['2022-01-01T00:00:00+00:00']))
    >>> series.dt.tz_localize('UTC').dt.tz
    TypeError: Don't know how to create metadata from UTC
    ```

- Dask mismatches datetime dtypes between delayed and computed series.

    ```
    >>> x = dd.to_datetime(pd.Series(['2022-01-01T00:00:00+00:00']))

    Dask Series Structure:
    npartitions=1
    0    datetime64[ns]
    0               ...
    dtype: datetime64[ns]
    Dask Name: to_datetime, 2 tasks

    >>> x.compute()

    0   2022-01-01 00:00:00+00:00
    dtype: datetime64[ns, UTC]
    ```

- Pandas and dask cannot infer timezones from strings except UTC. It will return timezone offsets instead.

    ```
    >>> dtype = 'datetime64[ns, US/Eastern]'
    >>> x = pd.Series(['2022-01-01', '2022-01-02', 'NaT'], dtype=dtype)
    >>> pd.to_datetime(x.astype(str))

        0   2022-01-01 00:00:00-05:00
    1   2022-01-02 00:00:00-05:00
    2                         NaT
    dtype: datetime64[ns, pytz.FixedOffset(-300)]

    >>> pd.to_datetime(x.astype(str), utc=True)

    0   2022-01-01 05:00:00+00:00
    1   2022-01-02 05:00:00+00:00
    2                         NaT
    dtype: datetime64[ns, UTC]
    ```

-  Spark doesn't support dateime series with timezones.

    ```
    >>> data = ['2022-01-01 00:00:00+00:00', '2022-01-02 00:00:00+00:00', 'NaT']
    >>> ps.from_pandas(pd.Series(data, dtype='datetime64[ns, UTC]'))
    TypeError: Type datetime64[ns, UTC] was not understood.

    >>> ps.from_pandas(pd.Series(data)).astype('datetime64[ns, UTC]')
    TypeError: Type datetime64[ns, UTC] was not understood.
    ```

Closes #111