### PR TITLE
Parallelize tests

### DIFF
--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Non-serialization' }}
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Serialization' }}
         name: Run Serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
@@ -72,7 +72,7 @@ jobs:
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'everything_else' }}
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Non-serialization' }}
         name: Run Non-serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-        libraries: ["core", "dask", "spark"]
+        directories: ["everything_else", "accessor"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -38,36 +38,51 @@ jobs:
       - name: Install woodwork - tests requirements
         run: |
           python -m pip install unpacked_sdist/[test]
-      - if: ${{ matrix.libraries == 'spark' }}
-        name: Install woodwork - spark requirements
+      - name: Install Dask and Spark
         run: |
           sudo apt update
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
-      - if: ${{ matrix.libraries == 'dask' }}
-        name: Install woodwork - dask requirements
-        run: |
           python -m pip install unpacked_sdist/[dask]
-      - if: ${{ matrix.python_version != 3.8 }}
-        name: Run unit tests (no code coverage)
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'accessor' }}
+        name: Run Accessor Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/ -n 2 --durations 0
+          pytest woodwork/tests/accessor/ -n 2 --durations 0
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
-      - if: ${{ matrix.python_version == 3.8 }}
-        name: Run unit tests with code coverage
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'everything_else' }}
+        name: Run all other Unit Tests (no code coverage)
+        run: |
+          cd unpacked_sdist
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/ --durations 0
+        env:
+          PYARROW_IGNORE_TIMEZONE: 1
+          ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'accessor' }}
+        name: Run Accessor Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/ -n 2 --cov=woodwork --cov-config=../.coveragerc
+          pytest woodwork/tests/accessor/ -n 2 --cov=woodwork --cov-config=../.coveragerc
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'everything_else' }}
+          name: Run all other Unit Tests with code coverage
+          run: |
+            python -m pip install "$(cat setup.cfg | grep codecov)"
+            coverage erase
+            cd unpacked_sdist/
+            coverage erase
+            pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/ --cov=woodwork --cov-config=../.coveragerc
+          env:
+            PYARROW_IGNORE_TIMEZONE: 1
+            ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -50,6 +50,7 @@ jobs:
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
           python -m pip install "$(cat setup.cfg | grep codecov)"
+          coverage erase
           cd unpacked_sdist
           coverage erase
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  PYARROW_IGNORE_TIMEZONE: 1
+  ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
+
 name: Unit Tests - Latest Dependencies
 jobs:
   unit_latest_tests:
@@ -50,17 +54,11 @@ jobs:
         run: |
           cd unpacked_sdist
           pytest woodwork/tests/accessor/test_serialization.py -n 2 --durations 0
-        env:
-          PYARROW_IGNORE_TIMEZONE: 1
-          ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Non-serialization' }}
         name: Run Non-serialization Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0
-        env:
-          PYARROW_IGNORE_TIMEZONE: 1
-          ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Serialization' }}
         name: Run Serialization Unit Tests with code coverage
         run: |
@@ -69,9 +67,6 @@ jobs:
           cd unpacked_sdist/
           coverage erase
           pytest woodwork/tests/accessor/test_serialization.py -n 2 --cov=woodwork --cov-config=../.coveragerc
-        env:
-          PYARROW_IGNORE_TIMEZONE: 1
-          ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Non-serialization' }}
         name: Run Non-serialization Unit Tests with code coverage
         run: |
@@ -80,9 +75,6 @@ jobs:
           cd unpacked_sdist/
           coverage erase
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --cov=woodwork --cov-config=../.coveragerc
-        env:
-          PYARROW_IGNORE_TIMEZONE: 1
-          ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -50,64 +50,47 @@ jobs:
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
           python -m pip install "$(cat setup.cfg | grep codecov)"
-          coverage erase
           cd unpacked_sdist
           coverage erase
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run testing to Disk with LatLong Unit Tests (no code coverage)
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests (no code coverage)
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests (no code coverage)
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests (no code coverage)
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run Testing to Disk with LatLong Unit Tests with code coverage
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests with code coverage
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests with code coverage
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests with code coverage
         run: |
-          ls
           cd unpacked_sdist
