### PR TITLE
Add new slack link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ As you can see, Woodwork makes it easy to manage typing information for your dat
 The Woodwork community is happy to provide support to users of Woodwork. Project support can be found in four places depending on the type of question:
 1. For usage questions, use [Stack Overflow](https://stackoverflow.com/questions/tagged/woodwork) with the `woodwork` tag.
 2. For bugs, issues, or feature requests start a [Github issue](https://github.com/alteryx/woodwork/issues).
-3. For discussion regarding development on the core library, use [Slack](https://join.slack.com/t/alteryx-oss/shared_invite/zt-6inxevps-RSbpr9lsACE1kObXz4rIuA).
+3. For discussion regarding development on the core library, use [Slack](https://join.slack.com/t/alteryx-oss/shared_invite/zt-182tyvuxv-NzIn6eiCEf8TBziuKp0bNA).
 4. For everything else, the core developers can be reached by email at open_source_support@alteryx.com
 
 ## Built at Alteryx

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Future Release
     * Fixes
     * Changes
     * Documentation Changes
-        * Update slack invite link to new (:pr:`1406`, :pr:`1407`)
+        * Update slack invite link to new (:pr:`1406`, :pr:`1407`, :pr:`1408`)
     * Testing Changes
         * Add workflow to kickoff Featuretools unit tests with Woodwork main (:pr:`1400`)
 


### PR DESCRIPTION
@thehomebrewnerd sorry about that. moving too fast. The old link is:
- https://join.slack.com/t/alteryx-oss/shared_invite/zt-6inxevps-RSbpr9lsACE1kObXz4rIuA

The new link is:
- https://join.slack.com/t/alteryx-oss/shared_invite/zt-182tyvuxv-NzIn6eiCEf8TBziuKp0bNA