### PR TITLE
Add create feedstock PR workflow

### DIFF
--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -20,13 +20,12 @@ jobs:
       - name: Pull latest from upstream for user forked feedstock
         run: |
           gh auth status
-          gh repo fork conda-forge/woodwork-feedstock --clone
-          gh repo sync machineAYX/woodwork-feedstock --branch main --source conda-forge/woodwork-feedstock --force
+          gh repo sync alteryx/woodwork-feedstock --branch main --source conda-forge/woodwork-feedstock --force
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
       - uses: actions/checkout@v3
         with:
-          repository: machineAYX/woodwork-feedstock
+          repository: alteryx/woodwork-feedstock
           ref: main
           path: "./woodwork-feedstock"
           fetch-depth: '0'
@@ -46,11 +45,11 @@ jobs:
           git config --unset-all http.https://github.com/.extraheader
           git config --global user.email "machineOSS@alteryx.com"
           git config --global user.name "machineAYX Bot"
-          git remote set-url origin https://${{ secrets.AUTO_APPROVE_TOKEN }}@github.com/machineAYX/woodwork-feedstock
+          git remote set-url origin https://${{ secrets.AUTO_APPROVE_TOKEN }}@github.com/alteryx/woodwork-feedstock
           git checkout -b conda-autocreate-${{ github.event.inputs.pypi_version }}
           git add recipe/meta.yaml
           git commit -m "auto commit"
           git push origin conda-autocreate-${{ github.event.inputs.pypi_version }}
       - name: Adding URL to job output
         run: |
-          echo "Conda Feedstock Pull Request: https://github.com/machineAYX/woodwork-feedstock/pull/new/conda-autocreate-${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "Conda Feedstock Pull Request: https://github.com/alteryx/woodwork-feedstock/pull/new/conda-autocreate-${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -46,10 +46,10 @@ jobs:
           git config --global user.email "machineOSS@alteryx.com"
           git config --global user.name "machineAYX Bot"
           git remote set-url origin https://${{ secrets.AUTO_APPROVE_TOKEN }}@github.com/alteryx/woodwork-feedstock
-          git checkout -b conda-autocreate-${{ github.event.inputs.pypi_version }}
+          git checkout -b ${{ github.event.inputs.pypi_version }}
           git add recipe/meta.yaml
           git commit -m "auto commit"
-          git push origin conda-autocreate-${{ github.event.inputs.pypi_version }}
+          git push origin ${{ github.event.inputs.pypi_version }}
       - name: Adding URL to job output
         run: |
-          echo "Conda Feedstock Pull Request: https://github.com/alteryx/woodwork-feedstock/pull/new/conda-autocreate-${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "Conda Feedstock Pull Request: https://github.com/alteryx/woodwork-feedstock/pull/new/${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
     inputs:
-      pypi_version:
+      version:
         description: 'released PyPI version to use (ex - v1.11.1)'
         required: true
 
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.inputs.pypi_version }}
+          ref: ${{ github.event.inputs.version }}
           path: "./woodwork"
       - name: Pull latest from upstream for user forked feedstock
         run: |
@@ -34,7 +34,7 @@ jobs:
         uses: alteryx/create-feedstock-meta-yaml@v3
         with:
           project: "woodwork"
-          pypi_version: ${{ github.event.inputs.pypi_version }}
+          pypi_version: ${{ github.event.inputs.version }}
           setup_cfg_filepath: "woodwork/setup.cfg"
           meta_yaml_filepath: "woodwork-feedstock/recipe/meta.yaml"
       - name: View updated meta yaml
@@ -46,10 +46,10 @@ jobs:
           git config --global user.email "machineOSS@alteryx.com"
           git config --global user.name "machineAYX Bot"
           git remote set-url origin https://${{ secrets.AUTO_APPROVE_TOKEN }}@github.com/alteryx/woodwork-feedstock
-          git checkout -b ${{ github.event.inputs.pypi_version }}
+          git checkout -b ${{ github.event.inputs.version }}
           git add recipe/meta.yaml
           git commit -m "auto commit"
-          git push origin ${{ github.event.inputs.pypi_version }}
+          git push origin ${{ github.event.inputs.version }}
       - name: Adding URL to job output
         run: |
           echo "Conda Feedstock Pull Request: https://github.com/alteryx/woodwork-feedstock/pull/new/${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -1,0 +1,56 @@
