### PR TITLE
Fix LatLong.transform on empty dask data

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,13 +7,14 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Fix applying LatLong.transform to empty dask data (:pr:`1507`)
     * Changes
     * Documentation Changes
     * Testing Changes
         * Update development requirements and use latest for documentation (:pr:`1499`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`rwedge`
 
 v0.17.2 August 5, 2022
 ======================

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -533,9 +533,8 @@ class LatLong(LogicalType):
 
         if _is_dask_series(series):
             name = series.name
-            meta = (series, tuple([float, float]))
+            meta = (name, tuple([float, float]))
             series = series.apply(_reformat_to_latlong, meta=meta)
-            series.name = name
         elif _is_spark_series(series):
             formatted_series = series.to_pandas().apply(
                 _reformat_to_latlong,

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -702,10 +702,12 @@ def latlong_df(request):
 def empty_latlong_df_pandas():
     return pd.DataFrame({"latlong": []}, dtype="object")
 
+
 @pytest.fixture()
 def empty_latlong_df_dask(empty_latlong_df_pandas):
     dd = pytest.importorskip("dask.dataframe", reason="Dask not installed, skipping")
     return dd.from_pandas(empty_latlong_df_pandas, npartitions=2)
+
 
 @pytest.fixture()
 def empty_latlong_df_spark(empty_latlong_df_pandas):
@@ -716,9 +718,17 @@ def empty_latlong_df_spark(empty_latlong_df_pandas):
         ),
     )
 
-@pytest.fixture(params=["empty_latlong_df_pandas", "empty_latlong_df_dask", "empty_latlong_df_spark"])
+
+@pytest.fixture(
+    params=[
+        "empty_latlong_df_pandas",
+        "empty_latlong_df_dask",
+        "empty_latlong_df_spark",
+    ],
+)
 def empty_latlong_df(request):
     return request.getfixturevalue(request.param)
+
 
 # LatLong Fixtures for testing access to latlong values
 @pytest.fixture

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -698,6 +698,28 @@ def latlong_df(request):
     return request.getfixturevalue(request.param)
 
 
+@pytest.fixture()
+def empty_latlong_df_pandas():
+    return pd.DataFrame({"latlong": []}, dtype="object")
+
+@pytest.fixture()
+def empty_latlong_df_dask(empty_latlong_df_pandas):
+    dd = pytest.importorskip("dask.dataframe", reason="Dask not installed, skipping")
+    return dd.from_pandas(empty_latlong_df_pandas, npartitions=2)
+
+@pytest.fixture()
+def empty_latlong_df_spark(empty_latlong_df_pandas):
+    ps = pytest.importorskip("pyspark.pandas", reason="Spark not installed, skipping")
+    return ps.from_pandas(
+        empty_latlong_df_pandas.applymap(
+            lambda tup: list(tup) if isinstance(tup, tuple) else tup,
+        ),
+    )
+
+@pytest.fixture(params=["empty_latlong_df_pandas", "empty_latlong_df_dask", "empty_latlong_df_spark"])
+def empty_latlong_df(request):
+    return request.getfixturevalue(request.param)
+
 # LatLong Fixtures for testing access to latlong values
 @pytest.fixture
 def pandas_latlongs():

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -155,6 +155,25 @@ def test_latlong_transform(latlong_df):
         pd.testing.assert_series_equal(actual, expected)
 
 
