### PR TITLE
Use trusted publisher approach for release process and remove numpy upper bound

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,17 +5,25 @@ on:
 name: Release
 jobs:
   pypi:
-    name: Release to PyPI
+    name: PyPI Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-    - uses: actions/checkout@v3
-    - name: Upload to PyPI
-      uses: FeatureLabs/gh-action-pypi-upload@v2
-      env:
-        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        TEST_PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-        TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - name: Install deps
+      run: |
+        python -m pip install --quiet --upgrade pip
+        python -m pip install --quiet --upgrade build
+        python -m pip install --quiet --upgrade setuptools
+    - name: Remove build artifacts and docs
+      run: |
+        rm -rf .eggs/ dist/ build/ docs/
+    - name: Build distribution
+      run: python -m build
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
     - name: Run workflow to create feedstock pull request
       run: |
         gh workflow run create_feedstock_pr.yaml --repo "alteryx/woodwork" -f version=${{ github.event.release.tag_name }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 -------------
 
 Future Release
-  ==============
+==============
     * Enhancements
     * Fixes
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,18 @@
 Release Notes
 -------------
 
-.. Future Release
+Future Release
   ==============
     * Enhancements
     * Fixes
     * Changes
+      * Remove numpy upper bound restriction in ``pyproject.toml`` :pr:`1819`
     * Documentation Changes
     * Testing Changes
+      * Update ``release.yaml`` to use trusted publisher for PyPI releases :pr:`1819`
 
-.. Thanks to the following people for contributing to this release:
+  Thanks to the following people for contributing to this release:
+  :user:`thehomebrewnerd`
 
 v0.28.0 Feb 5, 2024
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "python-dateutil >= 2.8.1",
     "scipy >= 1.10.0",
     "importlib-resources >= 5.10.0",
-    "numpy >= 1.25.0, <2.0.0",
+    "numpy >= 1.25.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Use trusted publisher for release and remove numpy upper bound
- Closes #1815 