+on:
+  workflow_dispatch:
+    inputs:
+      pypi_version:
+        description: 'released PyPI version to use (ex - v1.11.1)'
+        required: true
+
+name: Create Feedstock PR
+jobs:
+  create_feedstock_pr:
+    name: Create Feedstock PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout inputted version
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.inputs.pypi_version }}
+          path: "./woodwork"
+      - name: Pull latest from upstream for user forked feedstock
+        run: |
+          gh auth status
+          gh repo fork conda-forge/woodwork-feedstock --clone
+          gh repo sync machineAYX/woodwork-feedstock --branch main --source conda-forge/woodwork-feedstock --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          repository: machineAYX/woodwork-feedstock
+          ref: main
+          path: "./woodwork-feedstock"
+          fetch-depth: '0'
+      - name: Run Create Feedstock meta YAML
+        id: create-feedstock-meta
+        uses: alteryx/create-feedstock-meta-yaml@v3
+        with:
+          project: "woodwork"
+          pypi_version: ${{ github.event.inputs.pypi_version }}
+          setup_cfg_filepath: "woodwork/setup.cfg"
+          meta_yaml_filepath: "woodwork-feedstock/recipe/meta.yaml"
+      - name: View updated meta yaml
+        run: cat woodwork-feedstock/recipe/meta.yaml
+      - name: Push updated yaml
+        run: |
+          cd woodwork-feedstock
+          git config --unset-all http.https://github.com/.extraheader
+          git config --global user.email "machineOSS@alteryx.com"
+          git config --global user.name "machineAYX Bot"
+          git remote set-url origin https://${{ secrets.AUTO_APPROVE_TOKEN }}@github.com/machineAYX/woodwork-feedstock
+          git checkout -b conda-autocreate-${{ github.event.inputs.pypi_version }}
+          git add recipe/meta.yaml
+          git commit -m "auto commit"
+          git push origin conda-autocreate-${{ github.event.inputs.pypi_version }}
+      - name: Adding URL to job output
+        run: |
+          echo "Conda Feedstock Pull Request: https://github.com/machineAYX/woodwork-feedstock/pull/new/conda-autocreate-${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -52,4 +52,4 @@ jobs:
           git push origin ${{ github.event.inputs.version }}
       - name: Adding URL to job output
         run: |
-          echo "Conda Feedstock Pull Request: https://github.com/alteryx/woodwork-feedstock/pull/new/${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "Conda Feedstock Pull Request: https://github.com/alteryx/woodwork-feedstock/pull/new/${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,8 @@ Future Release
     * Documentation Changes
        * Add instructions to add new users to woodwork feedstock (:pr:`1483`)
     * Testing Changes
-
+       * Add create feedstock PR workflow (:pr:`1489`)
+        
     Thanks to the following people for contributing to this release:
     :user:`gsheni`
 

--- a/release.md
+++ b/release.md
@@ -93,8 +93,10 @@ In order to release on conda-forge, you can either wait for a bot to create a PR
     * You will need to visit this URL, and create a PR.
     * You can also create the PR by clicking the branch name (ex - `v0.13.3`): 
       - https://github.com/alteryx/woodwork-feedstock/branches
-5. Verify the `requirements['run']` (in __recipe/meta.yml__) match the `install_requires` in __woodwork/setup.cfg__.
-    * Verify the `test['requires']` (in __recipe/meta.yml__) match the test requirements in `[options.extras_require]` in __woodwork/setup.cfg__
+5. Verify that the PR has the following: 
+    * The build number is 0
+    * The `requirements['run']` (in __recipe/meta.yml__) match the `install_requires` in __woodwork/setup.cfg__.
+    * The `test['requires']` (in __recipe/meta.yml__) match the test requirements in `[options.extras_require]` in __woodwork/setup.cfg__
 
 ### Option 2: Waiting for bot to create new PR
 

--- a/release.md
+++ b/release.md
@@ -102,15 +102,10 @@ In order to release on conda-forge, you can either wait for a bot to create a PR
 3. After tests pass, a maintainer will merge the PR in
 
 # Miscellaneous
-## Add new maintainers to woodwork-feedstock
+## Add new maintainers to woodwwork-feedstock
 
 Per the instructions [here](https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list):
