### PR TITLE
Fix division by zero error in `type_system.py` 

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,9 +8,10 @@ Future Release
     * Enhancements
         * Improved ``Boolean`` and ``BooleanNullable`` inference to detect common string representations of boolean values (:pr:`1549`)
     * Fixes
-        * Resolve FutureWarning in `_get_box_plot_info_for_column` (:pr:`1563`)
+        * Resolve FutureWarning in ``_get_box_plot_info_for_column`` (:pr:`1563`)
         * Fixes error message in validate method in logical_types.py (:pr:`1565`)
         * Update demo dataset links to point to new endpoint (:pr:`1570`)
+        * Fix DivisionByZero error in ``type_system.py`` (:pr:`1571`)
     * Changes
         * Unpin dask dependency (:pr:`1561`)
         * Changed the sampling strategy for type inference from ``head`` to random (:pr:`1566`)

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -334,21 +334,21 @@ def pdnas(request):
 
 # Empty Inference Fixtures
 @pytest.fixture
-def pandas_empty():
+def pandas_empty_series():
     return [pd.Series([], dtype="object")]
 
 
 @pytest.fixture
-def dask_empty(pandas_empty):
-    return [pd_to_dask(series) for series in pandas_empty]
+def dask_empty_series(pandas_empty_series):
+    return [pd_to_dask(series) for series in pandas_empty_series]
 
 
 @pytest.fixture
-def pyspark_empty(pandas_empty):
-    return [pd_to_spark(series) for series in pandas_empty]
+def pyspark_empty_series(pandas_empty_series):
+    return [pd_to_spark(series) for series in pandas_empty_series]
 
 
-@pytest.fixture(params=["pandas_empty", "dask_empty", "pyspark_empty"])
+@pytest.fixture(params=["pandas_empty_series", "dask_empty_series", "pyspark_empty_series"])
 def empty_series(request):
     return request.getfixturevalue(request.param)
 

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -332,25 +332,7 @@ def pdnas(request):
     return request.getfixturevalue(request.param)
 
 
-# Empty Inference Fixtures
-@pytest.fixture
-def pandas_empty():
-    return pd.Series([], dtype="object")
 
-
-@pytest.fixture
-def dask_empty(pandas_empty):
-    return pd_to_dask(pandas_empty)
-
-
-@pytest.fixture
-def pyspark_empty(pandas_empty):
-    return pd_to_spark(pandas_empty)
-
-
-@pytest.fixture(params=["pandas_empty", "dask_empty", "pyspark_empty"])
-def empty_series(request):
-    return request.getfixturevalue(request.param)
 
 
 # Null Inference Fixtures

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -332,9 +332,6 @@ def pdnas(request):
     return request.getfixturevalue(request.param)
 
 
-
-
-
 # Null Inference Fixtures
 @pytest.fixture
 def pandas_nulls():

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -331,18 +331,22 @@ def dask_pdnas(pandas_pdnas):
 def pdnas(request):
     return request.getfixturevalue(request.param)
 
+
 # Empty Inference Fixtures
 @pytest.fixture
 def pandas_empty():
-    return pd.Series([], dtype='object')
+    return pd.Series([], dtype="object")
+
 
 @pytest.fixture
 def dask_empty(pandas_empty):
     return pd_to_dask(pandas_empty)
 
+
 @pytest.fixture
 def pyspark_empty(pandas_empty):
     return pd_to_spark(pandas_empty)
+
 
 @pytest.fixture(params=["pandas_empty", "dask_empty", "pyspark_empty"])
 def empty_series(request):

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -335,17 +335,17 @@ def pdnas(request):
 # Empty Series Inference Fixtures
 @pytest.fixture
 def pandas_empty_series():
-    return [pd.Series([], dtype="object")]
+    return pd.Series([], dtype="object")
 
 
 @pytest.fixture
 def dask_empty_series(pandas_empty_series):
-    return [pd_to_dask(series) for series in pandas_empty_series]
+    return pd_to_dask(pandas_empty_series)
 
 
 @pytest.fixture
 def pyspark_empty_series(pandas_empty_series):
