### PR TITLE
Add kickoff for create conda forge pull request from release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,3 +16,8 @@ jobs:
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         TEST_PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
         TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+    - name: Run workflow to create feedstock pull request
+      run: |
+        gh workflow run create_feedstock_pr.yaml --repo "alteryx/woodwork" -f version=${{ github.event.release.tag_name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Add kickoff for create conda forge pull request from release (:pr:`1515`)
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`gsheni`
 
 v0.18.0 August 31, 2022
 =======================

--- a/release.md
+++ b/release.md
@@ -85,21 +85,25 @@ After the release pull request has been merged into the `main` branch, it is tim
 
 In order to release on conda-forge, you can either wait for a bot to create a pull request, or manually kickoff the creation with GitHub Actions
 
-### Option 1: Manually create the new pull request with GitHub Actions
-1. Go to this GitHub Action: https://github.com/alteryx/woodwork/actions/workflows/create_feedstock_pr.yaml
-2. Click **Run workflow** and input the letter `v` followed by the release version (e.g. `v0.13.3`)
-3. Kickoff the GitHub Action, and monitor the Job Summary.
-4. At the completion of the job, you should see summary output, with a URL.
-    * Visit this URL and create a pull request.
-    * Alternatively, create the pull request by clicking the branch name (e.g. - `v0.13.3`):
+### Option a: Use a GitHub Action workflow
+
+1. After the package has been uploaded on PyPI, the **Create Feedstock Pull Request** workflow should automatically kickoff a job. 
+    * If it does not, go [here](https://github.com/alteryx/woodwork/actions/workflows/create_feedstock_pr.yaml)
+    * Click **Run workflow** and input the letter `v` followed by the release version (e.g. `v0.13.3`)
+    * Kickoff the GitHub Action, and monitor the Job Summary.
+2. Once the job has been completed, you will see summary output, with a URL. 
+    * Visit that URL and create a pull request.
+    * Alternatively, create the pull request by clicking the branch name (e.g. - `v0.13.3`): 
       - https://github.com/alteryx/woodwork-feedstock/branches
-5. Verify that the PR has the following:
+3. Verify that the PR has the following: 
     * The `build['number']` is 0 (in __recipe/meta.yml__).
     * The `requirements['run']` (in __recipe/meta.yml__) matches the `[project]['dependencies']` in __woodwork/pyproject.toml__.
     * The `test['requires']` (in __recipe/meta.yml__) matches the `[project.optional-dependencies]['test']` in __woodwork/pyproject.toml__
-6. Satisfy the conditions in pull request description and **merge it if the CI passes**.
+    > There will be 2 entries for graphviz: `graphviz` and `python-graphviz`. 
+    > Make sure `python-graphviz` (in __recipe/meta.yml__) matches `graphviz` in `[project.optional-dependencies]['test']` in __woodwork/pyproject.toml__.
+4. Satisfy the conditions in pull request description and **merge it if the CI passes**. 
 
-### Option 2: Waiting for bot to create new PR
+### Option b: Waiting for bot to create new PR
 
 1. A bot should automatically create a new PR in [conda-forge/woodwork-feedstock](https://github.com/conda-forge/woodwork-feedstock/pulls) - note, the PR may take up to a few hours to be created
 2. Update requirements changes in `recipe/meta.yaml` (bot should have handled version and source links on its own)

--- a/release.md
+++ b/release.md
@@ -99,8 +99,6 @@ In order to release on conda-forge, you can either wait for a bot to create a pu
     * The `build['number']` is 0 (in __recipe/meta.yml__).
     * The `requirements['run']` (in __recipe/meta.yml__) matches the `[project]['dependencies']` in __woodwork/pyproject.toml__.
     * The `test['requires']` (in __recipe/meta.yml__) matches the `[project.optional-dependencies]['test']` in __woodwork/pyproject.toml__
-    > There will be 2 entries for graphviz: `graphviz` and `python-graphviz`. 
-    > Make sure `python-graphviz` (in __recipe/meta.yml__) matches `graphviz` in `[project.optional-dependencies]['test']` in __woodwork/pyproject.toml__.
 4. Satisfy the conditions in pull request description and **merge it if the CI passes**. 
 
 ### Option b: Waiting for bot to create new PR

--- a/release.md
+++ b/release.md
@@ -95,11 +95,11 @@ In order to release on conda-forge, you can either wait for a bot to create a pu
     * Visit that URL and create a pull request.
     * Alternatively, create the pull request by clicking the branch name (e.g. - `v0.13.3`): 
       - https://github.com/alteryx/woodwork-feedstock/branches
-3. Verify that the PR has the following: 
+3. Verify that the PR has the following:
     * The `build['number']` is 0 (in __recipe/meta.yml__).
     * The `requirements['run']` (in __recipe/meta.yml__) matches the `[project]['dependencies']` in __woodwork/pyproject.toml__.
     * The `test['requires']` (in __recipe/meta.yml__) matches the `[project.optional-dependencies]['test']` in __woodwork/pyproject.toml__
-4. Satisfy the conditions in pull request description and **merge it if the CI passes**. 
+4. Satisfy the conditions in pull request description and **merge it if the CI passes**.
 
 ### Option b: Waiting for bot to create new PR
 


### PR DESCRIPTION
- Once a release has gone out, we can automatically kickoff the create feedstock pull request workflow
- Updated release.md instructions to capture this