### PR TITLE
Issue#1875 replace `pkg_resources` with `importlib`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
     * Fixes
     * Changes
         * Restrict numpy to <2.0.0 :pr:`1869`
+        * Replace deprecated setuptools `pkg_resources` usages with `importlib`
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Future Release
     * Fixes
     * Changes
         * Restrict numpy to <2.0.0 :pr:`1869`
-        * Replace deprecated setuptools `pkg_resources` usages with `importlib`
+        * Replace deprecated setuptools `pkg_resources` usages with `importlib` :pr:`1876`
     * Documentation Changes
     * Testing Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [
     "pydata-sphinx-theme == 0.9.0",
     "sphinx-inline-tabs == 2022.1.2b11",
     "sphinx-copybutton == 0.5.0",
+    "standard-imghdr >= 3.13.0",
     "myst-parser == 0.18.0",
     "nbconvert == 6.5.0",
     "ipython == 8.4.0",

--- a/woodwork/__init__.py
+++ b/woodwork/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
-import pkg_resources
 import sys
 import warnings
+from importlib.metadata import entry_points
 
 from woodwork.config import config
 from woodwork.type_sys import type_system
@@ -25,8 +25,8 @@ if sys.version_info.major == 3 and sys.version_info.minor == 7:  # pragma: no co
     )
 
 # Call functions registered by other libraries when woodwork is imported
-for entry_point in pkg_resources.iter_entry_points(
-    "alteryx_open_src_initialize",
+for entry_point in entry_points(
+    group="alteryx_open_src_initialize",
 ):  # pragma: no cover
     try:
         method = entry_point.load()


### PR DESCRIPTION
- Replaces the deprecated usages of the `pkg_resources` component of setuptools.
- Closes #1875

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*