### PR TITLE
Remove `autouse=True` for LatLong fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.262'
+    rev: 'v0.0.263'
     hooks:
       - id: ruff
         args:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,9 +11,10 @@ Future Release
     * Documentation Changes
     * Testing Changes
         * Add Python 3.11 markers, add 3.11 for unit tests & install test (:pr:`1678`)
+        * Remove ``autouse=True`` for LatLong fixtures (:pr:`1689`)
         
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`sbadithe`
     
 v0.23.0 April 12, 2023
 ======================

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -100,7 +100,7 @@ def sample_df_dask(sample_df_pandas):
     return dd.from_pandas(sample_df_pandas, npartitions=1)
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def sample_df_spark(sample_df_pandas):
     ps = pytest.importorskip(
         "pyspark.pandas",

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -100,7 +100,7 @@ def sample_df_dask(sample_df_pandas):
     return dd.from_pandas(sample_df_pandas, npartitions=1)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def sample_df_spark(sample_df_pandas):
     ps = pytest.importorskip(
         "pyspark.pandas",

--- a/woodwork/tests/conftest.py
+++ b/woodwork/tests/conftest.py
@@ -777,7 +777,7 @@ def small_df(request):
     return request.getfixturevalue(request.param)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def latlong_df_pandas():
     return pd.DataFrame(
         {
@@ -794,13 +794,13 @@ def latlong_df_pandas():
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def latlong_df_dask(latlong_df_pandas):
     dd = pytest.importorskip("dask.dataframe", reason="Dask not installed, skipping")
     return dd.from_pandas(latlong_df_pandas, npartitions=1)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def latlong_df_spark(latlong_df_pandas):
     ps = pytest.importorskip("pyspark.pandas", reason="Spark not installed, skipping")
     return ps.from_pandas(


### PR DESCRIPTION
- Fixes #1690