### PR TITLE
small typo in `select` docstring

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Replace use of deprecated ``append`` method for dataframes and series with ``concat`` method (:pr:`1533`)
     * Fixes
         * Fixed bug relating to ``dependence`` calculations to ensure columns exist in dataframe (:pr:`1534`)
+        * Small typo fix in ``select`` docstring (:pr:`1544`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/woodwork/table_accessor.py
+++ b/woodwork/table_accessor.py
@@ -586,7 +586,7 @@ class WoodworkTableAccessor:
                 types, semantic tags to include in the DataFrame.
             exclude (str or LogicalType or list[str or LogicalType]): Logical
                 types, semantic tags to exclude from the DataFrame.
-            return_schema (boolen): If True, return only the schema for the
+            return_schema (bool): If True, return only the schema for the
                 matching columns. Defaults to False
 
         Returns:


### PR DESCRIPTION
-  fixed a small typo in `table_accessor.py`. Changed it to `bool`, wasn't sure between `boolean` and `bool` which to prefer as I saw both in file.