-          ls
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-        directories: ["All Other Tests", "Testing to Disk with LatLong", "All other Serialization"]
+        directories: ["All Other Tests", "Testing Table Accessor", "Testing to Disk with LatLong", "All other Serialization"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -59,11 +59,16 @@ jobs:
         run: |
           cd unpacked_sdist
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing Table Accessor' }}
+        name: Run Table Accessor Unit Tests (no code coverage)
+        run: |
+          cd unpacked_sdist
+          pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run Serialization Unit Tests with code coverage
         run: |
@@ -80,6 +85,14 @@ jobs:
           cd unpacked_sdist/
           coverage erase
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing Table Accessor' }}
+        name: Run Table Accessor Unit Tests with code coverage
+        run: |
+          python -m pip install "$(cat setup.cfg | grep codecov)"
+          coverage erase
+          cd unpacked_sdist/
+          coverage erase
+          pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run Non-serialization Unit Tests with code coverage
         run: |
@@ -87,7 +100,7 @@ jobs:
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0 --cov=woodwork --cov-config=../.coveragerc
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -53,8 +53,7 @@ jobs:
         name: Run unit tests (no code coverage)
         run: |
           cd unpacked_sdist
-          ls
-          make test
+          pytest woodwork/ -n 2 --durations 0
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-        directories: ["Non-serialization", "Serialization"]
+        directories: ["All Other Tests", "Testing to Disk with LatLong", "All other Serialization"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -49,32 +49,45 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Serialization' }}
-        name: Run Serialization Unit Tests (no code coverage)
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
+        name: Run testing to Disk with LatLong Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/tests/accessor/test_serialization.py -n 2 --durations 0
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Non-serialization' }}
-        name: Run Non-serialization Unit Tests (no code coverage)
+          pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All other Serialization' }}
+        name: Run all other Serialization Unit Tests (no code coverage)
+        run: |
+          cd unpacked_sdist
+          pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All Other Tests' }}
+        name: Run all other Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Serialization' }}
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run Serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/tests/accessor/test_serialization.py -n 2 --cov=woodwork --cov-config=../.coveragerc
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Non-serialization' }}
+          pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All other Serialization' }}
+        name: Run Serialization Unit Tests with code coverage
+        run: |
+          python -m pip install "$(cat setup.cfg | grep codecov)"
+          coverage erase
+          cd unpacked_sdist/
+          coverage erase
+          pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run Non-serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --cov=woodwork --cov-config=../.coveragerc
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -52,7 +52,7 @@ jobs:
         name: Run unit tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/ -n 2
+          make test
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -57,35 +57,49 @@ jobs:
         name: Run testing to Disk with LatLong Unit Tests (no code coverage)
         run: |
           ls
+          cd unpacked_sdist
+          ls
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests (no code coverage)
         run: |
+          ls
+          cd unpacked_sdist
           ls
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests (no code coverage)
         run: |
           ls
+          cd unpacked_sdist
+          ls
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests (no code coverage)
         run: |
+          ls
+          cd unpacked_sdist
           ls
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run Testing to Disk with LatLong Unit Tests with code coverage
         run: |
           ls
+          cd unpacked_sdist
+          ls
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests with code coverage
         run: |
           ls
+          cd unpacked_sdist
+          ls
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests with code coverage
         run: |
+          ls
+          cd unpacked_sdist
           ls
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -49,7 +49,10 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
+          python -m pip install "$(cat setup.cfg | grep codecov)"
+          coverage erase
           cd unpacked_sdist
+          coverage erase
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run testing to Disk with LatLong Unit Tests (no code coverage)
         run: |
@@ -69,30 +72,18 @@ jobs:
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run Testing to Disk with LatLong Unit Tests with code coverage
         run: |
-          python -m pip install "$(cat setup.cfg | grep codecov)"
-          coverage erase
-          coverage erase
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests with code coverage
         run: |
-          python -m pip install "$(cat setup.cfg | grep codecov)"
-          coverage erase
-          coverage erase
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests with code coverage
         run: |
-          python -m pip install "$(cat setup.cfg | grep codecov)"
-          coverage erase
-          coverage erase
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests with code coverage
         run: |
-          python -m pip install "$(cat setup.cfg | grep codecov)"
-          coverage erase
-          coverage erase
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 2
       - name: Build woodwork package
         run: make package_woodwork
       - name: Set up pip
@@ -52,6 +53,7 @@ jobs:
         name: Run unit tests (no code coverage)
         run: |
           cd unpacked_sdist
+          ls
           make test
         env:
           PYARROW_IGNORE_TIMEZONE: 1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -73,16 +73,16 @@ jobs:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'everything_else' }}