+def test_latlong_transform_empty_series(empty_latlong_df):
+    df_type = str(type(empty_latlong_df))
+    dask = "dask" in df_type
+    spark = "spark" in df_type
+
+    latlong = LatLong()
+    series = empty_latlong_df['latlong']
+    actual = latlong.transform(series)
+
+    if dask:
+        actual = actual.compute()
+    elif spark:
+        actual = actual.to_pandas()
+
+    assert actual.empty
+    assert actual.name == "latlong"
+    assert actual.dtype == latlong.primary_dtype
+
+
 def test_latlong_validate(latlong_df):
     error_message = re.escape(
         "Cannot initialize Woodwork. Series does not contain properly formatted "

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from woodwork.accessor_utils import _is_spark_series, init_series
+from woodwork.accessor_utils import _is_dask_series, _is_spark_series, init_series
 from woodwork.exceptions import (
     TypeConversionError,
     TypeConversionWarning,
@@ -156,17 +156,13 @@ def test_latlong_transform(latlong_df):
 
 
 def test_latlong_transform_empty_series(empty_latlong_df):
-    df_type = str(type(empty_latlong_df))
-    _is_dask_dataframe = "dask" in df_type
-    _is_spark_dataframe = "spark" in df_type
-
     latlong = LatLong()
     series = empty_latlong_df["latlong"]
     actual = latlong.transform(series)
 
-    if _is_dask_dataframe:
+    if _is_dask_series(actual):
         actual = actual.compute()
-    elif _is_spark_dataframe:
+    elif _is_spark_series(actual):
         actual = actual.to_pandas()
 
     assert actual.empty

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -157,16 +157,16 @@ def test_latlong_transform(latlong_df):
 
 def test_latlong_transform_empty_series(empty_latlong_df):
     df_type = str(type(empty_latlong_df))
-    dask = "dask" in df_type
-    spark = "spark" in df_type
+    is_dask = "dask" in df_type
+    is_spark = "spark" in df_type
 
     latlong = LatLong()
     series = empty_latlong_df['latlong']
     actual = latlong.transform(series)
 
-    if dask:
+    if is_dask:
         actual = actual.compute()
-    elif spark:
+    elif is_spark:
         actual = actual.to_pandas()
 
     assert actual.empty

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -157,16 +157,16 @@ def test_latlong_transform(latlong_df):
 
 def test_latlong_transform_empty_series(empty_latlong_df):
     df_type = str(type(empty_latlong_df))
-    is_dask = "dask" in df_type
-    is_spark = "spark" in df_type
+    _is_dask_dataframe = "dask" in df_type
+    _is_spark_dataframe = "spark" in df_type
 
     latlong = LatLong()
     series = empty_latlong_df["latlong"]
     actual = latlong.transform(series)
 
-    if is_dask:
+    if _is_dask_dataframe:
         actual = actual.compute()
-    elif is_spark:
+    elif _is_spark_dataframe:
         actual = actual.to_pandas()
 
     assert actual.empty

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -161,7 +161,7 @@ def test_latlong_transform_empty_series(empty_latlong_df):
     is_spark = "spark" in df_type
 
     latlong = LatLong()
-    series = empty_latlong_df['latlong']
+    series = empty_latlong_df["latlong"]
     actual = latlong.transform(series)
 
     if is_dask:
@@ -687,12 +687,14 @@ def test_null_invalid_postal_code_numeric():
 
 
 @pytest.mark.parametrize(
-    "null_type", [None, pd.NA, pd.NaT, np.nan, "null", "N/A", "mix", 5]
+    "null_type",
+    [None, pd.NA, pd.NaT, np.nan, "null", "N/A", "mix", 5],
 )
 @pytest.mark.parametrize("data_type", [int, float])
 def test_integer_nullable(data_type, null_type):
     nullable_nums = pd.DataFrame(
-        map(data_type, [1, 2, 3, 4, 5] * 20), columns=["num_nulls"]
+        map(data_type, [1, 2, 3, 4, 5] * 20),
+        columns=["num_nulls"],
     )
     nullable_nums["num_nulls"].iloc[-5:] = (
         [None, pd.NA, np.nan, "NA", "none"]
@@ -711,7 +713,8 @@ def test_integer_nullable(data_type, null_type):
 
 
 @pytest.mark.parametrize(
-    "null_type", [None, pd.NA, pd.NaT, np.nan, "null", "N/A", "mix", True]
+    "null_type",
+    [None, pd.NA, pd.NaT, np.nan, "null", "N/A", "mix", True],
 )
 def test_boolean_nullable(null_type):
     nullable_bools = pd.DataFrame([True, False] * 50, columns=["bool_nulls"])
@@ -724,7 +727,8 @@ def test_boolean_nullable(null_type):
 
     if not isinstance(null_type, bool):
         assert isinstance(
-            nullable_bools.ww.logical_types["bool_nulls"], BooleanNullable
+            nullable_bools.ww.logical_types["bool_nulls"],
+            BooleanNullable,
         )
         assert all(nullable_bools["bool_nulls"][-5:].isna())
     else:


### PR DESCRIPTION
The `LatLong.transform` method had an issue when trying to transform an empty dask series.

The `meta` parameter for the dask `Series.apply` can be a tuple but if so it should be `(name, dtype)`.  The code was using `(series, dtype)`.

I believe this also removes the need to set `series.name` after the apply