-1. Ask an existing maintainer to create an issue on the [repo](https://github.com/conda-forge/woodwork-feedstock).
-  a. Select *Bot commands* and put the following title (change `username`):
-
-  ```text
-  @conda-forge-admin, please add user @username
-  ```
-
+1. Ask an existing maintainer to create an issue on the [repo](https://github.com/conda-forge/woodwwork-feedstock).
+    - Select *Bot commands* and put the following title (change `username`): `@conda-forge-admin, please add user @username`
 2. A PR will be auto-created on the repo, and will need to be merged by an existing maintainer.
 3. The new user will need to **check their email for an invite link to click**, which should be https://github.com/conda-forge

--- a/release.md
+++ b/release.md
@@ -94,7 +94,7 @@ In order to release on conda-forge, you can either wait for a bot to create a PR
     * You can also create the PR by clicking the branch name (ex - `v0.13.3`): 
       - https://github.com/alteryx/woodwork-feedstock/branches
 5. Verify that the PR has the following: 
-    * The build number is 0
+    * The `build['number']` is reset 0 (in __recipe/meta.yml__)
     * The `requirements['run']` (in __recipe/meta.yml__) match the `install_requires` in __woodwork/setup.cfg__.
     * The `test['requires']` (in __recipe/meta.yml__) match the test requirements in `[options.extras_require]` in __woodwork/setup.cfg__
 

--- a/release.md
+++ b/release.md
@@ -81,22 +81,36 @@ After the release pull request has been merged into the `main` branch, it is tim
 - Release description should be the full Release Notes updates for the release, including the line thanking contributors. Contributors should also have their links changed from the docs syntax (:user:\`gsheni\`) to github syntax (@gsheni)
 - This is not a pre-release
 - Publishing the release will automatically upload the package to PyPI
-
 ## Release on conda-forge
+
+In order to release on conda-forge, you can either wait for a bot to create a PR, or manually kickoff the creation with GitHub Actions
+
+### Option 1: Manually create the new PR with GitHub Actions
+1. Go to this GitHub Action: https://github.com/alteryx/woodwork/actions/workflows/create_feedstock_pr.yaml
+2. Input the released version with the v prefix (e.g. v0.13.3)
+3. Kickoff the GitHub action, and monitor the Job Summary.
+4. At the completion of the job, you should see summary output, with a URL. You will need to visit this URL, and create a PR.
+    * You can also just go to: https://github.com/machineAYX/woodwork-feedstock/pull/new/conda-autocreate-v0.13.3 
+    * *Change the last part to the released version*
+5. Verify the `requirements['run']` (in __recipe/meta.yml__) match the `install_requires` in __woodwork/setup.cfg__.
+    * Verify the `test['requires']` (in __recipe/meta.yml__) match the test requirements in `[options.extras_require]` in __woodwork/setup.cfg__
+
+### Option 2: Waiting for bot to create new PR
 
 1. A bot should automatically create a new PR in [conda-forge/woodwork-feedstock](https://github.com/conda-forge/woodwork-feedstock/pulls) - note, the PR may take up to a few hours to be created
 2. Update requirements changes in `recipe/meta.yaml` (bot should have handled version and source links on its own)
 3. After tests pass, a maintainer will merge the PR in
 
-# Adding users to woodwork-feedstock
+# Miscellaneous
+## Add new maintainers to woodwork-feedstock
 
 Per the instructions [here](https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list):
-1. Go to the repo: [conda-forge/woodwork-feedstock](https://github.com/conda-forge/woodwork-feedstock/issues)
-2. Create an issue with the following title (change `username`):
+1. Ask an existing maintainer to create an issue on the [repo](https://github.com/conda-forge/woodwork-feedstock).
+  a. Select *Bot commands* and put the following title (change `username`):
 
   ```text
   @conda-forge-admin, please add user @username
   ```
 
-3. A PR will be automatically created on the repo, and will need to be merged by an existing maintainer.
-4. The new user will need to **check their email for an invite link to click**, which should be https://github.com/conda-forge
+2. A PR will be auto-created on the repo, and will need to be merged by an existing maintainer.
+3. The new user will need to **check their email for an invite link to click**, which should be https://github.com/conda-forge

--- a/release.md
+++ b/release.md
@@ -89,9 +89,10 @@ In order to release on conda-forge, you can either wait for a bot to create a PR
 1. Go to this GitHub Action: https://github.com/alteryx/woodwork/actions/workflows/create_feedstock_pr.yaml
 2. Input the released version with the v prefix (e.g. v0.13.3)
 3. Kickoff the GitHub action, and monitor the Job Summary.
-4. At the completion of the job, you should see summary output, with a URL. You will need to visit this URL, and create a PR.
-    * You can also just go to: https://github.com/machineAYX/woodwork-feedstock/pull/new/conda-autocreate-v0.13.3 
-    * *Change the last part to the released version*
+4. At the completion of the job, you should see summary output, with a URL. 
+    * You will need to visit this URL, and create a PR.
+    * You can also create the PR by clicking the branch name (ex - `conda-autocreate-v0.13.3`): 
+      - https://github.com/alteryx/woodwork-feedstock/branches
 5. Verify the `requirements['run']` (in __recipe/meta.yml__) match the `install_requires` in __woodwork/setup.cfg__.
     * Verify the `test['requires']` (in __recipe/meta.yml__) match the test requirements in `[options.extras_require]` in __woodwork/setup.cfg__
 

--- a/release.md
+++ b/release.md
@@ -91,7 +91,7 @@ In order to release on conda-forge, you can either wait for a bot to create a PR
 3. Kickoff the GitHub action, and monitor the Job Summary.
 4. At the completion of the job, you should see summary output, with a URL. 
     * You will need to visit this URL, and create a PR.
-    * You can also create the PR by clicking the branch name (ex - `conda-autocreate-v0.13.3`): 
+    * You can also create the PR by clicking the branch name (ex - `v0.13.3`): 
       - https://github.com/alteryx/woodwork-feedstock/branches
 5. Verify the `requirements['run']` (in __recipe/meta.yml__) match the `install_requires` in __woodwork/setup.cfg__.
     * Verify the `test['requires']` (in __recipe/meta.yml__) match the test requirements in `[options.extras_require]` in __woodwork/setup.cfg__

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ test =
     moto[all] >= 3.0.7
     smart-open >= 5.0.0
     pyarrow >= 4.0.1
-    six>=1.11.0
+    six >= 1.11.0
 
 dask =
     dask[dataframe] >= 2021.10.0


### PR DESCRIPTION
- Use a github action to instantly create a feedstock pull request when our library is release on PyPI
- Uses this workflow action: https://github.com/alteryx/create-feedstock-meta-yaml