-          name: Run all other Unit Tests with code coverage
-          run: |
-            python -m pip install "$(cat setup.cfg | grep codecov)"
-            coverage erase
-            cd unpacked_sdist/
-            coverage erase
-            pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/ --cov=woodwork --cov-config=../.coveragerc
-          env:
-            PYARROW_IGNORE_TIMEZONE: 1
-            ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
+        name: Run all other Unit Tests with code coverage
+        run: |
+          python -m pip install "$(cat setup.cfg | grep codecov)"
+          coverage erase
+          cd unpacked_sdist/
+          coverage erase
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/ --cov=woodwork --cov-config=../.coveragerc
+        env:
+          PYARROW_IGNORE_TIMEZONE: 1
+          ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -49,40 +49,35 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
+          cd unpacked_sdist
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run testing to Disk with LatLong Unit Tests (no code coverage)
         run: |
-          cd unpacked_sdist
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests (no code coverage)
         run: |
-          cd unpacked_sdist
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests (no code coverage)
         run: |
-          cd unpacked_sdist
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests (no code coverage)
         run: |
-          cd unpacked_sdist
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
-        name: Run Serialization Unit Tests with code coverage
+        name: Run Testing to Disk with LatLong Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
-          cd unpacked_sdist/
           coverage erase
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All other Serialization' }}
-        name: Run Serialization Unit Tests with code coverage
+        name: Run all other Serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
-          cd unpacked_sdist/
           coverage erase
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing Table Accessor' }}
@@ -90,15 +85,13 @@ jobs:
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
-          cd unpacked_sdist/
           coverage erase
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}
-        name: Run Non-serialization Unit Tests with code coverage
+        name: Run all other Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
-          cd unpacked_sdist/
           coverage erase
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -81,10 +81,12 @@ jobs:
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests with code coverage
         run: |
+          ls
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests with code coverage
         run: |
+          ls
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests with code coverage

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-        directories: ["all other", "Serialization and Table Accessor"]
+        directories: ["Non-serialization", "Serialization"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -49,32 +49,32 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Serialization and Table Accessor' }}
-        name: Run Serialization and Table Accessor Unit Tests (no code coverage)
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Serialization' }}
+        name: Run Serialization Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/tests/accessor/test_serialization.py woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'all other' }}
-        name: Run all other Unit Tests (no code coverage)
+          pytest woodwork/tests/accessor/test_serialization.py -n 2 --durations 0
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Non-serialization' }}
+        name: Run Non-serialization Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Serialization and Table Accessor' }}
-        name: Run Serialization and Table Accessor Unit Tests with code coverage
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Serialization' }}
+        name: Run Serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/tests/accessor/test_serialization.py woodwork/tests/accessor/test_table_accessor.py -n 2 --cov=woodwork --cov-config=../.coveragerc
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'all other' }}
-        name: Run all other Unit Tests with code coverage
+          pytest woodwork/tests/accessor/test_serialization.py -n 2 --cov=woodwork --cov-config=../.coveragerc
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Non-serialization' }}
+        name: Run Non-serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --cov=woodwork --cov-config=../.coveragerc
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-        directories: ["Non-serialization", "Serialization"]
+        directories: ["all other", "Serialization and Table Accessor"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -49,32 +49,32 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Serialization' }}
-        name: Run Serialization Unit Tests (no code coverage)
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Serialization and Table Accessor' }}
+        name: Run Serialization and Table Accessor Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/tests/accessor/test_serialization.py -n 2 --durations 0
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Non-serialization' }}
-        name: Run Non-serialization Unit Tests (no code coverage)
+          pytest woodwork/tests/accessor/test_serialization.py woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'all other' }}
+        name: Run all other Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Serialization' }}
-        name: Run Serialization Unit Tests with code coverage
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Serialization and Table Accessor' }}
+        name: Run Serialization and Table Accessor Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/tests/accessor/test_serialization.py -n 2 --cov=woodwork --cov-config=../.coveragerc
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Non-serialization' }}
-        name: Run Non-serialization Unit Tests with code coverage
+          pytest woodwork/tests/accessor/test_serialization.py woodwork/tests/accessor/test_table_accessor.py -n 2 --cov=woodwork --cov-config=../.coveragerc
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'all other' }}
+        name: Run all other Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --cov=woodwork --cov-config=../.coveragerc
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -105,6 +105,9 @@ jobs:
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests with code coverage
         run: |
