### PR TITLE
Add a workflow for testing Woodwork without test dependencies

### DIFF
--- a/.github/workflows/simple_test_without_test_dependencies.yml
+++ b/.github/workflows/simple_test_without_test_dependencies.yml
@@ -1,0 +1,39 @@
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+name: Woodwork Usage without Test Dependencies
+jobs:
+  use_woodwork_without_test_dependencies:
+    name: Woodwork Usage without Test Dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Set up python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Build woodwork and install
+        run: |
+          make package_woodwork
+          python -m pip install unpacked_sdist/
+      - name: Run simple woodwork usage
+        run: |
+          import pandas as pd
+          import woodwork as ww
+          df = ww.demo.load_retail(nrows=100, init_woodwork=False)
+          df.ww.init(name="retail")
+          logical_types = list({k: str(v) for k, v in df.ww.logical_types.items()}.values())
+          assert logical_types = ['Integer', 'Integer', 'Unknown', 'NaturalLanguage', 'Integer', 'Datetime', 'Double', 'Categorical', 'Categorical', 'Double', 'Boolean']
+          filtered_df = df.ww.select(include=['numeric', 'Boolean'])
+          assert filtered_df.shape == (100, 6)
+        shell: python

--- a/.github/workflows/test_without_test_dependencies.yml
+++ b/.github/workflows/test_without_test_dependencies.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
 
-name: Woodwork Usage without Test Dependencies
+name: Test Woodwork without Test Dependencies
 jobs:
   use_woodwork_without_test_dependencies:
-    name: Woodwork Usage without Test Dependencies
+    name: Test Woodwork without Test Dependencies
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test_without_test_dependencies.yml
+++ b/.github/workflows/test_without_test_dependencies.yml
@@ -33,7 +33,7 @@ jobs:
           df = ww.demo.load_retail(nrows=100, init_woodwork=False)
           df.ww.init(name="retail")
           logical_types = list({k: str(v) for k, v in df.ww.logical_types.items()}.values())
-          assert logical_types = ['Integer', 'Integer', 'Unknown', 'NaturalLanguage', 'Integer', 'Datetime', 'Double', 'Categorical', 'Categorical', 'Double', 'Boolean']
+          assert logical_types == ['Integer', 'Integer', 'Unknown', 'NaturalLanguage', 'Integer', 'Datetime', 'Double', 'Categorical', 'Categorical', 'Double', 'Boolean']
           filtered_df = df.ww.select(include=['numeric', 'Boolean'])
           assert filtered_df.shape == (100, 6)
         shell: python

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Update slack invite link to new (:pr:`1406`, :pr:`1407`, :pr:`1408`)
     * Testing Changes
         * Add workflow to kickoff Featuretools unit tests with Woodwork main (:pr:`1400`)
+	* Add workflow for testing Woodwork without test dependencies (:pr:`1414`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`


### PR DESCRIPTION
- This workflow adds a test to Woodwork to install `core` Woodwork, and use the library