### PR TITLE
Add postal code inference

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Uses ``string[pyarrow]`` instead of ``string`` dtype to save memory (:pr:`1360`)
         * Added a better error message when dataframe and schema have different columns (:pr:`1366`)
         * Added type inference for phone numbers (:pr:`1357`)
+        * Added type inference for zip code (:pr:``)
     * Fixes
         * Cap pandas at 1.4.1 (:pr:`1373`)
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Future Release
         * Uses ``string[pyarrow]`` instead of ``string`` dtype to save memory (:pr:`1360`)
         * Added a better error message when dataframe and schema have different columns (:pr:`1366`)
         * Added type inference for phone numbers (:pr:`1357`)
-        * Added type inference for zip code (:pr:``)
+        * Added type inference for zip code (:pr:`1378`)
     * Fixes
         * Cap pandas at 1.4.1 (:pr:`1373`)
     * Changes

--- a/woodwork/config.py
+++ b/woodwork/config.py
@@ -18,6 +18,7 @@ CONFIG_DEFAULTS = {
 """.splitlines()
     ),
     "phone_inference_regex": r"(?:\+?(0{2})?1[-.\s●]?)?\(?([2-9][0-9]{2})\)?[-\.\s●]?([2-9][0-9]{2})[-\.\s●]?([0-9]{4})$",
+    "postal_code_inference_regex": r"^[0-9]{5}(?:-[0-9]{4})?$",
     "nan_values": ["", "None", "nan", "NaN", "<NA>", "null"],
     "frequence_inference_window_length": 15,
     "frequence_inference_threshold": 0.9,

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -671,12 +671,26 @@ class PostalCode(LogicalType):
 
             ["90210"
              "60018-0123",
-             "SW1A"]
+             "10010"]
     """
 
     primary_dtype = "category"
     backup_dtype = "string[pyarrow]"
     standard_tags = {"category"}
+
+    def validate(self, series, return_invalid_values=False):
+        """Validates PostalCode values based on the regex in the config. Currently only validates US Postal codes.
+
+        Args:
+            series (Series): Series of PostalCode values.
+            return_invalid_values (bool): Whether or not to return invalid PostalCodes.
+
+        Returns:
+            Series: If return_invalid_values is True, returns invalid PostalCodes.
+        """
+        return _regex_validate(
+            "postal_code_inference_regex", series, return_invalid_values
+        )
 
 
 _NULLABLE_PHYSICAL_TYPES = {
@@ -727,6 +741,7 @@ def _regex_validate(regex_key, series, return_invalid_values):
                 "url_inference_regex": "url",
                 "email_inference_regex": "email address",
                 "phone_inference_regex": "phone number",
+                "postal_code_inference_regex": "postal code",
             }[regex_key]
 
             info = f"Series {series.name} contains invalid {type_string} values. "

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -137,6 +137,20 @@ def sample_df_phone_numbers():
 
 
 @pytest.fixture()
+def sample_df_postal_code():
+    return pd.DataFrame(
+        {
+            "postal_code": [
+                "20020",
+                "07865",
+                "12345-6789",
+                "11111-1111",
+            ]
+        }
+    )
+
+
+@pytest.fixture()
 def datetime_freqs_df_pandas():
     return pd.DataFrame(
         {

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -371,6 +371,25 @@ def test_string_dtype_validate(sample_df):
     assert lt.dtype == "string[pyarrow]"
 
 
+def test_postal_code_validate(sample_df_postal_code):
+    pc = PostalCode()
+    series = sample_df_postal_code["postal_code"]
+    invalid_types = pd.Series(
+        [
+            "hello",
+            "HELLO",
+            "51342-HEL0",
+        ]
+    )
+    series = series.append(invalid_types)
+    series.name = "postal_code"
+    match = "Series postal_code contains invalid postal code values. "
+    match += "The postal_code_inference_regex can be changed in the config if needed."
+
+    with pytest.raises(TypeValidationError, match=match):
+        pc.validate(series)
+
+
 def test_postal_code_validate_complex(sample_df_postal_code):
     pc = PostalCode()
     series = sample_df_postal_code["postal_code"]

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -17,6 +17,7 @@ from woodwork.logical_types import (
     LatLong,
     Ordinal,
     PhoneNumber,
+    PostalCode,
 )
 from woodwork.tests.testing_utils.table_utils import to_pandas
 from woodwork.utils import import_or_none
@@ -368,3 +369,27 @@ def test_string_dtype_validate(sample_df):
     assert logical_type.validate(series) is None
     lt = logical_type.transform(series)
     assert lt.dtype == "string[pyarrow]"
+
+
+def test_postal_code_validate_complex(sample_df_postal_code):
+    pc = PostalCode()
+    series = sample_df_postal_code["postal_code"]
+    invalid_types = pd.Series(
+        [
+            "1234",
+            "123455",
+            "123456789",
+            "1234-65433",
+            "K1A0B1",  # Canadian formatting
+            "K1A 0B1",
+            "K1A-0B1",
+            "DT1 1AE",  # UK formatting
+            "DT1-1AE",
+            "DT11AE",
+        ]
+    )
+    actual = pc.validate(series, return_invalid_values=True)
+    assert not len(actual)
+    series = series.append(invalid_types)
+    actual = pc.validate(series, return_invalid_values=True)
+    pd.testing.assert_series_equal(actual, invalid_types)

--- a/woodwork/type_sys/inference_functions.py
+++ b/woodwork/type_sys/inference_functions.py
@@ -143,6 +143,9 @@ email_address_func = InferWithRegex(
 phone_number_func = InferWithRegex(
     lambda: ww.config.get_option("phone_inference_regex")
 )
+postal_code_func = InferWithRegex(
+    lambda: ww.config.get_option("postal_code_inference_regex")
+)
 url_func = InferWithRegex(lambda: ww.config.get_option("url_inference_regex"))
 ip_address_func = InferWithRegex(
     lambda: (

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -12,6 +12,7 @@ from .inference_functions import (
     ip_address_func,
     natural_language_func,
     phone_number_func,
+    postal_code_func,
     timedelta_func,
     url_func,
 )
@@ -69,7 +70,7 @@ DEFAULT_INFERENCE_FUNCTIONS = {
     NaturalLanguage: natural_language_func,
     Ordinal: None,
     PhoneNumber: phone_number_func,
-    PostalCode: None,
+    PostalCode: postal_code_func,
     SubRegionCode: None,
     Timedelta: timedelta_func,
     URL: url_func,


### PR DESCRIPTION
fix #1312 

Only adds inference for US postal codes. Other countries, like [UK](https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s16.html) and [Canadian](https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s15.html) postal codes, follow different formats.