### PR TITLE
Restrict numpy version to fix boolean inference issue

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
+      * Restrict ``numpy`` version to resolve boolean inference issue with v1.25.0 :pr:`1735`
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+  Thanks to the following people for contributing to this release:
+  :user:`thehomebrewnerd`
 
 v0.25.0 Jul 17, 2023
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "python-dateutil >= 2.8.1",
     "scipy >= 1.10.0",
     "importlib-resources >= 5.10.0",
-    "numpy >= 1.22.0",
+    "numpy >= 1.22.0, <1.25.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #1736 
Restrict numpy version to fix boolean inference issue

Adds temporary restriction on upper version of numpy to avoid a boolean inference issue with numpy 1.25.1.