-    return [pd_to_spark(series) for series in pandas_empty_series]
+    return pd_to_spark(pandas_empty_series)
 
 
 @pytest.fixture(

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -331,6 +331,23 @@ def dask_pdnas(pandas_pdnas):
 def pdnas(request):
     return request.getfixturevalue(request.param)
 
+# Empty Inference Fixtures
+@pytest.fixture
+def pandas_empty():
+    return pd.Series([], dtype='object')
+
+@pytest.fixture
+def dask_empty(pandas_empty):
+    return pd_to_dask(pandas_empty)
+
+@pytest.fixture
+def pyspark_empty(pandas_empty):
+    return pd_to_spark(pandas_empty)
+
+@pytest.fixture(params=["pandas_empty", "dask_empty", "pyspark_empty"])
+def empty_series(request):
+    return request.getfixturevalue(request.param)
+
 
 # Null Inference Fixtures
 @pytest.fixture

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -332,6 +332,27 @@ def pdnas(request):
     return request.getfixturevalue(request.param)
 
 
+# Empty Inference Fixtures
+@pytest.fixture
+def pandas_empty():
+    return [pd.Series([], dtype="object")]
+
+
+@pytest.fixture
+def dask_empty(pandas_empty):
+    return [pd_to_dask(series) for series in pandas_empty]
+
+
+@pytest.fixture
+def pyspark_empty(pandas_empty):
+    return [pd_to_spark(series) for series in pandas_empty]
+
+
+@pytest.fixture(params=["pandas_empty", "dask_empty", "pyspark_empty"])
+def empty_series(request):
+    return request.getfixturevalue(request.param)
+
+
 # Null Inference Fixtures
 @pytest.fixture
 def pandas_nulls():

--- a/woodwork/tests/type_system/conftest.py
+++ b/woodwork/tests/type_system/conftest.py
@@ -348,7 +348,9 @@ def pyspark_empty_series(pandas_empty_series):
     return [pd_to_spark(series) for series in pandas_empty_series]
 
 
-@pytest.fixture(params=["pandas_empty_series", "dask_empty_series", "pyspark_empty_series"])
+@pytest.fixture(
+    params=["pandas_empty_series", "dask_empty_series", "pyspark_empty_series"]
+)
 def empty_series(request):
     return request.getfixturevalue(request.param)
 

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -252,8 +252,8 @@ def test_unknown_inference_all_null(nulls):
             assert isinstance(inferred_type, Unknown)
 
 
-def test_unknown_inference_empty_series(empty_df):
-    for series in empty_df:
+def test_unknown_inference_empty_series(empty_series):
+    for series in empty_series:
         inferred_type = ww.type_system.infer_logical_type(series.astype("string"))
         inferred_type.transform(series)
         assert isinstance(inferred_type, Unknown)

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -252,6 +252,13 @@ def test_unknown_inference_all_null(nulls):
             assert isinstance(inferred_type, Unknown)
 
 
+def test_unknown_inference_empty_series(empty_series):
+    for series in empty_series:
+        inferred_type = ww.type_system.infer_logical_type(series.astype("string"))
+        inferred_type.transform(series)
+        assert isinstance(inferred_type, Unknown)
+
+
 def test_pdna_inference(pdnas):
     expected_logical_types = [
         NaturalLanguage,

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -253,9 +253,8 @@ def test_unknown_inference_all_null(nulls):
 
 
 def test_unknown_inference_empty_series(empty_series):
-    for series in empty_series:
-        inferred_type = ww.type_system.infer_logical_type(series.astype("string"))
-        assert isinstance(inferred_type, Unknown)
+    inferred_type = ww.type_system.infer_logical_type(empty_series.astype("string"))
+    assert isinstance(inferred_type, Unknown)
 
 
 def test_pdna_inference(pdnas):

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -252,8 +252,8 @@ def test_unknown_inference_all_null(nulls):
             assert isinstance(inferred_type, Unknown)
 
 
-def test_unknown_inference_empty_series(empty_series):
-    for series in empty_series:
+def test_unknown_inference_empty_series(empty_df):
+    for series in empty_df:
         inferred_type = ww.type_system.infer_logical_type(series.astype("string"))
         inferred_type.transform(series)
         assert isinstance(inferred_type, Unknown)

--- a/woodwork/tests/type_system/test_ltype_inference.py
+++ b/woodwork/tests/type_system/test_ltype_inference.py
@@ -255,7 +255,6 @@ def test_unknown_inference_all_null(nulls):
 def test_unknown_inference_empty_series(empty_series):
     for series in empty_series:
         inferred_type = ww.type_system.infer_logical_type(series.astype("string"))
-        inferred_type.transform(series)
         assert isinstance(inferred_type, Unknown)
 
 

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -312,12 +312,13 @@ class TypeSystem(object):
             # Dask and Spark don't accept the n argument
 
             # prevent division by zero error
-            if not len(series):
+            series_len = len(series)
+            if not series_len:
                 return Unknown()
-            kw_args_sampling["frac"] = INFERENCE_SAMPLE_SIZE / len(series)
+            kw_args_sampling["frac"] = INFERENCE_SAMPLE_SIZE / series_len
             if _is_dask_series(series):
                 series = get_random_sample(
-                    series.head(len(series), npartitions=-1), **kw_args_sampling
+                    series.head(series_len, npartitions=-1), **kw_args_sampling
                 )
             elif _is_spark_series(series):
                 series = get_random_sample(series, **kw_args_sampling)

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -310,9 +310,9 @@ class TypeSystem(object):
             series = get_random_sample(series, **kw_args_sampling)
         else:
             # Dask and Spark don't accept the n argument
-            
+
             # prevent division by zero error
-            if not len(series): 
+            if not len(series):
                 return Unknown()
             kw_args_sampling["frac"] = INFERENCE_SAMPLE_SIZE / len(series)
             if _is_dask_series(series):

--- a/woodwork/type_sys/type_system.py
+++ b/woodwork/type_sys/type_system.py
@@ -310,6 +310,10 @@ class TypeSystem(object):
             series = get_random_sample(series, **kw_args_sampling)
         else:
             # Dask and Spark don't accept the n argument
+            
+            # prevent division by zero error
+            if not len(series): 
+                return Unknown()
             kw_args_sampling["frac"] = INFERENCE_SAMPLE_SIZE / len(series)
             if _is_dask_series(series):
                 series = get_random_sample(


### PR DESCRIPTION
- Fixes division by zero error by checking length of series first
- Adds test to `test_ltype_inference.py` to test case with empty series
- This should resolve integration test failures with Featuretools main