### PR TITLE
Temporarily restrict pyarrow version to <13.0.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+      * Temporarily restrict pyarrow version due to serialization issues (:pr:`1768`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+  Thanks to the following people for contributing to this release:
+  :user:`thehomebrewnerd`
 
 v0.26.0 Aug 22, 2023
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ test = [
     "boto3 >= 1.10.45",
     "moto[all] >= 3.0.7",
     "smart-open >= 5.0.0",
-    "pyarrow >= 4.0.1",
+    "pyarrow >= 4.0.1, <13.0.0",
 ]
 dask = [
     "dask[dataframe] >= 2022.11.1",
@@ -70,6 +70,7 @@ spark = [
     "pyspark >= 3.2.2",
     "pandas >= 1.4.3, <2.0.0",
     "numpy < 1.24.0",
+    "pyarrow >= 4.0.1, <13.0.0",
 ]
 updater = [
     "alteryx-open-src-update-checker >= 3.1.0"


### PR DESCRIPTION
Temporarily restrict pyarrow version due to issues with `pyarrow==13.0.0` and serialization to parquet.

- Closes #1767 