### PR TITLE
Rename `backup_dtype` to `pyspark_dtype`

### DIFF
--- a/docs/source/guides/custom_types_and_type_inference.ipynb
+++ b/docs/source/guides/custom_types_and_type_inference.ipynb
@@ -53,7 +53,7 @@
     "    \"\"\"Represents Logical Types that contain 12-digit UPC Codes.\"\"\"\n",
     "\n",
     "    primary_dtype = \"category\"\n",
-    "    backup_dtype = \"string\"\n",
+    "    pyspark_dtype = \"string\"\n",
     "    standard_tags = {\"category\", \"upc_code\"}"
    ]
   },
@@ -64,7 +64,7 @@
     "When defining the `UPCCode` LogicalType class, three class attributes were set. All three of these attributes are optional, and will default to the values defined on the `LogicalType` class if they are not set when defining the new type.\n",
     "\n",
     "- `primary_dtype`: This value specifies how the data will be stored. If the column of the dataframe is not already of this type, Woodwork will convert the data to this dtype. This should be specified as a string that represents a valid pandas dtype. If not specified, this will default to `'string'`.\n",
-    "- `backup_dtype`: This is primarily useful when working with Spark dataframes. `backup_dtype` specifies the dtype to use if Woodwork is unable to convert to the dtype specified by `primary_dtype`. In our example, we set this to `'string'` since Spark does not currently support the `'category'` dtype.\n",
+    "- `pyspark_dtype`: This value specifies the dtype to use if pyspark does not support the dtype specified by `primary_dtype`. In our example, we set this to `'string'` since Spark does not currently support the `'category'` dtype.\n",
     "- `standard_tags`: This is a set of semantic tags to apply to any column that is set with the specified LogicalType. If not specified, `standard_tags` will default to an empty set.\n",
     "- docstring: Adding a docstring for the class is optional, but if specified, this text will be used for adding a description of the type in the list of available types returned by `ww.list_logical_types()`."
    ]

--- a/docs/source/guides/logical_types_and_semantic_tags.ipynb
+++ b/docs/source/guides/logical_types_and_semantic_tags.ipynb
@@ -120,7 +120,7 @@
     "        \"\"\"Base class for all other Logical Types\"\"\"\n",
     "        type_string = ClassNameDescriptor()\n",
     "        primary_dtype = 'string'\n",
-    "        backup_dtype = None\n",
+    "        pyspark_dtype = None\n",
     "        standard_tags = set()\n",
     "    ```\n",
     "\n",
@@ -704,7 +704,7 @@
    "source": [
     "## Checking for nullable logical types\n",
     "\n",
-    "Some logical types support having null values in the underlying data while others do not.  This is entirely based on whether a logical type's underlying primary dtype or backup dtype supports null values.  For example, the `EmailAddress` logical type has an underlying primary dtype of `string`.  Pandas allows series with the dtype `string` to contain null values marked by the `pandas.NA` sentinel.  Therefore, `EmailAddress` supports null values.  On the other hand, the `Integer` logical type does not support null values since its underlying primary pandas dtype is `int64`.  Pandas does not allow null values in series with the dtype `int64`.  However, pandas does allow null values in series with the dtype `Int64`.  Therefore, the `IntegerNullable` logical type supports null values since its primary dtype is `Int64`.\n",
+    "Some logical types support having null values in the underlying data while others do not.  This is entirely based on whether a logical type's underlying `primary_dtype` or `pyspark_dtype` supports null values.  For example, the `EmailAddress` logical type has an underlying primary dtype of `string`.  Pandas allows series with the dtype `string` to contain null values marked by the `pandas.NA` sentinel.  Therefore, `EmailAddress` supports null values.  On the other hand, the `Integer` logical type does not support null values since its underlying primary pandas dtype is `int64`.  Pandas does not allow null values in series with the dtype `int64`.  However, pandas does allow null values in series with the dtype `Int64`.  Therefore, the `IntegerNullable` logical type supports null values since its primary dtype is `Int64`.\n",
     "\n",
     "You can check if a column contains a nullable logical type by using `nullable` on the column accessor.  The sections above that describe each type's characteristics include information about whether or not a logical type is nullable."
    ]

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Rename `backup_dtype` to `pyspark_dtype`
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`sbadithe`
 
 v0.21.0 December 1, 2022
 ========================

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -46,7 +46,7 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
 
     type_string = ClassNameDescriptor()
     primary_dtype = "string"
-    backup_dtype = None
+    pyspark_dtype = None
     standard_tags = set()
 
     def __eq__(self, other, deep=False):
@@ -60,8 +60,8 @@ class LogicalType(object, metaclass=LogicalTypeMetaClass):
     @classmethod
     def _get_valid_dtype(cls, series_type):
         """Return the dtype that is considered valid for a series with the given logical_type"""
-        if ps and series_type == ps.Series and cls.backup_dtype:
-            return cls.backup_dtype
+        if ps and series_type == ps.Series and cls.pyspark_dtype:
+            return cls.pyspark_dtype
         else:
             return cls.primary_dtype
 
@@ -268,7 +268,7 @@ class Categorical(LogicalType):
     """
 
     primary_dtype = "category"
-    backup_dtype = "string"
+    pyspark_dtype = "string"
     standard_tags = {"category"}
 
     def __init__(self, encoding=None):
@@ -289,7 +289,7 @@ class CountryCode(LogicalType):
     """
 
     primary_dtype = "category"
-    backup_dtype = "string"
+    pyspark_dtype = "string"
     standard_tags = {"category"}
 
 
@@ -304,7 +304,7 @@ class CurrencyCode(LogicalType):
     """
 
     primary_dtype = "category"
-    backup_dtype = "string"
+    pyspark_dtype = "string"
     standard_tags = {"category"}
 
 
@@ -649,7 +649,7 @@ class Ordinal(LogicalType):
     """
 
     primary_dtype = "category"
-    backup_dtype = "string"
+    pyspark_dtype = "string"
     standard_tags = {"category"}
 
     def __init__(self, order=None):
@@ -739,7 +739,7 @@ class SubRegionCode(LogicalType):
     """
 
     primary_dtype = "category"
-    backup_dtype = "string"
+    pyspark_dtype = "string"
     standard_tags = {"category"}
 
 
@@ -802,7 +802,7 @@ class PostalCode(LogicalType):
     """
 
     primary_dtype = "category"
-    backup_dtype = "string"
+    pyspark_dtype = "string"
     standard_tags = {"category"}
 
     def transform(self, series, null_invalid_values=False):

--- a/woodwork/tests/accessor/test_table_accessor.py
+++ b/woodwork/tests/accessor/test_table_accessor.py
@@ -262,8 +262,8 @@ def test_accessor_physical_types_property(sample_df):
     assert set(sample_df.ww.physical_types.keys()) == set(sample_df.columns)
     for k, v in sample_df.ww.physical_types.items():
         logical_type = sample_df.ww.columns[k].logical_type
-        if _is_spark_dataframe(sample_df) and logical_type.backup_dtype is not None:
-            assert v == logical_type.backup_dtype
+        if _is_spark_dataframe(sample_df) and logical_type.pyspark_dtype is not None:
+            assert v == logical_type.pyspark_dtype
         else:
             assert v == logical_type.primary_dtype
 


### PR DESCRIPTION
- renames `backup_dtype` to `pyspark_dtype`. As part of the cudf integration, another attribute called `cudf_dtype` will be added. This name will better disambiguate between the two. 