+          ls
+          cd unpacked_sdist
+          ls
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 }}
         name: Upload coverage to Codecov

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -45,7 +45,7 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'accessor' }}
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'serialization' }}
         name: Run Accessor Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
@@ -61,7 +61,7 @@ jobs:
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'accessor' }}
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'serialization' }}
         name: Run Accessor Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -9,13 +9,13 @@ on:
 name: Unit Tests - Latest Dependencies
 jobs:
   unit_latest_tests:
-    name: ${{ matrix.python_version }} unit tests ${{ matrix.libraries }}
+    name: ${{ matrix.python_version }} ${{ matrix.directories }} unit tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-        directories: ["everything_else", "accessor"]
+        directories: ["everything_else", "serialization"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -49,7 +49,7 @@ jobs:
         name: Run Accessor Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/tests/accessor/ -n 2 --durations 0
+          pytest woodwork/tests/accessor/test_serialization.py -n 2 --durations 0
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
@@ -57,7 +57,7 @@ jobs:
         name: Run all other Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/ --durations 0
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
@@ -68,7 +68,7 @@ jobs:
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/tests/accessor/ -n 2 --cov=woodwork --cov-config=../.coveragerc
+          pytest woodwork/tests/accessor/test_serialization.py -n 2 --cov=woodwork --cov-config=../.coveragerc
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
@@ -79,7 +79,7 @@ jobs:
           coverage erase
           cd unpacked_sdist/
           coverage erase
-          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/ --cov=woodwork --cov-config=../.coveragerc
+          pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --cov=woodwork --cov-config=../.coveragerc
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -56,22 +56,27 @@ jobs:
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run testing to Disk with LatLong Unit Tests (no code coverage)
         run: |
+          ls
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests (no code coverage)
         run: |
+          ls
           pytest woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Testing Table Accessor' }}
         name: Run Table Accessor Unit Tests (no code coverage)
         run: |
+          ls
           pytest woodwork/tests/accessor/test_table_accessor.py -n 2 --durations 0
       - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'All Other Tests' }}
         name: Run all other Unit Tests (no code coverage)
         run: |
+          ls
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --ignore=woodwork/tests/accessor/test_table_accessor.py --durations 0
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Testing to Disk with LatLong' }}
         name: Run Testing to Disk with LatLong Unit Tests with code coverage
         run: |
+          ls
           pytest woodwork/tests/accessor/test_serialization.py::test_to_disk_with_latlong -n 2 --durations 0 --cov=woodwork --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'All other Serialization' }}
         name: Run all other Serialization Unit Tests with code coverage

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
-        directories: ["everything_else", "serialization"]
+        directories: ["Non-serialization", "Serialization"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2
@@ -45,24 +45,24 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install unpacked_sdist/[spark]
           python -m pip install unpacked_sdist/[dask]
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'serialization' }}
-        name: Run Accessor Unit Tests (no code coverage)
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Serialization' }}
+        name: Run Serialization Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
           pytest woodwork/tests/accessor/test_serialization.py -n 2 --durations 0
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
-      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'everything_else' }}
-        name: Run all other Unit Tests (no code coverage)
+      - if: ${{ matrix.python_version != 3.8 && matrix.directories == 'Non-serialization' }}
+        name: Run Non-serialization Unit Tests (no code coverage)
         run: |
           cd unpacked_sdist
           pytest woodwork/ -n 2 --ignore=woodwork/tests/accessor/test_serialization.py --durations 0
         env:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
