### PR TITLE
Remove Dask upper version limit

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,12 +10,13 @@ Future Release
         * Fix datetime pivot point to be set at current year + 10 rather than the default for two-digit years when ``datetime_format`` provided (:pr:`1512`)
     * Changes
         * Added ``ignore_columns`` as an argument when initializing a dataframe (:pr:`1504`)
+        * Remove ``dask[dataframe]`` version restriction (:pr:`1527`)
     * Documentation Changes
     * Testing Changes
         * Add kickoff for create conda forge pull request from release (:pr:`1515`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`ParthivNaresh`, :user:`bchen1116`
+    :user:`gsheni`, :user:`ParthivNaresh`, :user:`bchen1116`, :user:`thehomebrewnerd`
 
 v0.18.0 August 31, 2022
 =======================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ test = [
     "pyarrow >= 4.0.1",
 ]
 dask = [
-    "dask[dataframe] >= 2021.10.0, <2022.8.0",
+    "dask[dataframe] >= 2021.10.0",
 ]
 spark = [
     "pyspark >= 3.2.0, <3.3.0",

--- a/woodwork/tests/accessor/test_serialization.py
+++ b/woodwork/tests/accessor/test_serialization.py
@@ -673,8 +673,8 @@ def test_to_disk_with_latlong(latlong_df, tmpdir, file_format):
         )
 
         pd.testing.assert_frame_equal(
-            to_pandas(latlong_df, index=latlong_df.ww.index, sort_index=True),
-            to_pandas(deserialized_df, index=deserialized_df.ww.index, sort_index=True),
+            to_pandas(latlong_df).reset_index(drop=True),
+            to_pandas(deserialized_df).reset_index(drop=True),
         )
         assert latlong_df.ww.schema == deserialized_df.ww.schema
 


### PR DESCRIPTION
- Remove Dask upper version restriction
- Closes #1498 

Removes the upper bound on `dask[dataframe]` and updates `test_to_disk_with_latlong` to ignore the index column since we can't rely on Dask maintaining the index column during serialization and the `latlong_df` fixture does not utilize an index column, so the underlying dataframe range/int index isn't meaningful in the test.