### PR TITLE
Automated Latest Dependency Updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.278'
+    rev: 'v0.0.279'
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
This is an auto-generated PR with **latest** dependency updates. Please do not delete the `latest-dep-update` branch because it's needed by the auto-dependency bot.