### PR TITLE
Improve handling of `Config` values for boolean inference

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Future Release
         * Schema now maintains column order after renaming a column (:pr:`1594`)
     * Changes
         * Rename `backup_dtype` to `pyspark_dtype` (:pr:`1593`)
-        * Updated ``Config`` and ``_transform_boolean`` to better handle manual setting of boolean inference values (:pr:`1598`)
+        * Updated ``Config`` and ``_transform_boolean`` to better handle manual setting of boolean inference values (:pr:`1599`)
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Future Release
         * Schema now maintains column order after renaming a column (:pr:`1594`)
     * Changes
         * Rename `backup_dtype` to `pyspark_dtype` (:pr:`1593`)
+        * Updated ``Config`` and ``_transform_boolean`` to better handle manual setting of boolean inference values (:pr:`1598`)
     * Documentation Changes
     * Testing Changes
 

--- a/woodwork/config.py
+++ b/woodwork/config.py
@@ -61,7 +61,7 @@ CONFIG_DEFAULTS = {
         ["true", "false"],
         ["t", "f"],
     ],
-    "boolean_inference_ints": [1, 0],
+    "boolean_inference_ints": [[1, 0]],
 }
 
 

--- a/woodwork/logical_types.py
+++ b/woodwork/logical_types.py
@@ -967,8 +967,11 @@ def _coerce_boolean(series, null_invalid_values=False):
 
 
 def _transform_boolean(series, null_invalid_values):
-    boolean_inference_list = config.get_option("boolean_inference_strings")
-    boolean_inference_list.append(config.get_option("boolean_inference_ints"))
+    boolean_inference_list_strings = config.get_option("boolean_inference_strings")
+    boolean_inference_list_ints = config.get_option("boolean_inference_ints")
+    boolean_inference_list = boolean_inference_list_strings
+    if boolean_inference_list_ints:
+        boolean_inference_list.extend(boolean_inference_list_ints)
     valid = {}
     for booleans in boolean_inference_list:
         valid[booleans[0]] = True

--- a/woodwork/type_sys/inference_functions.py
+++ b/woodwork/type_sys/inference_functions.py
@@ -111,9 +111,10 @@ def boolean_nullable_func(series):
         except TypeError:  # Necessary to check for non-hashable values because of object dtype consideration
             return False
     elif pdtypes.is_integer_dtype(series.dtype):
-        series_unique = set(series)
-        if series_unique == set(config.get_option("boolean_inference_ints")):
-            return True
+        if config.get_option("boolean_inference_ints"):
+            series_unique = set(series)
+            if series_unique == set(config.get_option("boolean_inference_ints")):
+                return True
     return False
 
 

--- a/woodwork/type_sys/inference_functions.py
+++ b/woodwork/type_sys/inference_functions.py
@@ -113,8 +113,9 @@ def boolean_nullable_func(series):
     elif pdtypes.is_integer_dtype(series.dtype):
         if config.get_option("boolean_inference_ints"):
             series_unique = set(series)
-            if series_unique == set(config.get_option("boolean_inference_ints")):
-                return True
+            for boolean_list in config.get_option("boolean_inference_ints"):
+                if series_unique == set(boolean_list):
+                    return True
     return False
 
 


### PR DESCRIPTION
If a user attempts to update `boolean_inference_ints` as a config value to be an empty list, this results in an error during boolean inference since `[]` doesn't have positional indexers.