-      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'serialization' }}
-        name: Run Accessor Unit Tests with code coverage
+      - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'Non-serialization' }}
+        name: Run Serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase
@@ -73,7 +73,7 @@ jobs:
           PYARROW_IGNORE_TIMEZONE: 1
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False
       - if: ${{ matrix.python_version == 3.8 && matrix.directories == 'everything_else' }}
-        name: Run all other Unit Tests with code coverage
+        name: Run Non-serialization Unit Tests with code coverage
         run: |
           python -m pip install "$(cat setup.cfg | grep codecov)"
           coverage erase

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,7 @@ lint-fix:
 
 .PHONY: test
 test:
-	pytest woodwork/ --durations 10
-
-.PHONY: test-logical-types
-test-logical-types:
-	pytest woodwork/tests/logical_types/ --durations 0
+	pytest woodwork/
 
 .PHONY: testcoverage
 testcoverage:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ lint-fix:
 
 .PHONY: test
 test:
-	pytest woodwork/
+	pytest woodwork/ -n 2 --durations 0
+
+.PHONY: test-logical-types
+test-logical-types:
+	pytest woodwork/tests/logical_types/ --durations 0
 
 .PHONY: testcoverage
 testcoverage:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint-fix:
 
 .PHONY: test
 test:
-	pytest woodwork/ -n 2 --durations 0
+	pytest woodwork/ --durations 10
 
 .PHONY: test-logical-types
 test-logical-types:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,7 +26,7 @@ Future Release
         * Separate testing matrix to speed up GitHub Actions Linux tests for latest dependencies :pr:`1380`
 
     Thanks to the following people for contributing to this release:
-    :user:`bchen1116`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`ParthivNaresh`, :user:`rwedge`, :user:`thehomebrewnerd`, :user:`ParthivNaresh`
+    :user:`bchen1116`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`ParthivNaresh`, :user:`rwedge`, :user:`thehomebrewnerd`
 
 v0.15.0 Mar 24, 2022
 ====================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -22,9 +22,9 @@ Future Release
         * Upgrade nbconvert and remove jinja2 dependency (:pr:`1362`)
         * Add M1 installation instructions to docs and contributing guide (:pr:`1367`)
     * Testing Changes
-
+        * Separate testing matrix to speed up GitHub Actions Linux tests for latest dependencies :pr:`1380`
     Thanks to the following people for contributing to this release:
-    :user:`bchen1116`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`ParthivNaresh`, :user:`rwedge`, :user:`thehomebrewnerd`
+    :user:`bchen1116`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`ParthivNaresh`, :user:`rwedge`, :user:`thehomebrewnerd`, :user:`ParthivNaresh`
 
 v0.15.0 Mar 24, 2022
 ====================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,6 +24,7 @@ Future Release
         * Update README text to Alteryx (:pr:`1381`)
     * Testing Changes
         * Separate testing matrix to speed up GitHub Actions Linux tests for latest dependencies :pr:`1380`
+
     Thanks to the following people for contributing to this release:
     :user:`bchen1116`, :user:`gsheni`, :user:`jeff-hernandez`, :user:`ParthivNaresh`, :user:`rwedge`, :user:`thehomebrewnerd`, :user:`ParthivNaresh`
 


### PR DESCRIPTION
Fixes: #760 

The issue surrounding the current testing time is primarily associated with `accessor/test_serialization.py` and `accessor/test_table_accessor.py.` These two files contain several tests accounting for the vast majority of the testing time.

Within `test_serialization.py`, `test_to_disk_with_latlong` itself takes around 4 min to run.

Taking the past 10 Linux Test GitHub jobs, the average time until completion is currently 18 min and 4 seconds.

After separating out the serialization tests, over the past 10 jobs the new average time until completion was 12 min and 44 seconds, a 30% improvement.

After further separation (the proposed implementation), over the past 10 jobs the new average time until completion was 10 min and 35 seconds, a 41% improvement.