### PR TITLE
Fixes error message in `validate` method in `logical_types.py`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Improved ``Boolean`` and ``BooleanNullable`` inference to detect common string representations of boolean values (:pr:`1549`)
     * Fixes
         * Resolve FutureWarning in `_get_box_plot_info_for_column` (:pr:`1563`)
+        * Fixes error message in validate method in logical_types.py (:pr:`1565`)
     * Changes
         * Unpin dask dependency (:pr:`1561`)
     * Documentation Changes

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -83,7 +83,7 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
         valid_dtype = self._get_valid_dtype(type(series))
         if valid_dtype != str(series.dtype):
             raise TypeValidationError(
-                f"Series dtype '{series.dtype}' is incompatible with {self.type_string} LogicalType, try converting to {valid_dtype}",
+                f"Series dtype '{series.dtype}' is incompatible with {self.type_string} LogicalType, try converting to {valid_dtype} dtype",
             )
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -83,7 +83,7 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
         valid_dtype = self._get_valid_dtype(type(series))
         if valid_dtype != str(series.dtype):
             raise TypeValidationError(
-                f"Series dtype '{series.dtype}' is incompatible with {self.type_string} LogicalType.",
+                f"Series dtype '{series.dtype}' is incompatible with {self.type_string} LogicalType, try converting to {valid_dtype}",
             )
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -83,7 +83,7 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
         valid_dtype = self._get_valid_dtype(type(series))
         if valid_dtype != str(series.dtype):
             raise TypeValidationError(
-                f"Series dtype '{series.dtype}' is incompatible with {self.type_string} dtype.",
+                f"Series dtype '{series.dtype}' is incompatible with {self.type_string} LogicalType.",
             )
 
 

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -271,7 +271,7 @@ def test_ordinal_validate(sample_series):
 
     new_type = "string"
     error_message = re.escape(
-        f"Series dtype '{new_type}' is incompatible with ordinal dtype.",
+        f"Series dtype '{new_type}' is incompatible with ordinal LogicalType.",
     )
     with pytest.raises(TypeValidationError, match=error_message):
         ordinal_incomplete_order.validate(sample_series.astype(new_type))

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -271,7 +271,7 @@ def test_ordinal_validate(sample_series):
 
     new_type = "string"
     error_message = re.escape(
-        f"Series dtype '{new_type}' is incompatible with ordinal LogicalType, try converting to {valid_dtype}",
+        f"Series dtype '{new_type}' is incompatible with ordinal LogicalType, try converting to category dtype",
     )
     with pytest.raises(TypeValidationError, match=error_message):
         ordinal_incomplete_order.validate(sample_series.astype(new_type))

--- a/woodwork/tests/logical_types/test_logical_types.py
+++ b/woodwork/tests/logical_types/test_logical_types.py
@@ -271,7 +271,7 @@ def test_ordinal_validate(sample_series):
 
     new_type = "string"
     error_message = re.escape(
-        f"Series dtype '{new_type}' is incompatible with ordinal LogicalType.",
+        f"Series dtype '{new_type}' is incompatible with ordinal LogicalType, try converting to {valid_dtype}",
     )
     with pytest.raises(TypeValidationError, match=error_message):
         ordinal_incomplete_order.validate(sample_series.astype(new_type))


### PR DESCRIPTION
The error message refers to an incompatible `dtype` when it should be `LogicalType`. 