### PR TITLE
Fixes FutureWarning messages in `box_plot_dict`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,13 +7,14 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Resolve FutureWarning in `_get_box_plot_info_for_column` (:pr:`1563`)
     * Changes
         * Unpin dask dependency (:pr:`1561`)
     * Documentation Changes
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`sbadithe`
 
 v0.20.0 October 31, 2022
 ========================

--- a/woodwork/statistics_utils/_get_box_plot_info_for_column.py
+++ b/woodwork/statistics_utils/_get_box_plot_info_for_column.py
@@ -112,10 +112,10 @@ def _get_box_plot_info_for_column(
     if include_indices_and_values:
         # identify outliers in the series
         low_series = (
-            series[series < low_bound] if low_bound > min_value else pd.Series()
+            series[series < low_bound] if low_bound > min_value else pd.Series(dtype='float64')
         )
         high_series = (
-            series[series > high_bound] if high_bound < max_value else pd.Series()
+            series[series > high_bound] if high_bound < max_value else pd.Series(dtype='float64')
         )
 
         outliers_dict = {

--- a/woodwork/statistics_utils/_get_box_plot_info_for_column.py
+++ b/woodwork/statistics_utils/_get_box_plot_info_for_column.py
@@ -112,10 +112,14 @@ def _get_box_plot_info_for_column(
     if include_indices_and_values:
         # identify outliers in the series
         low_series = (
-            series[series < low_bound] if low_bound > min_value else pd.Series(dtype='float64')
+            series[series < low_bound]
+            if low_bound > min_value
+            else pd.Series(dtype="float64")
         )
         high_series = (
-            series[series > high_bound] if high_bound < max_value else pd.Series(dtype='float64')
+            series[series > high_bound]
+            if high_bound < max_value
+            else pd.Series(dtype="float64")
         )
 
         outliers_dict = {


### PR DESCRIPTION
I noticed these FutureWarnings when working on the `RollingOutlierPrimitive` in featuretools. 

` FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.`

This PR should resolve the FutureWarnings, which resulted from instantiating a `pd.Series` instance without specifying `dtype.`