### PR TITLE
Stop calculating `top_values` for Double columns with integer values

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,13 +8,14 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
+        * Stopped calculating ``top_values`` for Double columns with integer values (:pr:`1692`)
     * Documentation Changes
     * Testing Changes
         * Add Python 3.11 markers, add 3.11 for unit tests & install test (:pr:`1678`)
-        
+
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
-    
+    :user:`gsheni`, :user:`tamargrey`
+
 v0.23.0 April 12, 2023
 ======================
     * Fixes

--- a/woodwork/statistics_utils/_get_describe_dict.py
+++ b/woodwork/statistics_utils/_get_describe_dict.py
@@ -4,7 +4,15 @@ from typing import Any, Callable, Dict, Sequence
 import pandas as pd
 
 from woodwork.accessor_utils import _is_dask_dataframe, _is_spark_dataframe
-from woodwork.logical_types import Datetime, Integer, IntegerNullable, LatLong, Unknown
+from woodwork.logical_types import (
+    Age,
+    AgeNullable,
+    Datetime,
+    Integer,
+    IntegerNullable,
+    LatLong,
+    Unknown,
+)
 from woodwork.statistics_utils._get_histogram_values import _get_histogram_values
 from woodwork.statistics_utils._get_mode import _get_mode
 from woodwork.statistics_utils._get_numeric_value_counts_in_range import (
@@ -166,7 +174,10 @@ def _get_describe_dict(
                     values["top_values"] = []
                 else:
                     values["histogram"] = _get_histogram_values(series, bins=bins)
-                    if isinstance(column.logical_type, (Integer, IntegerNullable)):
+                    if isinstance(
+                        column.logical_type,
+                        (Age, AgeNullable, Integer, IntegerNullable),
+                    ):
                         _range = range(int(values["min"]), int(values["max"]) + 1)
                         # Calculate top numeric values if range of values present
                         # is less than or equal number of histogram bins

--- a/woodwork/statistics_utils/_get_describe_dict.py
+++ b/woodwork/statistics_utils/_get_describe_dict.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Sequence
 import pandas as pd
 
 from woodwork.accessor_utils import _is_dask_dataframe, _is_spark_dataframe
-from woodwork.logical_types import Datetime, LatLong, Unknown
+from woodwork.logical_types import Datetime, Integer, IntegerNullable, LatLong, Unknown
 from woodwork.statistics_utils._get_histogram_values import _get_histogram_values
 from woodwork.statistics_utils._get_mode import _get_mode
 from woodwork.statistics_utils._get_numeric_value_counts_in_range import (
@@ -166,16 +166,16 @@ def _get_describe_dict(
                     values["top_values"] = []
                 else:
                     values["histogram"] = _get_histogram_values(series, bins=bins)
-                    _range = range(int(values["min"]), int(values["max"]) + 1)
-                    # Calculate top numeric values if range of values present
-                    # is less than or equal number of histogram bins and series
-                    # contains only integer values
-                    range_len = int(values["max"]) + 1 - int(values["min"])
-                    if range_len <= bins and (series % 1 == 0).all():
-                        values["top_values"] = _get_numeric_value_counts_in_range(
-                            series,
-                            _range,
-                        )
+                    if isinstance(column.logical_type, (Integer, IntegerNullable)):
+                        _range = range(int(values["min"]), int(values["max"]) + 1)
+                        # Calculate top numeric values if range of values present
+                        # is less than or equal number of histogram bins
+                        range_len = int(values["max"]) + 1 - int(values["min"])
+                        if range_len <= bins and (series % 1 == 0).all():
+                            values["top_values"] = _get_numeric_value_counts_in_range(
+                                series,
+                                _range,
+                            )
             elif column.is_categorical:
                 values["top_values"] = _get_top_values_categorical(series, top_x)
             elif column.is_datetime:

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -1369,7 +1369,8 @@ def test_describe_callback(describe_df, mock_callback):
     assert mock_callback.total_elapsed_time > 0
 
 
-def test_describe_dict_extra_stats(describe_df):
+@pytest.mark.parametrize("use_age", [True, False])
+def test_describe_dict_extra_stats(use_age, describe_df):
     describe_df = describe_df.drop(
         columns=[
             "boolean_col",
@@ -1399,6 +1400,17 @@ def test_describe_dict_extra_stats(describe_df):
         "small_range_col_ints_as_double": "Double",
         "small_range_col_double_not_valid": "Double",
     }
+    if use_age:
+        ltypes.update(
+            {
+                "numeric_col": "AgeFractional",
+                "nullable_integer_col": "AgeNullable",
+                "integer_col": "Age",
+                "small_range_col": "Age",
+                "small_range_col_ints_as_double": "AgeFractional",
+                "small_range_col_double_not_valid": "AgeFractional",
+            },
+        )
     describe_df.ww.init(index="index_col", logical_types=ltypes)
     desc_dict = describe_df.ww.describe_dict(extra_stats=True)
 

--- a/woodwork/tests/accessor/test_statistics.py
+++ b/woodwork/tests/accessor/test_statistics.py
@@ -1423,7 +1423,7 @@ def test_describe_dict_extra_stats(describe_df):
     ]:
         assert isinstance(desc_dict[col]["histogram"], list)
         assert desc_dict[col].get("recent_values") is None
-        if col in {"small_range_col", "small_range_col_ints_as_double"}:
+        if col in {"small_range_col"}:
             # If values are in a narrow range, top values should be present
             assert isinstance(desc_dict[col]["top_values"], list)
         else:
@@ -1456,7 +1456,10 @@ def test_describe_dict_extra_stats_overflow_range(
     assert not mock_get_numeric_value_counts_in_range.called
 
     # Confirm we actually have the ability to make it into that block
-    describe_df["small_range_col"] = describe_df["numeric_col"].fillna(0) // 10
+    # by shrinking the range and keeping the integer values
+    describe_df["small_range_col"] = (
+        describe_df["numeric_col"].fillna(0) // 10
+    ).astype("Int64")
     describe_df.ww.init(index="index_col")
     describe_df.ww.describe_dict(extra_stats=True)
     assert mock_get_numeric_value_counts_in_range.called


### PR DESCRIPTION
- Previously, we needed to calculate top values for Double columns with integer values, but now that we no longer need that behavior, we should remove it from `_get_describe_dict`
- Closes #1691