### PR TITLE
Automated Latest Dependency Updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         additional_dependencies: [".[jupyter]"]
         types_or: [python, jupyter]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.285'
+    rev: 'v0.0.286'
     hooks:
       - id: ruff
         args:

--- a/woodwork/tests/requirement_files/latest_core_dependencies.txt
+++ b/woodwork/tests/requirement_files/latest_core_dependencies.txt
@@ -1,4 +1,4 @@
 numpy==1.24.4
 pandas==2.0.3
-pyarrow==12.0.1
+pyarrow==13.0.0
 scikit-learn==1.3.0

--- a/woodwork/tests/requirement_files/latest_dask_dependencies.txt
+++ b/woodwork/tests/requirement_files/latest_dask_dependencies.txt
@@ -2,5 +2,5 @@ click==8.1.7
 dask==2023.5.0
 numpy==1.24.4
 pandas==2.0.3
-pyarrow==12.0.1
+pyarrow==13.0.0
 scikit-learn==1.3.0

--- a/woodwork/tests/requirement_files/latest_spark_dependencies.txt
+++ b/woodwork/tests/requirement_files/latest_spark_dependencies.txt
@@ -1,5 +1,5 @@
 numpy==1.23.5
 pandas==1.5.3
-pyarrow==12.0.1
+pyarrow==13.0.0
 pyspark==3.4.1
 scikit-learn==1.3.0


### PR DESCRIPTION
This is an auto-generated PR with **latest** dependency updates. Please do not delete the `latest-dep-update` branch because it's needed by the auto-dependency bot.