### PR TITLE
concat_columns handles DataFrames with differing rows

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Updated concat_columns to work with dataframes with mismatched indices or different shapes (:pr:`1485`)
     * Changes
     * Documentation Changes
        * Add instructions to add new users to woodwork feedstock (:pr:`1483`)
@@ -22,7 +23,7 @@ v0.17.1 July 29, 2022
 
     Thanks to the following people for contributing to this release:
     :user:`bchen1116`, :user:`gsheni`
-    
+
 v0.17.0 July 14, 2022
 =====================
     .. warning::

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Future Release
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`chukarsten`
 
 v0.17.1 July 29, 2022
 =====================

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -281,20 +281,3 @@ def test_updated_ltype_inference(integers, type_sys):
             inferred_type = type_sys.infer_logical_type(series.astype(dtype))
             assert isinstance(inferred_type, Integer)
             assert inferred_type.primary_dtype == "string"
-
-
-import numpy as np
-import pytest
-
-
-@pytest.mark.parametrize("none_type", [None, np.nan, pd.NA])
-@pytest.mark.parametrize("pass_logical_types", [True, False])
-def test_boolean_inference(none_type, pass_logical_types):
-    df = pd.DataFrame({"boolean": [none_type, True, False, True]})
-    if pass_logical_types:
-        with pytest.raises(Exception):
-            # Would expect init to fail as you're trying to coerce a boolean to bool.
-            df.ww.init(logical_types={"boolean": Boolean})
-    else:
-        df.ww.init()
-        assert isinstance(df.ww.logical_types["boolean"], BooleanNullable)

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
 
-import pandas as pd
-
 import woodwork as ww
 from woodwork.accessor_utils import _is_spark_series
 from woodwork.logical_types import (

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -517,8 +517,9 @@ def concat_columns(objs, validate_schema=True):
 
     # The lib.concat breaks the woodwork schema for dataframes with different shapes
     # or mismatched indices.
-    null_cols = combined_df.isnull().any()[combined_df.isnull().any()].index
-    if "dask" not in lib.__name__:
+    mask = combined_df.isnull().any()
+    null_cols = mask[mask].index
+    if not ww.accessor_utils._is_dask_dataframe(combined_df):
         null_cols = null_cols.to_numpy()
     else:
         null_cols = list(null_cols)

--- a/woodwork/utils.py
+++ b/woodwork/utils.py
@@ -515,6 +515,20 @@ def concat_columns(objs, validate_schema=True):
 
     combined_df = lib.concat(objs, axis=1, join="outer")
 
+    # The lib.concat breaks the woodwork schema for dataframes with different shapes
+    # or mismatched indices.
+    null_cols = combined_df.isnull().any()[combined_df.isnull().any()].index
+    if "dask" not in lib.__name__:
+        null_cols = null_cols.to_numpy()
+    else:
+        null_cols = list(null_cols)
+    for null_col in null_cols:
+        if null_col in logical_types and isinstance(
+            logical_types[null_col],
+            ww.logical_types.Integer,
+        ):
+            logical_types.pop(null_col)
+
     # Initialize Woodwork with all of the typing information from the input objs
     # performing type inference on any columns that did not already have Woodwork initialized
     combined_df.ww.init(


### PR DESCRIPTION
- When `woodwork.concat_columns` is called on two pandas DataFrames with different numbers of rows or mismatched indices, this causes the underlying library, be it pandas, dask or spark to insert null values into the data where there is no feature support.  This can cause the schema to be invalidated, requiring re-inference.