### PR TITLE
Updates for compatibility with numpy 1.24.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,18 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Bump scipy min version for compatibility with numpy 1.24.0 (:pr:`1606`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
 
 v0.21.1 December 16, 2022
 =========================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
-        * Bump scipy min version for compatibility with numpy 1.24.0 (:pr:`1606`)
+        * Bump scipy and scikit-learn min versions for compatibility with numpy 1.24.0 (:pr:`1606`)
     * Documentation Changes
     * Testing Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ license = {file = "LICENSE"}
 requires-python = ">=3.8,<4"
 dependencies = [
     "pandas >= 1.4.0, != 1.4.2",
-    "scikit-learn >= 0.22",
+    "scikit-learn >= 0.24",
     "python-dateutil >= 2.8.1",
     "scipy >= 1.8.0",
     "importlib-resources >= 5.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ license = {file = "LICENSE"}
 requires-python = ">=3.8,<4"
 dependencies = [
     "pandas >= 1.4.0, != 1.4.2",
-    "scikit-learn >= 0.24",
+    "scikit-learn >= 0.22",
     "python-dateutil >= 2.8.1",
-    "scipy >= 1.8.0",
+    "scipy >= 1.4.0",
     "importlib-resources >= 5.10.0",
     "numpy >= 1.21.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pandas >= 1.4.0, != 1.4.2",
     "scikit-learn >= 0.22",
     "python-dateutil >= 2.8.1",
-    "scipy >= 1.4.0",
+    "scipy >= 1.8.0",
     "importlib-resources >= 5.10.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dask = [
 spark = [
     "pyspark >= 3.2.0, <3.3.0",
     "pandas >= 1.4.3",
+    "numpy < 1.24.0",
 ]
 updater = [
     "alteryx-open-src-update-checker >= 2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "scikit-learn >= 0.24",
     "python-dateutil >= 2.8.1",
     "scipy >= 1.8.0",
-    "importlib-resources >= 5.10.0"
+    "importlib-resources >= 5.10.0",
+    "numpy >= 1.21.0",
 ]
 
 [project.urls]

--- a/woodwork/tests/requirement_files/minimum_core_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_core_requirements.txt
@@ -1,6 +1,6 @@
 importlib-resources==5.10.0
 pandas==1.4.0
 python-dateutil==2.8.1
-scikit-learn==0.24
-scipy==1.8.0
+scikit-learn==0.22
+scipy==1.4.0
 numpy==1.21.0

--- a/woodwork/tests/requirement_files/minimum_core_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_core_requirements.txt
@@ -1,5 +1,5 @@
 importlib-resources==5.10.0
 pandas==1.4.0
 python-dateutil==2.8.1
-scikit-learn==0.22
+scikit-learn==0.24
 scipy==1.8.0

--- a/woodwork/tests/requirement_files/minimum_core_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_core_requirements.txt
@@ -2,4 +2,4 @@ importlib-resources==5.10.0
 pandas==1.4.0
 python-dateutil==2.8.1
 scikit-learn==0.22
-scipy==1.4.0
+scipy==1.8.0

--- a/woodwork/tests/requirement_files/minimum_core_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_core_requirements.txt
@@ -3,3 +3,4 @@ pandas==1.4.0
 python-dateutil==2.8.1
 scikit-learn==0.24
 scipy==1.8.0
+numpy==1.21.0

--- a/woodwork/tests/requirement_files/minimum_dask_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_dask_requirements.txt
@@ -2,5 +2,5 @@ dask[dataframe]==2021.10.0
 importlib-resources==5.10.0
 pandas==1.4.0
 python-dateutil==2.8.1
-scikit-learn==0.22
+scikit-learn==0.24
 scipy==1.8.0

--- a/woodwork/tests/requirement_files/minimum_dask_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_dask_requirements.txt
@@ -2,6 +2,6 @@ dask[dataframe]==2021.10.0
 importlib-resources==5.10.0
 pandas==1.4.0
 python-dateutil==2.8.1
-scikit-learn==0.24
-scipy==1.8.0
+scikit-learn==0.22
+scipy==1.4.0
 numpy==1.21.0

--- a/woodwork/tests/requirement_files/minimum_dask_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_dask_requirements.txt
@@ -4,3 +4,4 @@ pandas==1.4.0
 python-dateutil==2.8.1
 scikit-learn==0.24
 scipy==1.8.0
+numpy==1.21.0

--- a/woodwork/tests/requirement_files/minimum_dask_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_dask_requirements.txt
@@ -3,4 +3,4 @@ importlib-resources==5.10.0
 pandas==1.4.0
 python-dateutil==2.8.1
 scikit-learn==0.22
-scipy==1.4.0
+scipy==1.8.0

--- a/woodwork/tests/requirement_files/minimum_spark_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_spark_requirements.txt
@@ -3,4 +3,4 @@ pandas==1.4.3
 pyspark==3.2.0
 python-dateutil==2.8.1
 scikit-learn==0.22
-scipy==1.4.0
+scipy==1.8.0

--- a/woodwork/tests/requirement_files/minimum_spark_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_spark_requirements.txt
@@ -2,6 +2,6 @@ importlib-resources==5.10.0
 pandas==1.4.3
 pyspark==3.2.0
 python-dateutil==2.8.1
-scikit-learn==0.24
-scipy==1.8.0
+scikit-learn==0.22
+scipy==1.4.0
 numpy==1.21.0

--- a/woodwork/tests/requirement_files/minimum_spark_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_spark_requirements.txt
@@ -4,4 +4,4 @@ pyspark==3.2.0
 python-dateutil==2.8.1
 scikit-learn==0.24
 scipy==1.8.0
-numpy==1.23.0
+numpy==1.21.0

--- a/woodwork/tests/requirement_files/minimum_spark_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_spark_requirements.txt
@@ -4,3 +4,4 @@ pyspark==3.2.0
 python-dateutil==2.8.1
 scikit-learn==0.24
 scipy==1.8.0
+numpy==1.23.0

--- a/woodwork/tests/requirement_files/minimum_spark_requirements.txt
+++ b/woodwork/tests/requirement_files/minimum_spark_requirements.txt
@@ -2,5 +2,5 @@ importlib-resources==5.10.0
 pandas==1.4.3
 pyspark==3.2.0
 python-dateutil==2.8.1
-scikit-learn==0.22
+scikit-learn==0.24
 scipy==1.8.0


### PR DESCRIPTION
Update to replace usage of depreciated numpy alias.

Also adds numpy as an explicit core dependency in pyproject.toml since numpy is imported and directly used throughout the code base.