### PR TITLE
Fix minimum dependency checker

### DIFF
--- a/.github/workflows/minimum_dependency_checker.yaml
+++ b/.github/workflows/minimum_dependency_checker.yaml
@@ -29,7 +29,7 @@ jobs:
           paths: 'pyproject.toml'
           options: 'dependencies'
           output_filepath: 'woodwork/tests/requirement_files/minimum_core_requirements.txt'
-      - name: Run min dep generator - core reqs
+      - name: Run min dep generator - core + spark reqs
         id: min_dep_gen_spark
         uses: alteryx/minimum-dependency-generator@v3
         with:
@@ -37,7 +37,7 @@ jobs:
           options: 'dependencies'
           extras_require: 'spark'
           output_filepath: 'woodwork/tests/requirement_files/minimum_spark_requirements.txt'
-      - name: Run min dep generator - dask
+      - name: Run min dep generator - core + dask
         id: min_dep_gen_dask
         uses: alteryx/minimum-dependency-generator@v3
         with:

--- a/.github/workflows/minimum_dependency_checker.yaml
+++ b/.github/workflows/minimum_dependency_checker.yaml
@@ -30,7 +30,7 @@ jobs:
           options: 'dependencies'
           output_filepath: 'woodwork/tests/requirement_files/minimum_core_requirements.txt'
       - name: Run min dep generator - core reqs
-        id: min_dep_gen_core
+        id: min_dep_gen_spark
         uses: alteryx/minimum-dependency-generator@v3
         with:
           paths: 'pyproject.toml'

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Future Release
     * Fixes
         * Fix applying LatLong.transform to empty dask data (:pr:`1507`)
     * Changes
-        * Transition from setup.cfg to pyproject.toml (:pr:`1506`)
+        * Transition from setup.cfg to pyproject.toml (:pr:`1506`,:pr:`1508`)
         * Added a check to see if a series dtype has changed prior to using ``_replace_nans`` (:pr:`1502`)
     * Documentation Changes
     * Testing Changes


### PR DESCRIPTION
- Fixes the following error:
```
The workflow is not valid. .github/workflows/minimum_dependency_checker.yaml (Line: 33, Col: 13): The identifier 'min_dep_gen_core' may not be used more than once within the same scope.
```
- Passing Run:
  - https://github.com/alteryx/woodwork/actions/runs/2957508891