### PR TITLE
Use filter arg to safe extract archives

### DIFF
--- a/.github/workflows/pull_request_check.yaml
+++ b/.github/workflows/pull_request_check.yaml
@@ -7,7 +7,7 @@ jobs:
     name: pull request check
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/github-action-check-linked-issues@v1
+      - uses: nearform-action/github-action-check-linked-issues@v1
         id: check-linked-issues
         with:
           exclude-branches: "release_v**, backport_v**, main, latest-dep-update-**, min-dep-update-**, dependabot/**"

--- a/.github/workflows/pull_request_check.yaml
+++ b/.github/workflows/pull_request_check.yaml
@@ -7,7 +7,7 @@ jobs:
     name: pull request check
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform-action/github-action-check-linked-issues@v1
+      - uses: nearform-actions/github-action-check-linked-issues@v1
         id: check-linked-issues
         with:
           exclude-branches: "release_v**, backport_v**, main, latest-dep-update-**, min-dep-update-**, dependabot/**"

--- a/.github/workflows/release_notes_updated.yaml
+++ b/.github/workflows/release_notes_updated.yaml
@@ -12,6 +12,7 @@ jobs:
       - name: Check for development branch
         id: branch
         shell: python
+
         run: |
           from re import compile
           main = '^main$'

--- a/.github/workflows/release_notes_updated.yaml
+++ b/.github/workflows/release_notes_updated.yaml
@@ -12,7 +12,8 @@ jobs:
       - name: Check for development branch
         id: branch
         shell: python
-
+        env:
+          REF: ${{ github.event.pull_request.head.ref }}
         run: |
           from re import compile
           main = '^main$'
@@ -22,7 +23,7 @@ jobs:
           min_dep_update = '^min-dep-update-[a-f0-9]{7}$'
           regex = main, release, backport, dep_update, min_dep_update
           patterns = list(map(compile, regex))
-          ref = "${{ github.event.pull_request.head.ref }}"
+          ref = "$REF"
           is_dev = not any(pattern.match(ref) for pattern in patterns)
           print('::set-output name=is_dev::' + str(is_dev))
       - if: ${{ steps.branch.outputs.is_dev == 'True' }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,9 +6,9 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Add support for Python 3.12 :pr:`1855`
     * Fixes
     * Changes
-        * Add support for Python 3.12 :pr:`1855`
         * Drop support for using Woodwork with Dask or Pyspark dataframes :pr:`1857`
         * Use ``filter`` arg in call to ``tarfile.extractall`` to safely deserialize DataFrames :pr:`1862`
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,8 @@ Future Release
     * Fixes
     * Changes
         * Add support for Python 3.12 :pr:`1855`
-        * Drop support for using Woodwork with Dask or Pyspark dataframes (:pr:`1857`)
+        * Drop support for using Woodwork with Dask or Pyspark dataframes :pr:`1857`
+        * Use ``filter`` arg in call to ``tarfile.extractall`` to safely deserialize DataFrames :pr:`1862`
     * Documentation Changes
     * Testing Changes
 

--- a/woodwork/deserializers/deserializer_base.py
+++ b/woodwork/deserializers/deserializer_base.py
@@ -2,6 +2,7 @@ import os
 import tarfile
 import tempfile
 import warnings
+from inspect import getfullargspec
 from itertools import zip_longest
 from pathlib import Path
 
@@ -125,7 +126,12 @@ class Deserializer:
 
             use_smartopen(tar_filepath, self.path, transport_params)
             with tarfile.open(str(tar_filepath)) as tar:
-                tar.extractall(path=tmpdir)
+                if "filter" in getfullargspec(tar.extractall).kwonlyargs:
+                    tar.extractall(path=tmpdir, filter="data")
+                else:
+                    raise RuntimeError(
+                        "Please upgrade your Python version to the latest patch release to allow for safe extraction of the EntitySet archive.",
+                    )
             self.read_path = os.path.join(
                 tmpdir,
                 self.typing_info["loading_info"]["location"],

--- a/woodwork/deserializers/parquet_deserializer.py
+++ b/woodwork/deserializers/parquet_deserializer.py
@@ -2,6 +2,7 @@ import json
 import os
 import tarfile
 import tempfile
+from inspect import getfullargspec
 from pathlib import Path
 
 import pandas as pd
@@ -61,7 +62,12 @@ class ParquetDeserializer(Deserializer):
 
             use_smartopen(tar_filepath, self.path, transport_params)
             with tarfile.open(str(tar_filepath)) as tar:
-                tar.extractall(path=tmpdir)
+                if "filter" in getfullargspec(tar.extractall).kwonlyargs:
+                    tar.extractall(path=tmpdir, filter="data")
+                else:
+                    raise RuntimeError(
+                        "Please upgrade your Python version to the latest patch release to allow for safe extraction of the EntitySet archive.",
+                    )
 
             self.read_path = os.path.join(tmpdir, self.data_subdirectory, self.filename)
 

--- a/woodwork/deserializers/utils.py
+++ b/woodwork/deserializers/utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import tarfile
 import tempfile
+from inspect import getfullargspec
 from pathlib import Path
 
 from woodwork.deserializers import (
@@ -99,7 +100,12 @@ def read_table_typing_information(path, typing_info_filename, profile_name):
 
             use_smartopen(file_path, path, transport_params)
             with tarfile.open(str(file_path)) as tar:
-                tar.extractall(path=tmpdir)
+                if "filter" in getfullargspec(tar.extractall).kwonlyargs:
+                    tar.extractall(path=tmpdir, filter="data")
+                else:
+                    raise RuntimeError(
+                        "Please upgrade your Python version to the latest patch release to allow for safe extraction of the EntitySet archive.",
+                    )
 
             file = os.path.join(tmpdir, typing_info_filename)
             with open(file, "r") as file:

--- a/woodwork/deserializers/utils.py
+++ b/woodwork/deserializers/utils.py
@@ -100,9 +100,6 @@ def read_table_typing_information(path, typing_info_filename, profile_name):
 
             use_smartopen(file_path, path, transport_params)
             with tarfile.open(str(file_path)) as tar:
-                import pdb
-
-                pdb.set_trace()
                 if "filter" in getfullargspec(tar.extractall).kwonlyargs:
                     tar.extractall(path=tmpdir, filter="data")
                 else:

--- a/woodwork/deserializers/utils.py
+++ b/woodwork/deserializers/utils.py
@@ -100,6 +100,9 @@ def read_table_typing_information(path, typing_info_filename, profile_name):
 
             use_smartopen(file_path, path, transport_params)
             with tarfile.open(str(file_path)) as tar:
+                import pdb
+
+                pdb.set_trace()
                 if "filter" in getfullargspec(tar.extractall).kwonlyargs:
                     tar.extractall(path=tmpdir, filter="data")
                 else:


### PR DESCRIPTION
Closes #1860 

The filter argument was added in these Python versions: 3.9.17, 3.10.12, 3.11.4, 3.12.0. If the user is running an older Python version an error will be thrown and they will need to upgrade to one of these patch releases (or newer) to extract the archive.