### PR TITLE
Automated Latest Dependency Updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: add-trailing-comma
         name: Add trailing comma
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.4.2'
+    rev: 'v0.4.3'
     hooks:
       - id: ruff
         types_or: [ python, pyi, jupyter ]

--- a/woodwork/tests/requirement_files/latest_dask_dependencies.txt
+++ b/woodwork/tests/requirement_files/latest_dask_dependencies.txt
@@ -1,6 +1,6 @@
 click==8.1.7
-dask==2024.4.2
-dask-expr==1.0.14
+dask==2024.5.0
+dask-expr==1.1.0
 numpy==1.26.4
 pandas==2.2.2
 pyarrow==16.0.0


### PR DESCRIPTION
This is an auto-generated PR with **latest** dependency updates. Please do not delete the `latest-dep-update` branch because it's needed by the auto-dependency bot.